### PR TITLE
add NewTools-SpTextPresenterDecorator as a NewTools-Debugger dependency

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -21,7 +21,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Inspector' with: [ spec requires: #('NewTools-Inspector-Extensions' 'TaskIt') ];
 			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
 			"debugger"
-			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions') ];
+			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions' 'NewTools-SpTextPresenterDecorators') ];
 			package: 'NewTools-Debugger-Commands';
 			package: 'NewTools-Debugger-Extensions';
 			package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];


### PR DESCRIPTION
We are not able to load NewTools using the baseline with a working debugger because the package NewTools-SpTextPresenterDecorator is not automatically loaded.
So, I just add it as a dependency of NewTools-Debugger.
It may go somewhere else, but at least we can load a working NewTools directly from the baseline with my modification