### PR TITLE
Organize baseline into groups

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -18,7 +18,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Morphic';
 			package: 'NewTools-Gtk';
 			"inspector"
-			package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions') ];
+			package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions' 'TaskIt') ];
 			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
 			"debugger"
 			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -7,47 +7,62 @@ Class {
 { #category : #baselines }
 BaselineOfNewTools >> baseline: spec [
 	<baseline>
-	spec
-		for: #common
-		do: [ self
-				taskit: spec;
-				spec: spec;
-				sindarin: spec.
+	spec for: #common do: [
+		self
+			taskit: spec;
+			spec: spec;
+			sindarin: spec.
 
-			spec
-				package: 'NewTools-Core' with: [ spec requires: #('Spec2') ];
-				package: 'NewTools-Morphic';
-				package: 'NewTools-Gtk';
-				"inspector"
-					package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
-				package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions') ];
-				"playground"
-					package: 'NewTools-Playground' with: [ spec requires: #('NewTools-Inspector') ];
-				"browser"
-					package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Inspector') ];
-				"debugger"
-					package: 'NewTools-Debugger-Commands';
-				package: 'NewTools-Debugger-Extensions';
-				package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];
-				package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
-				"extras"
-					package: 'HelpCenter' with: [ spec requires: #('NewTools-Core') ];
-				package: 'NewTools-FlagBrowser' with: [ spec requires: #('NewTools-Core') ];
-				package: 'NewTools-FlagBrowser-Tests' with: [ spec requires: #('NewTools-FlagBrowser') ];
-				"package: 'NewTools-FileDialog' with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-FileDialog-Tests' with: [ spec requires: #('NewTools-FileDialog') ];"
-					package: 'NewTools-SpTextPresenterDecorators';
-				"Object-centric breakpoints"
-					package: 'NewTools-ObjectCentricBreakpoints';
-				package: 'NewTools-ObjectCentricBreakpointsTests';
-				"Sindarin"
-					package: 'NewTools-Sindarin-Commands';
-				package: 'NewTools-Sindarin-Tools' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
-				package: 'NewTools-Sindarin-ProcessInspector'
-					with: [ "Debugger Selector" ";
+		spec
+			package: 'NewTools-Core' with: [ spec requires: #('Spec2') ];
+			package: 'NewTools-Morphic';
+			package: 'NewTools-Gtk';
+			"inspector"
+			package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions') ];
+			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
+			"debugger"
+			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];
+			package: 'NewTools-Debugger-Commands';
+			package: 'NewTools-Debugger-Extensions';
+			package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
+			"playground"
+			package: 'NewTools-Playground' with: [ spec requires: #('NewTools-Inspector') ];
+			"browser"
+			package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Inspector') ];
+			"extras"
+			package: 'HelpCenter' with: [ spec requires: #('NewTools-Core') ];
+			package: 'NewTools-FlagBrowser' with: [ spec requires: #('NewTools-Core') ];
+			package: 'NewTools-FlagBrowser-Tests' with: [ spec requires: #('NewTools-FlagBrowser') ];
+			package: 'NewTools-FileDialog' with: [ spec requires: #('NewTools-Core') ];
+			package: 'NewTools-FileDialog-Tests' with: [ spec requires: #('NewTools-FileDialog') ];
+			package: 'NewTools-SpTextPresenterDecorators';
+			"Object-centric breakpoints"
+			package: 'NewTools-ObjectCentricBreakpoints';
+			package: 'NewTools-ObjectCentricBreakpointsTests';
+			"Sindarin"
+			package: 'NewTools-Sindarin-Commands';
+			package: 'NewTools-Sindarin-Tools' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
+			package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
+			"Debugger Selector"
 			package: 'NewTools-DebuggerSelector' with: [ spec requires: #('NewTools-SpTextPresenterDecorators') ];
-			package: 'NewTools-DebuggerSelector';
-			package: 'NewTools-DebuggerSelector-Tests' with: [ spec requires: #('NewTools-DebuggerSelector') ]" spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ] ]
+			package: 'NewTools-DebuggerSelector-Tests' with: [ spec requires: #('NewTools-DebuggerSelector') ].
+		
+		spec
+			group: #default with: #(
+				'NewTools-Core' 'NewTools-Morphic' 'NewTools-Gtk'
+				'NewTools-Inspector'
+				'NewTools-Debugger' 'NewTools-Debugger-Tests'
+				'NewTools-Playground'
+				'NewTools-SystemBrowser'
+				'HelpCenter'
+				'NewTools-FlagBrowser' 'NewTools-FlagBrowser-Tests'
+				'NewTools-ObjectCentricBreakpoints' 'NewTools-ObjectCentricBreakpointsTests'
+				'NewTools-Sindarin-Tools'
+				'NewTools-Sindarin-ProcessInspector');
+			group: #development with: #(default
+				'NewTools-DebuggerSelector' 'NewTools-DebuggerSelector-Tests'
+				'NewTools-FileDialog' 'NewTools-FileDialog-Tests').
+	]
 ]
 
 { #category : #dependencies }

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -60,8 +60,8 @@ BaselineOfNewTools >> baseline: spec [
 				'NewTools-Sindarin-Tools'
 				'NewTools-Sindarin-ProcessInspector');
 			group: #development with: #(default
-				'NewTools-DebuggerSelector' 'NewTools-DebuggerSelector-Tests'
-				'NewTools-FileDialog' 'NewTools-FileDialog-Tests').
+				'NewTools-DebuggerSelector' 'NewTools-DebuggerSelector-Tests');
+			group: #broken with: #('NewTools-FileDialog' 'NewTools-FileDialog-Tests')
 	]
 ]
 


### PR DESCRIPTION
Added dep to TaskIt on Inspector, and segregated FileDialog into a `broken` group (loading it fails with DNU `#asTraitComposition`)