### PR TITLE
Add dependency to the last version of Spec2

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -7,59 +7,47 @@ Class {
 { #category : #baselines }
 BaselineOfNewTools >> baseline: spec [
 	<baseline>
-	
-	spec for: #common do: [ 
-			
-		self
-			taskit: spec;
-			sindarin: spec.
+	spec
+		for: #common
+		do: [ self
+				taskit: spec;
+				spec: spec;
+				sindarin: spec.
 
-		spec
-			package: 'NewTools-Core';
-			package: 'NewTools-Morphic';
-			package: 'NewTools-Gtk';
-			
-			"inspector"
-			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Inspector-Extensions') ];
-			
-			"playground"
-			package: 'NewTools-Playground' with: [ spec requires: #('NewTools-Inspector') ];
-			
-			"browser"
-			package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Inspector') ];
-			
-			"debugger"
-			package: 'NewTools-Debugger-Commands';
-			package: 'NewTools-Debugger-Extensions';
-			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];			
-			package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
-			
-			"extras"
-			package: 'HelpCenter' with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-FlagBrowser' with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-FlagBrowser-Tests' with: [ spec requires: #('NewTools-FlagBrowser') ];
-			"package: 'NewTools-FileDialog' with: [ spec requires: #('NewTools-Core') ];
+			spec
+				package: 'NewTools-Core' with: [ spec requires: #('Spec2') ];
+				package: 'NewTools-Morphic';
+				package: 'NewTools-Gtk';
+				"inspector"
+					package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
+				package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions') ];
+				"playground"
+					package: 'NewTools-Playground' with: [ spec requires: #('NewTools-Inspector') ];
+				"browser"
+					package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Inspector') ];
+				"debugger"
+					package: 'NewTools-Debugger-Commands';
+				package: 'NewTools-Debugger-Extensions';
+				package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];
+				package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
+				"extras"
+					package: 'HelpCenter' with: [ spec requires: #('NewTools-Core') ];
+				package: 'NewTools-FlagBrowser' with: [ spec requires: #('NewTools-Core') ];
+				package: 'NewTools-FlagBrowser-Tests' with: [ spec requires: #('NewTools-FlagBrowser') ];
+				"package: 'NewTools-FileDialog' with: [ spec requires: #('NewTools-Core') ];
 			package: 'NewTools-FileDialog-Tests' with: [ spec requires: #('NewTools-FileDialog') ];"
-			package: 'NewTools-SpTextPresenterDecorators';
-			
-			"Object-centric breakpoints"
-			package: 'NewTools-ObjectCentricBreakpoints';
-			package: 'NewTools-ObjectCentricBreakpointsTests';
-			
-			"Sindarin"
-			package: 'NewTools-Sindarin-Commands';
-			package: 'NewTools-Sindarin-Tools' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
-			
-			package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ]
-			
-			"Debugger Selector"
-			";
+					package: 'NewTools-SpTextPresenterDecorators';
+				"Object-centric breakpoints"
+					package: 'NewTools-ObjectCentricBreakpoints';
+				package: 'NewTools-ObjectCentricBreakpointsTests';
+				"Sindarin"
+					package: 'NewTools-Sindarin-Commands';
+				package: 'NewTools-Sindarin-Tools' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
+				package: 'NewTools-Sindarin-ProcessInspector'
+					with: [ "Debugger Selector" ";
 			package: 'NewTools-DebuggerSelector' with: [ spec requires: #('NewTools-SpTextPresenterDecorators') ];
 			package: 'NewTools-DebuggerSelector';
-			package: 'NewTools-DebuggerSelector-Tests' with: [ spec requires: #('NewTools-DebuggerSelector') ]"
-			
-		]
+			package: 'NewTools-DebuggerSelector-Tests' with: [ spec requires: #('NewTools-DebuggerSelector') ]" spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ] ]
 ]
 
 { #category : #dependencies }
@@ -68,6 +56,14 @@ BaselineOfNewTools >> sindarin: spec [
 	spec 
 		baseline: 'Sindarin' 
 		with: [ spec repository: 'github://dupriezt/ScriptableDebugger' ]
+]
+
+{ #category : #dependencies }
+BaselineOfNewTools >> spec: spec [
+
+	spec 
+		baseline: 'Spec2'
+		with: [ spec repository: 'github://pharo-spec/Spec:master/src' ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
I suppose that the NewTools should depends on the last version of Spec2 during its dev.
(I also format with the default formatter the baseline method...)