### PR TITLE
Debuggers selection strategies

### DIFF
--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -294,6 +294,7 @@ DSDebuggerSelectorTest >> testNextDebugger [
 
 { #category : #'tests -  algorithm' }
 DSDebuggerSelectorTest >> testNextDebuggerForSession [
+	"Upon a debugger failure, we call the nextDebuggerForSession: interface to get the next debugger"
 	
 	self
 		assert: (debuggerSelector nextDebuggerForSession: self session)

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -26,13 +26,15 @@ DSDebuggerSelectorTest >> assertDebuggerOpened: aDebugger onException: anExcepti
 
 { #category : #helper }
 DSDebuggerSelectorTest >> session [
-	| process |
-	process := [  ] newProcess.
-	^ debuggerSelector
-		newSessionFromException:
-			(DebuggerSelectorNullException
-				fromSignallerContext: process suspendedContext)
-		forProcess: process
+	| context process session |
+	context := [ Set new ] asContext.
+	process := Process
+		forContext: context
+		priority: Processor userInterruptPriority.
+	session := process
+		newDebugSessionNamed: 'test session'
+		startedAt: context.
+	^ session
 ]
 
 { #category : #running }
@@ -42,7 +44,7 @@ DSDebuggerSelectorTest >> setUp [
 	super setUp.
 	debuggers := OrderedCollection
 		withAll:
-			{(DSDummyDebugger named: #A) beUnusable.
+			{(DSDummyDebugger named: #A).
 			(DSDummyDebugger named: #B).
 			(DSDummyDebugger named: #C)}.
 	debuggerSelector := DSDebuggerSelector with: debuggers copy
@@ -234,10 +236,16 @@ DSDebuggerSelectorTest >> testFindDebuggerForDebuggerFailure [
 ]
 
 { #category : #'tests -  algorithm' }
-DSDebuggerSelectorTest >> testFindDebuggerToHandleContext [
+DSDebuggerSelectorTest >> testFirstUsableDebuggerForSession [
+	
+	debuggerSelector debuggers first beUnusable.
+	debuggerSelector debuggers second beUnusable.
+
 	self
-		assert: (debuggerSelector findDebuggerForSession: self session)
-		identicalTo: debuggers second
+		assert: (debuggerSelector nextDebuggerForSession: self session)
+		identicalTo: debuggers third
+	
+	
 ]
 
 { #category : #'tests - debuggers' }
@@ -285,24 +293,26 @@ DSDebuggerSelectorTest >> testNextDebugger [
 ]
 
 { #category : #'tests -  algorithm' }
-DSDebuggerSelectorTest >> testNoDebuggerForDebuggerFailure [
-	| process semaphore exception session |
-	semaphore := Semaphore new.
-	process := [ [ 1 / 0 ]
-		on: Error
-		do: [ :err | exception := DebuggerFailure of: debuggers second on: err ] ]
-		newProcess.
-	[[ process resume ]
-		ensure: [ semaphore signal ]] fork.
-	semaphore wait.
+DSDebuggerSelectorTest >> testNextDebuggerForSession [
 	
-	exception := DebuggerFailure of: debuggers third on: exception.
-	session := debuggerSelector
-		newSessionFromException: exception
-		forProcess: process.
+	self
+		assert: (debuggerSelector nextDebuggerForSession: self session)
+		identicalTo: debuggers first.
+	
+	self
+		assert: (debuggerSelector nextDebuggerForSession: self session)
+		identicalTo: debuggers second.
 		
 	self
-		assert: (debuggerSelector findDebuggerForSession: session) identicalTo: Transcripter
+		assert: (debuggerSelector nextDebuggerForSession: self session)
+		identicalTo: debuggers last.
+		
+	self
+		assert: (debuggerSelector nextDebuggerForSession: self session)
+		identicalTo: Transcripter.
+		
+	
+	
 ]
 
 { #category : #tests }

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -9,22 +9,6 @@ Class {
 }
 
 { #category : #helper }
-DSDebuggerSelectorTest >> assertDebuggerOpened: aDebugger onException: anException inProcess: aProcess [
-	| session process |
-	session := aDebugger tag.
-	self assert: session class equals: DebugSession.
-	self assert: session exception identicalTo: anException.
-
-	"The interrupted process is the one given to the API, 
-	whatever this process is."
-	process := session interruptedProcess.
-	self assert: session interruptedProcess identicalTo: aProcess.
-	self deny: process isTerminating.
-	self deny: process isTerminated.
-	self assert: process isSuspended
-]
-
-{ #category : #helper }
 DSDebuggerSelectorTest >> session [
 	^DSDummyDebugger dummySession
 ]
@@ -47,7 +31,7 @@ DSDebuggerSelectorTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : #'tests - debuggers' }
 DSDebuggerSelectorTest >> testDebuggers [
 	self
 		assertCollection: debuggerSelector debuggers asOrderedCollection
@@ -79,7 +63,7 @@ DSDebuggerSelectorTest >> testHandlesDebuggerErrors [
 	self assert: debuggerSelector handlesDebuggerErrors
 ]
 
-{ #category : #tests }
+{ #category : #'tests - debuggers' }
 DSDebuggerSelectorTest >> testNextDebugger [
 	debuggers
 		do: [ :dbg | self assert: debuggerSelector nextDebugger identicalTo: dbg ]
@@ -115,17 +99,28 @@ DSDebuggerSelectorTest >> testNextDebuggerForSession [
 		identicalTo: debuggers last.
 		
 	self
-		assert: (debuggerSelector nextDebuggerForSession: self session)
-		identicalTo: Transcripter.
+		should: [ debuggerSelector nextDebuggerForSession: self session]
+		raise: CollectionIsEmpty
 		
-	
-	
+		
+
 ]
 
-{ #category : #tests }
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testNoDebuggerForSession [
+	debuggerSelector debuggers: #().
+	self
+		shouldnt: [ debuggerSelector openDebuggerForSession: self session ]
+		raise: CollectionIsEmpty.
+	self deny: debuggerSelector handled
+]
+
+{ #category : #'tests - debuggers' }
 DSDebuggerSelectorTest >> testNoNextDebugger [
 	debuggerSelector debuggers: #().
-	self assert: debuggerSelector nextDebugger identicalTo: Transcripter
+	self
+		should: [ debuggerSelector nextDebugger ]
+		raise: CollectionIsEmpty
 ]
 
 { #category : #'tests -  algorithm' }

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -59,31 +59,6 @@ DSDebuggerSelectorTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testDebugExceptionInProcessFromWith [
-	| process exception dummyUIManager |
-	
-	self flag: 'Process are not the same, which is OK from the API point of view, but not accurate from the execution point of view'.
-	[ DSDummyDebugger new zeroDivide ]
-		on: Exception
-		do: [ :e | 
-			exception := e.
-			DebuggerSelector
-				debugException: exception
-				inProcess: (process := [ ] newProcess)
-				from: (dummyUIManager := DSDummyDebugger new)
-				with: debuggerSelector ].
-
-	"With this test, we ensure that calling the API opens a debugger on a debug session,
-	that holds the exception, its signaler context and the interrupted process.
-	We check the second debugger because it is the one that is selected (first always fails)."
-	self assertDebuggerOpened: debuggers second onException: exception inProcess: process.
-	
-	""
-	self assert: dummyUIManager deferred
-	
-]
-
 { #category : #tests }
 DSDebuggerSelectorTest >> testDebuggers [
 	self
@@ -207,37 +182,6 @@ DSDebuggerSelectorTest >> testOpenDebuggerWithErrorForSession [
 	self assert: debuggers second tag class identicalTo: Error.	
 	self assert: debuggers third tag identicalTo: session.
 	self assert: debuggerSelector handled
-]
-
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testOpenOn [
-	"Basically openOn: finds a debugger and calls tryOpen:on:.
-	So the first usable debugger (second in the list, see setUp)
-	should work"
-	| session |
-	session := self session.
-	debuggerSelector openOn: session.
-	self assert: debuggers second tag identicalTo: session
-]
-
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testSignalDebuggerError [
-	"The dummy debugger selector uses a debug session object that does not actually signal a debugger error."
-
-	| exception signalerBlock |
-	exception := DebuggerSelectorNullException
-		fromSignallerContext: [  ] asContext.
-	signalerBlock := [ DummyDebuggerSelector
-		signalDebuggerError: exception ].
-	
-	self should: signalerBlock raise: DebuggerFailure.
-	signalerBlock
-		on: DebuggerFailure
-		do: [ :e | 
-			self
-				assert: e failedDebugger name
-				equals: DebuggerSelector signalDebuggerErrorMessage.
-			self assert: e innerException identicalTo: exception ]
 ]
 
 { #category : #'tests -  algorithm' }

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -59,32 +59,6 @@ DSDebuggerSelectorTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testAvailableDebuggers [
-	|availableDebuggerClasses sortedDebuggerClasses|
-	self fail.
-	availableDebuggerClasses := OldDebuggerSelector availableDebuggers collect:[:assoc| assoc key].
-	sortedDebuggerClasses := OldDebuggerSelector sortedDebuggersByRank collect:[:assoc| assoc value].  
-	self assertCollection: availableDebuggerClasses equals: sortedDebuggerClasses 
-]
-
-{ #category : #'tests - debugging API' }
-DSDebuggerSelectorTest >> testDebugExceptionInProcessFrom [
-	| exception process |
-	[ DSDummyDebugger new zeroDivide ]
-		on: Exception
-		do: [ :e | 
-			exception := e.
-			DummyDebuggerSelector
-				debugException: exception
-				inProcess: (process := [  ] newProcess)
-				from: DSDummyDebugger new ].
-	self
-		assertDebuggerOpened: debuggers second
-		onException: exception
-		inProcess: process
-]
-
 { #category : #'tests - debugging' }
 DSDebuggerSelectorTest >> testDebugExceptionInProcessFromWith [
 	| process exception dummyUIManager |
@@ -110,108 +84,11 @@ DSDebuggerSelectorTest >> testDebugExceptionInProcessFromWith [
 	
 ]
 
-{ #category : #'tests - debugging API' }
-DSDebuggerSelectorTest >> testDebugMethodInProcessFromContextLabeled [
-	| dbg session process suspendedContext |
-	process := [ DSDummyDebugger new methodToDebug ] newProcess.
-	suspendedContext := process suspendedContext.
-	DummyDebuggerSelector
-		debugMethod: DSDummyDebugger >> #methodToDebug
-		inProcess: process
-		fromContext: suspendedContext
-		labeled: 'debug it'.
-	dbg := debuggers second.
-	session := dbg tag.
-	self
-		assertDebuggerOpened: dbg
-		onException: session exception
-		inProcess: process.
-	self
-		assert: session interruptedContext method
-		identicalTo: DSDummyDebugger >> #methodToDebug.
-	self
-		assert: session exception class
-		equals: DebuggerSelectorNullException.
-		
-	"Debugger Selector must have put us right at the entry of the method.
-	If we step over, we should be on the first ast node of the method"
-	session stepOver.
-	self
-		assert: ((DSDummyDebugger >> #methodToDebug) sourceNodeForPC: session interruptedContext pc)
-		identicalTo: (DSDummyDebugger >> #methodToDebug) ast statements first.
-]
-
-{ #category : #'tests - debugging API' }
-DSDebuggerSelectorTest >> testDebugProcessFromContextLabeled [
-	| context process session interruptedProcess exception |	
-	context := [  ] asContext.
-	process := [  ] newProcess.
-	"we use the dummy debugger selector to control the debuggers list and the ui manager.
-	we do not actually want to raise a real warning but just to ensure
-	the API gets the system to the opening of a debugger with the exception."
-	DummyDebuggerSelector
-		debugProcess: process
-		fromContext: context
-		labeled: #tag.
-	session := debuggers second tag.
-	interruptedProcess := session interruptedProcess.
-	exception := session exception.
-	self assert: session class equals: DebugSession.
-	self assert: interruptedProcess identicalTo: process.
-	self assert: interruptedProcess isSuspended.
-	self assert: session interruptedContext identicalTo: context.
-	self assert: exception class equals: DebuggerSelectorNullException.
-	self assert: exception signalerContext identicalTo: context.
-	self assert: exception messageText equals: #tag.
-	self assert: DummyDebuggerSelector uiManager deferred 
-]
-
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testDebugSessionClass [
-	self assert: DebuggerSelector debugSessionClass equals: DebugSession
-]
-
-{ #category : #'tests - debugging API' }
-DSDebuggerSelectorTest >> testDebuggerWarningFrom [
-	| dbg |
-	dbg := DSDummyDebugger new.
-	DebuggerSelector debuggerWarning: #tag from: dbg.
-	self assert: dbg tag equals: #tag
-]
-
-{ #category : #'tests - debugging API' }
-DSDebuggerSelectorTest >> testDebuggerWarningInProcessFrom [
-	|e p|
-	[ Warning signal: #tag ]
-		on: Warning
-		do: [ :w | 
-			e := w.
-			"we use the dummy debugger selector to control the debuggers list.
-			we do not actually want to raise a real warning but just to ensure
-			the API gets the system to the opening of a debugger with the exception."
-			DummyDebuggerSelector
-				debuggerWarning: w
-				inProcess: (p := [  ] newProcess)
-				from: DSDummyDebugger new ].
-	self assertDebuggerOpened: debuggers second onException: e inProcess: p
-]
-
 { #category : #tests }
 DSDebuggerSelectorTest >> testDebuggers [
 	self
 		assertCollection: debuggerSelector debuggers asOrderedCollection
 		equals: debuggers
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testDebuggersWithRanks [
-	|assocs systemDebuggers|
-	self fail.
-	assocs := OldDebuggerSelector debuggersWithRanks.
-	systemDebuggers := Smalltalk tools debuggers.
-	self assert: assocs size equals: systemDebuggers size.
-	self assertCollection: assocs equals: systemDebuggers
-
 ]
 
 { #category : #'tests -  algorithm' }
@@ -246,44 +123,6 @@ DSDebuggerSelectorTest >> testFirstUsableDebuggerForSession [
 		identicalTo: debuggers third
 	
 	
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testLabeledDebuggers [
-	| dbgs labeledDebuggers |
-	self fail.
-	dbgs := {(999 -> 'main dbg').
-	(80 -> 'a dbg').
-	(5 -> 'another dbg')}.
-	labeledDebuggers := OldDebuggerSelector labeledDebuggers: dbgs.
-	self assert: labeledDebuggers first key equals: 'main dbg'.
-	self assert: labeledDebuggers first value equals: 'Main'.
-	self assert: labeledDebuggers second key equals: 'a dbg'.
-	self assert: labeledDebuggers second value equals: '80'.
-	self assert: labeledDebuggers third key equals: 'another dbg'.
-	self assert: labeledDebuggers third value equals: '5'
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testNewDebuggerSelector [
-	| dbgsel |
-	dbgsel := DebuggerSelector newDebuggerSelector.
-	self assert: dbgsel class equals: DebuggerSelector.
-	self
-		assertCollection: dbgsel availableDebuggers
-		equals: DebuggerSelector availableDebuggers
-]
-
-{ #category : #'tests - sessions' }
-DSDebuggerSelectorTest >> testNewSessionFromExceptionForProcess [
-
-	|exception process session|
-	exception := DebuggerSelectorNullException new signalIn: [] asContext; yourself.
-	process := [  ] newProcess.
-	session := debuggerSelector newSessionFromException: exception forProcess: process.
-	self assert: session interruptedProcess identicalTo: process.
-	self assert: session exception identicalTo: exception.
-	self assert: session interruptedContext identicalTo: exception signalerContext
 ]
 
 { #category : #tests }
@@ -323,17 +162,6 @@ DSDebuggerSelectorTest >> testNoNextDebugger [
 ]
 
 { #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testNullExceptionForNamed [
-	|ctx e|
-	ctx := Context newForMethod: (DSDummyDebugger>>#tag).
-	ctx receiver: self.
-	e := DebuggerSelector nullExceptionFor: ctx named: #tag.
-	self assert: e receiver identicalTo: self.
-	self assert: e signalerContext identicalTo: ctx.
-	self assert: e messageText equals: #tag
-]
-
-{ #category : #'tests - debugging' }
 DSDebuggerSelectorTest >> testOpenOn [
 	"Basically openOn: finds a debugger and calls tryOpen:on:.
 	So the first usable debugger (second in the list, see setUp)
@@ -342,57 +170,6 @@ DSDebuggerSelectorTest >> testOpenOn [
 	session := self session.
 	debuggerSelector openOn: session.
 	self assert: debuggers second tag identicalTo: session
-]
-
-{ #category : #'tests - sessions' }
-DSDebuggerSelectorTest >> testPerformPreDebugActionsOn [
-	| tag |
-	"Default debug action is an empty block with 1 parameter"
-	debuggerSelector performPreDebugActionsOn: #tag.
-
-	"Custom debug action should execute the give block"
-	debuggerSelector preDebugAction: [ :session | tag := session ].
-	debuggerSelector performPreDebugActionsOn: #tag.
-	self assert: tag equals: #tag
-]
-
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testPreDebugActionForDebugItMethod [
-	| session process suspendedContext |
-	process := [ DSDummyDebugger new methodToDebug ] newProcess.
-	suspendedContext := process suspendedContext.
-	session := debuggerSelector
-		newSessionFromException: (DebuggerSelector nullExceptionFor: suspendedContext named: #tag)
-		forProcess: process.
-	(DebuggerSelector
-		preDebugActionForDebugItMethod: DSDummyDebugger >> #methodToDebug)
-		value: session.
-
-	"Debugger Selector must have put us right at the entry of the method.
-	If we step over, we should be on the first ast node of the method"
-	self
-		assert: session interruptedContext method
-		identicalTo: DSDummyDebugger >> #methodToDebug.
-	session stepOver.
-	self
-		assert:
-			(DSDummyDebugger >> #methodToDebug
-				sourceNodeForPC: session interruptedContext pc)
-		identicalTo: (DSDummyDebugger >> #methodToDebug) ast statements first
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testRegisteredDebuggersWithRanks [
-	self fail
-]
-
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testResumeException [
-	| res |
-	[ res := DummyExceptionToResume signal ]
-		on: DummyExceptionToResume
-		do: [ :e | DebuggerSelector resumeException: e ].
-	self assert: res equals: #tag
 ]
 
 { #category : #'tests - debugging' }
@@ -413,20 +190,6 @@ DSDebuggerSelectorTest >> testSignalDebuggerError [
 				assert: e failedDebugger name
 				equals: DebuggerSelector signalDebuggerErrorMessage.
 			self assert: e innerException identicalTo: exception ]
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testSortedDebuggersByRank [
-	| assocs systemDebuggers sortedRanks expectedRanks |
-	self fail.
-	assocs := OldDebuggerSelector sortedDebuggersByRank.
-	systemDebuggers := Smalltalk tools debuggers.
-	self
-		assertCollection: (assocs collect: [ :assoc | assoc value ])
-		includesAll: (systemDebuggers collect: [ :assoc | assoc key ]).
-	sortedRanks := assocs collect: [ :assoc | assoc key ].
-	expectedRanks := (systemDebuggers collect: [ :assoc | assoc value ]) asSortedCollection.
-	self assert: sortedRanks equals: expectedRanks asOrderedCollection reversed
 ]
 
 { #category : #'tests - debugging' }
@@ -459,11 +222,4 @@ DSDebuggerSelectorTest >> testTryOpenOn [
 	debugger := DSDummyDebugger new.
 	debuggerSelector tryOpen: debugger on: session.
 	self assert: debugger tag identicalTo: session
-]
-
-{ #category : #'tests - debuggers' }
-DSDebuggerSelectorTest >> testWith [
-	|trace|
-	trace := Object new.
-	self assert: (DebuggerSelector with: trace) availableDebuggers identicalTo: trace
 ]

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -26,15 +26,7 @@ DSDebuggerSelectorTest >> assertDebuggerOpened: aDebugger onException: anExcepti
 
 { #category : #helper }
 DSDebuggerSelectorTest >> session [
-	| context process session |
-	context := [ Set new ] asContext.
-	process := Process
-		forContext: context
-		priority: Processor userInterruptPriority.
-	session := process
-		newDebugSessionNamed: 'test session'
-		startedAt: context.
-	^ session
+	^DSDummyDebugger dummySession
 ]
 
 { #category : #running }
@@ -42,11 +34,7 @@ DSDebuggerSelectorTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 
 	super setUp.
-	debuggers := OrderedCollection
-		withAll:
-			{(DSDummyDebugger named: #A).
-			(DSDummyDebugger named: #B).
-			(DSDummyDebugger named: #C)}.
+	debuggers := DSDummyDebugger dummyDebuggerList.
 	debuggerSelector := DSDebuggerSelector with: debuggers copy
 ]
 

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -19,7 +19,8 @@ DSDebuggerSelectorTest >> setUp [
 
 	super setUp.
 	debuggers := DSDummyDebugger dummyDebuggerList.
-	debuggerSelector := DSDebuggerSelector with: debuggers copy
+	debuggerSelector := DSDebuggerSelector with: debuggers copy.
+	debuggerSelector handlesDebuggerErrors: false
 ]
 
 { #category : #running }
@@ -60,7 +61,10 @@ DSDebuggerSelectorTest >> testHandled [
 DSDebuggerSelectorTest >> testHandlesDebuggerErrors [
 	self deny: debuggerSelector handlesDebuggerErrors.
 	debuggerSelector handlesDebuggerErrors: true.
-	self assert: debuggerSelector handlesDebuggerErrors
+	self assert: debuggerSelector handlesDebuggerErrors.
+	self
+		assert: DSDebuggerSelector new handlesDebuggerErrors
+		equals: DSDebuggerSelector handleDebuggerErrors
 ]
 
 { #category : #'tests - debuggers' }

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -1,0 +1,462 @@
+Class {
+	#name : #DSDebuggerSelectorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'debuggers',
+		'debuggerSelector'
+	],
+	#category : #'Debuggers-SelectionStrategies-Tests'
+}
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> assertDebuggerOpened: aDebugger onException: anException inProcess: aProcess [
+	| session process |
+	session := aDebugger tag.
+	self assert: session class equals: DebugSession.
+	self assert: session exception identicalTo: anException.
+
+	"The interrupted process is the one given to the API, 
+	whatever this process is."
+	process := session interruptedProcess.
+	self assert: session interruptedProcess identicalTo: aProcess.
+	self deny: process isTerminating.
+	self deny: process isTerminated.
+	self assert: process isSuspended
+]
+
+{ #category : #helper }
+DSDebuggerSelectorTest >> session [
+	| process |
+	process := [  ] newProcess.
+	^ debuggerSelector
+		newSessionFromException:
+			(DebuggerSelectorNullException
+				fromSignallerContext: process suspendedContext)
+		forProcess: process
+]
+
+{ #category : #running }
+DSDebuggerSelectorTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+
+	super setUp.
+	debuggers := OrderedCollection
+		withAll:
+			{(DummyUnusableDebugger named: #A).
+			(DSDummyDebugger named: #B).
+			(DSDummyDebugger named: #C)}.
+	debuggerSelector := DebuggerSelector with: debuggers copy.
+	DummyDebuggerSelector
+		debuggers: debuggers;
+		uiManager: nil
+]
+
+{ #category : #running }
+DSDebuggerSelectorTest >> tearDown [
+	debuggers
+		do: [ :dbg | 
+			(dbg tag isKindOf: DebugSession)
+				ifTrue: [ dbg tag terminate ] ].
+	DummyDebuggerSelector debuggers: nil.
+	super tearDown
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testAvailableDebuggers [
+	|availableDebuggerClasses sortedDebuggerClasses|
+	self fail.
+	availableDebuggerClasses := OldDebuggerSelector availableDebuggers collect:[:assoc| assoc key].
+	sortedDebuggerClasses := OldDebuggerSelector sortedDebuggersByRank collect:[:assoc| assoc value].  
+	self assertCollection: availableDebuggerClasses equals: sortedDebuggerClasses 
+]
+
+{ #category : #'tests - debugging API' }
+DSDebuggerSelectorTest >> testDebugExceptionInProcessFrom [
+	| exception process |
+	[ DSDummyDebugger new zeroDivide ]
+		on: Exception
+		do: [ :e | 
+			exception := e.
+			DummyDebuggerSelector
+				debugException: exception
+				inProcess: (process := [  ] newProcess)
+				from: DSDummyDebugger new ].
+	self
+		assertDebuggerOpened: debuggers second
+		onException: exception
+		inProcess: process
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testDebugExceptionInProcessFromWith [
+	| process exception dummyUIManager |
+	
+	self flag: 'Process are not the same, which is OK from the API point of view, but not accurate from the execution point of view'.
+	[ DSDummyDebugger new zeroDivide ]
+		on: Exception
+		do: [ :e | 
+			exception := e.
+			DebuggerSelector
+				debugException: exception
+				inProcess: (process := [ ] newProcess)
+				from: (dummyUIManager := DSDummyDebugger new)
+				with: debuggerSelector ].
+
+	"With this test, we ensure that calling the API opens a debugger on a debug session,
+	that holds the exception, its signaler context and the interrupted process.
+	We check the second debugger because it is the one that is selected (first always fails)."
+	self assertDebuggerOpened: debuggers second onException: exception inProcess: process.
+	
+	""
+	self assert: dummyUIManager deferred
+	
+]
+
+{ #category : #'tests - debugging API' }
+DSDebuggerSelectorTest >> testDebugMethodInProcessFromContextLabeled [
+	| dbg session process suspendedContext |
+	process := [ DSDummyDebugger new methodToDebug ] newProcess.
+	suspendedContext := process suspendedContext.
+	DummyDebuggerSelector
+		debugMethod: DSDummyDebugger >> #methodToDebug
+		inProcess: process
+		fromContext: suspendedContext
+		labeled: 'debug it'.
+	dbg := debuggers second.
+	session := dbg tag.
+	self
+		assertDebuggerOpened: dbg
+		onException: session exception
+		inProcess: process.
+	self
+		assert: session interruptedContext method
+		identicalTo: DSDummyDebugger >> #methodToDebug.
+	self
+		assert: session exception class
+		equals: DebuggerSelectorNullException.
+		
+	"Debugger Selector must have put us right at the entry of the method.
+	If we step over, we should be on the first ast node of the method"
+	session stepOver.
+	self
+		assert: ((DSDummyDebugger >> #methodToDebug) sourceNodeForPC: session interruptedContext pc)
+		identicalTo: (DSDummyDebugger >> #methodToDebug) ast statements first.
+]
+
+{ #category : #'tests - debugging API' }
+DSDebuggerSelectorTest >> testDebugProcessFromContextLabeled [
+	| context process session interruptedProcess exception |	
+	context := [  ] asContext.
+	process := [  ] newProcess.
+	"we use the dummy debugger selector to control the debuggers list and the ui manager.
+	we do not actually want to raise a real warning but just to ensure
+	the API gets the system to the opening of a debugger with the exception."
+	DummyDebuggerSelector
+		debugProcess: process
+		fromContext: context
+		labeled: #tag.
+	session := debuggers second tag.
+	interruptedProcess := session interruptedProcess.
+	exception := session exception.
+	self assert: session class equals: DebugSession.
+	self assert: interruptedProcess identicalTo: process.
+	self assert: interruptedProcess isSuspended.
+	self assert: session interruptedContext identicalTo: context.
+	self assert: exception class equals: DebuggerSelectorNullException.
+	self assert: exception signalerContext identicalTo: context.
+	self assert: exception messageText equals: #tag.
+	self assert: DummyDebuggerSelector uiManager deferred 
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testDebugSessionClass [
+	self assert: DebuggerSelector debugSessionClass equals: DebugSession
+]
+
+{ #category : #'tests - debugging API' }
+DSDebuggerSelectorTest >> testDebuggerWarningFrom [
+	| dbg |
+	dbg := DSDummyDebugger new.
+	DebuggerSelector debuggerWarning: #tag from: dbg.
+	self assert: dbg tag equals: #tag
+]
+
+{ #category : #'tests - debugging API' }
+DSDebuggerSelectorTest >> testDebuggerWarningInProcessFrom [
+	|e p|
+	[ Warning signal: #tag ]
+		on: Warning
+		do: [ :w | 
+			e := w.
+			"we use the dummy debugger selector to control the debuggers list.
+			we do not actually want to raise a real warning but just to ensure
+			the API gets the system to the opening of a debugger with the exception."
+			DummyDebuggerSelector
+				debuggerWarning: w
+				inProcess: (p := [  ] newProcess)
+				from: DSDummyDebugger new ].
+	self assertDebuggerOpened: debuggers second onException: e inProcess: p
+]
+
+{ #category : #tests }
+DSDebuggerSelectorTest >> testDebuggers [
+	self
+		assertCollection: debuggerSelector debuggers asOrderedCollection
+		equals: debuggers
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testDebuggersWithRanks [
+	|assocs systemDebuggers|
+	self fail.
+	assocs := OldDebuggerSelector debuggersWithRanks.
+	systemDebuggers := Smalltalk tools debuggers.
+	self assert: assocs size equals: systemDebuggers size.
+	self assertCollection: assocs equals: systemDebuggers
+
+]
+
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testFindDebuggerForDebuggerFailure [
+	| process semaphore exception session |
+	semaphore := Semaphore new.
+	process := [ [ 1 / 0 ]
+		on: Error
+		do: [ :err | exception := DebuggerFailure of: debuggers second on: err ] ]
+		newProcess.
+	[[ process resume ]
+		ensure: [ semaphore signal ]] fork.
+	semaphore wait.
+	
+	session := debuggerSelector
+		newSessionFromException: exception
+		forProcess: process.
+		
+	self
+		assert: (debuggerSelector findDebuggerForSession: session)
+		identicalTo: debuggers third
+]
+
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testFindDebuggerToHandleContext [
+	self
+		assert: (debuggerSelector findDebuggerForSession: self session)
+		identicalTo: debuggers second
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testLabeledDebuggers [
+	| dbgs labeledDebuggers |
+	self fail.
+	dbgs := {(999 -> 'main dbg').
+	(80 -> 'a dbg').
+	(5 -> 'another dbg')}.
+	labeledDebuggers := OldDebuggerSelector labeledDebuggers: dbgs.
+	self assert: labeledDebuggers first key equals: 'main dbg'.
+	self assert: labeledDebuggers first value equals: 'Main'.
+	self assert: labeledDebuggers second key equals: 'a dbg'.
+	self assert: labeledDebuggers second value equals: '80'.
+	self assert: labeledDebuggers third key equals: 'another dbg'.
+	self assert: labeledDebuggers third value equals: '5'
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testNewDebuggerSelector [
+	| dbgsel |
+	dbgsel := DebuggerSelector newDebuggerSelector.
+	self assert: dbgsel class equals: DebuggerSelector.
+	self
+		assertCollection: dbgsel availableDebuggers
+		equals: DebuggerSelector availableDebuggers
+]
+
+{ #category : #'tests - sessions' }
+DSDebuggerSelectorTest >> testNewSessionFromExceptionForProcess [
+
+	|exception process session|
+	exception := DebuggerSelectorNullException new signalIn: [] asContext; yourself.
+	process := [  ] newProcess.
+	session := debuggerSelector newSessionFromException: exception forProcess: process.
+	self assert: session interruptedProcess identicalTo: process.
+	self assert: session exception identicalTo: exception.
+	self assert: session interruptedContext identicalTo: exception signalerContext
+]
+
+{ #category : #tests }
+DSDebuggerSelectorTest >> testNextDebugger [
+	debuggers
+		do: [ :dbg | self assert: debuggerSelector nextDebugger identicalTo: dbg ]
+]
+
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testNoDebuggerForDebuggerFailure [
+	| process semaphore exception session |
+	semaphore := Semaphore new.
+	process := [ [ 1 / 0 ]
+		on: Error
+		do: [ :err | exception := DebuggerFailure of: debuggers second on: err ] ]
+		newProcess.
+	[[ process resume ]
+		ensure: [ semaphore signal ]] fork.
+	semaphore wait.
+	
+	exception := DebuggerFailure of: debuggers third on: exception.
+	session := debuggerSelector
+		newSessionFromException: exception
+		forProcess: process.
+		
+	self
+		assert: (debuggerSelector findDebuggerForSession: session) identicalTo: Transcripter
+]
+
+{ #category : #tests }
+DSDebuggerSelectorTest >> testNoNextDebugger [
+	debuggerSelector debuggers: #().
+	self assert: debuggerSelector nextDebugger identicalTo: Transcripter
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testNullExceptionForNamed [
+	|ctx e|
+	ctx := Context newForMethod: (DSDummyDebugger>>#tag).
+	ctx receiver: self.
+	e := DebuggerSelector nullExceptionFor: ctx named: #tag.
+	self assert: e receiver identicalTo: self.
+	self assert: e signalerContext identicalTo: ctx.
+	self assert: e messageText equals: #tag
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testOpenOn [
+	"Basically openOn: finds a debugger and calls tryOpen:on:.
+	So the first usable debugger (second in the list, see setUp)
+	should work"
+	| session |
+	session := self session.
+	debuggerSelector openOn: session.
+	self assert: debuggers second tag identicalTo: session
+]
+
+{ #category : #'tests - sessions' }
+DSDebuggerSelectorTest >> testPerformPreDebugActionsOn [
+	| tag |
+	"Default debug action is an empty block with 1 parameter"
+	debuggerSelector performPreDebugActionsOn: #tag.
+
+	"Custom debug action should execute the give block"
+	debuggerSelector preDebugAction: [ :session | tag := session ].
+	debuggerSelector performPreDebugActionsOn: #tag.
+	self assert: tag equals: #tag
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testPreDebugActionForDebugItMethod [
+	| session process suspendedContext |
+	process := [ DSDummyDebugger new methodToDebug ] newProcess.
+	suspendedContext := process suspendedContext.
+	session := debuggerSelector
+		newSessionFromException: (DebuggerSelector nullExceptionFor: suspendedContext named: #tag)
+		forProcess: process.
+	(DebuggerSelector
+		preDebugActionForDebugItMethod: DSDummyDebugger >> #methodToDebug)
+		value: session.
+
+	"Debugger Selector must have put us right at the entry of the method.
+	If we step over, we should be on the first ast node of the method"
+	self
+		assert: session interruptedContext method
+		identicalTo: DSDummyDebugger >> #methodToDebug.
+	session stepOver.
+	self
+		assert:
+			(DSDummyDebugger >> #methodToDebug
+				sourceNodeForPC: session interruptedContext pc)
+		identicalTo: (DSDummyDebugger >> #methodToDebug) ast statements first
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testRegisteredDebuggersWithRanks [
+	self fail
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testResumeException [
+	| res |
+	[ res := DummyExceptionToResume signal ]
+		on: DummyExceptionToResume
+		do: [ :e | DebuggerSelector resumeException: e ].
+	self assert: res equals: #tag
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testSignalDebuggerError [
+	"The dummy debugger selector uses a debug session object that does not actually signal a debugger error."
+
+	| exception signalerBlock |
+	exception := DebuggerSelectorNullException
+		fromSignallerContext: [  ] asContext.
+	signalerBlock := [ DummyDebuggerSelector
+		signalDebuggerError: exception ].
+	
+	self should: signalerBlock raise: DebuggerFailure.
+	signalerBlock
+		on: DebuggerFailure
+		do: [ :e | 
+			self
+				assert: e failedDebugger name
+				equals: DebuggerSelector signalDebuggerErrorMessage.
+			self assert: e innerException identicalTo: exception ]
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testSortedDebuggersByRank [
+	| assocs systemDebuggers sortedRanks expectedRanks |
+	self fail.
+	assocs := OldDebuggerSelector sortedDebuggersByRank.
+	systemDebuggers := Smalltalk tools debuggers.
+	self
+		assertCollection: (assocs collect: [ :assoc | assoc value ])
+		includesAll: (systemDebuggers collect: [ :assoc | assoc key ]).
+	sortedRanks := assocs collect: [ :assoc | assoc key ].
+	expectedRanks := (systemDebuggers collect: [ :assoc | assoc value ]) asSortedCollection.
+	self assert: sortedRanks equals: expectedRanks asOrderedCollection reversed
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testTryOpenOn [
+	| debugger session |
+	session := self session.
+
+	"In case of error, it should raise a debugger failure."
+	debugger := DummyUnusableDebugger new.
+	self
+		should: [ debuggerSelector tryOpen: debugger on: session ]
+		raise: DebuggerFailure.
+	[ debuggerSelector tryOpen: debugger on: session ]
+		on: DebuggerFailure
+		do: [ :dbgFailure | 
+			self assert: dbgFailure signaler identicalTo: debugger.
+			self assert: dbgFailure failedDebugger identicalTo: debugger.
+			self deny: (dbgFailure isHandleableBy: debugger).
+			self
+				assert: dbgFailure innerException
+				identicalTo: dbgFailure originException.
+			self
+				assert: dbgFailure innerException
+				identicalTo: debugger tag.
+			 ].
+
+	"A bit simplistic: we just check that tryOpen:On: 
+	sends debugSession: to the debugger with the session
+	as argument."
+	debugger := DSDummyDebugger new.
+	debuggerSelector tryOpen: debugger on: session.
+	self assert: debugger tag identicalTo: session
+]
+
+{ #category : #'tests - debuggers' }
+DSDebuggerSelectorTest >> testWith [
+	|trace|
+	trace := Object new.
+	self assert: (DebuggerSelector with: trace) availableDebuggers identicalTo: trace
+]

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -105,15 +105,15 @@ DSDebuggerSelectorTest >> testFirstUsableDebuggerForSession [
 ]
 
 { #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testHandleDebuggerErrors [
-	self deny: debuggerSelector handleDebuggerErrors.
-	debuggerSelector handleDebuggerErrors: true.
-	self assert: debuggerSelector handleDebuggerErrors
+DSDebuggerSelectorTest >> testHandled [
+	self deny: debuggerSelector handled
 ]
 
 { #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testHandled [
-	self deny: debuggerSelector handled
+DSDebuggerSelectorTest >> testHandlesDebuggerErrors [
+	self deny: debuggerSelector handlesDebuggerErrors.
+	debuggerSelector handlesDebuggerErrors: true.
+	self assert: debuggerSelector handlesDebuggerErrors
 ]
 
 { #category : #tests }
@@ -232,7 +232,7 @@ DSDebuggerSelectorTest >> testTryOpenWithSignalsError [
 		raise: DebuggerFailure.
 	self deny: debuggerSelector handled.	
 
-	debuggerSelector handleDebuggerErrors: true.
+	debuggerSelector handlesDebuggerErrors: true.
 	self
 		should: [ debuggerSelector tryOpen: session with: debuggers second ]
 		raise: DebuggerFailure.

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -166,11 +166,42 @@ DSDebuggerSelectorTest >> testNoNextDebugger [
 ]
 
 { #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testOpenDebuggerError [
+	| session |
+	session := self session.
+	session exception: (DebuggerFailure of: debuggers first on: session exception).
+	debuggers first beError.
+	debuggers second beError.
+	
+	"Because we are debugging a debugger error, we cannot raise another DebuggerFailure:
+	we want to find a debugger to debug the failing debugger."
+	debuggerSelector handlesDebuggerErrors: true.	
+	self shouldnt: [debuggerSelector openDebuggerForSession: session] raise: DebuggerFailure.	
+		
+	"Because the first debugger originated the debugger failure,
+	it is not considered in the algorithm anymore."
+	self assert: debuggers first tag equals: nil.
+	self assert: debuggers second tag class identicalTo: Error.
+	self assert: debuggers third tag identicalTo: session.
+	self assert: debuggerSelector handled
+]
+
+{ #category : #'tests -  algorithm' }
 DSDebuggerSelectorTest >> testOpenDebuggerForSession [
 	| session |
 	session := self session.
+	debuggerSelector openDebuggerForSession: session.
+	self assert: debuggers first tag identicalTo: session.
+	self assert: debuggerSelector handled
+]
+
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testOpenDebuggerWithErrorForSession [
+	| session |
+	session := self session.
 	debuggers first beError.
-	debuggers second beError.	
+	debuggers second beError.			
+	debuggerSelector handlesDebuggerErrors: false.
 	debuggerSelector openDebuggerForSession: session.
 	self assert: debuggers first tag class identicalTo: Error.
 	self assert: debuggers second tag class identicalTo: Error.	

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -139,6 +139,19 @@ DSDebuggerSelectorTest >> testNextDebugger [
 ]
 
 { #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testNextDebuggerForDebuggerFailure [
+	"Upon a debugger failure, we call the nextDebuggerForSession: interface to get the next debugger"
+	|session|
+	session := self session.
+	session exception: (DebuggerFailure of: debuggers first on: session exception).
+	self
+		assert: (debuggerSelector nextDebuggerForSession: session)
+		identicalTo: debuggers second
+
+	
+]
+
+{ #category : #'tests -  algorithm' }
 DSDebuggerSelectorTest >> testNextDebuggerForSession [
 	"Upon a debugger failure, we call the nextDebuggerForSession: interface to get the next debugger"
 	

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Debuggers-SelectionStrategies-Tests'
 }
 
-{ #category : #'tests - debugging' }
+{ #category : #helper }
 DSDebuggerSelectorTest >> assertDebuggerOpened: aDebugger onException: anException inProcess: aProcess [
 	| session process |
 	session := aDebugger tag.
@@ -92,27 +92,6 @@ DSDebuggerSelectorTest >> testDebuggers [
 ]
 
 { #category : #'tests -  algorithm' }
-DSDebuggerSelectorTest >> testFindDebuggerForDebuggerFailure [
-	| process semaphore exception session |
-	semaphore := Semaphore new.
-	process := [ [ 1 / 0 ]
-		on: Error
-		do: [ :err | exception := DebuggerFailure of: debuggers second on: err ] ]
-		newProcess.
-	[[ process resume ]
-		ensure: [ semaphore signal ]] fork.
-	semaphore wait.
-	
-	session := debuggerSelector
-		newSessionFromException: exception
-		forProcess: process.
-		
-	self
-		assert: (debuggerSelector findDebuggerForSession: session)
-		identicalTo: debuggers third
-]
-
-{ #category : #'tests -  algorithm' }
 DSDebuggerSelectorTest >> testFirstUsableDebuggerForSession [
 	
 	debuggerSelector debuggers first beUnusable.
@@ -130,6 +109,11 @@ DSDebuggerSelectorTest >> testHandleDebuggerErrors [
 	self deny: debuggerSelector handleDebuggerErrors.
 	debuggerSelector handleDebuggerErrors: true.
 	self assert: debuggerSelector handleDebuggerErrors
+]
+
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testHandled [
+	self deny: debuggerSelector handled
 ]
 
 { #category : #tests }
@@ -181,6 +165,19 @@ DSDebuggerSelectorTest >> testNoNextDebugger [
 	self assert: debuggerSelector nextDebugger identicalTo: Transcripter
 ]
 
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testOpenDebuggerForSession [
+	| session |
+	session := self session.
+	debuggers first beError.
+	debuggers second beError.	
+	debuggerSelector openDebuggerForSession: session.
+	self assert: debuggers first tag class identicalTo: Error.
+	self assert: debuggers second tag class identicalTo: Error.	
+	self assert: debuggers third tag identicalTo: session.
+	self assert: debuggerSelector handled
+]
+
 { #category : #'tests - debugging' }
 DSDebuggerSelectorTest >> testOpenOn [
 	"Basically openOn: finds a debugger and calls tryOpen:on:.
@@ -212,34 +209,32 @@ DSDebuggerSelectorTest >> testSignalDebuggerError [
 			self assert: e innerException identicalTo: exception ]
 ]
 
-{ #category : #'tests - debugging' }
-DSDebuggerSelectorTest >> testTryOpenOn [
-	| debugger session |
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testTryOpenWith [
+	| session |
 	session := self session.
-
-	"In case of error, it should raise a debugger failure."
-	debugger := DummyUnusableDebugger new.
 	self
-		should: [ debuggerSelector tryOpen: debugger on: session ]
+		shouldnt: [ debuggerSelector tryOpen: session with: debuggers first ]
 		raise: DebuggerFailure.
-	[ debuggerSelector tryOpen: debugger on: session ]
-		on: DebuggerFailure
-		do: [ :dbgFailure | 
-			self assert: dbgFailure signaler identicalTo: debugger.
-			self assert: dbgFailure failedDebugger identicalTo: debugger.
-			self deny: (dbgFailure isHandleableBy: debugger).
-			self
-				assert: dbgFailure innerException
-				identicalTo: dbgFailure originException.
-			self
-				assert: dbgFailure innerException
-				identicalTo: debugger tag.
-			 ].
+	self assert: debuggers first tag identicalTo: session.
+	self assert: debuggerSelector handled
+]
 
-	"A bit simplistic: we just check that tryOpen:On: 
-	sends debugSession: to the debugger with the session
-	as argument."
-	debugger := DSDummyDebugger new.
-	debuggerSelector tryOpen: debugger on: session.
-	self assert: debugger tag identicalTo: session
+{ #category : #'tests -  algorithm' }
+DSDebuggerSelectorTest >> testTryOpenWithSignalsError [
+	| session |
+	session := self session.
+	debuggers first beError.
+	debuggers second beError.
+	
+	self
+		shouldnt: [ debuggerSelector tryOpen: session with: debuggers first ]
+		raise: DebuggerFailure.
+	self deny: debuggerSelector handled.	
+
+	debuggerSelector handleDebuggerErrors: true.
+	self
+		should: [ debuggerSelector tryOpen: session with: debuggers second ]
+		raise: DebuggerFailure.
+	self deny: debuggerSelector handled
 ]

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -42,13 +42,10 @@ DSDebuggerSelectorTest >> setUp [
 	super setUp.
 	debuggers := OrderedCollection
 		withAll:
-			{(DummyUnusableDebugger named: #A).
+			{(DSDummyDebugger named: #A) beUnusable.
 			(DSDummyDebugger named: #B).
 			(DSDummyDebugger named: #C)}.
-	debuggerSelector := DebuggerSelector with: debuggers copy.
-	DummyDebuggerSelector
-		debuggers: debuggers;
-		uiManager: nil
+	debuggerSelector := DSDebuggerSelector with: debuggers copy
 ]
 
 { #category : #running }
@@ -57,7 +54,6 @@ DSDebuggerSelectorTest >> tearDown [
 		do: [ :dbg | 
 			(dbg tag isKindOf: DebugSession)
 				ifTrue: [ dbg tag terminate ] ].
-	DummyDebuggerSelector debuggers: nil.
 	super tearDown
 ]
 

--- a/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDebuggerSelectorTest.class.st
@@ -125,6 +125,13 @@ DSDebuggerSelectorTest >> testFirstUsableDebuggerForSession [
 	
 ]
 
+{ #category : #'tests - debugging' }
+DSDebuggerSelectorTest >> testHandleDebuggerErrors [
+	self deny: debuggerSelector handleDebuggerErrors.
+	debuggerSelector handleDebuggerErrors: true.
+	self assert: debuggerSelector handleDebuggerErrors
+]
+
 { #category : #tests }
 DSDebuggerSelectorTest >> testNextDebugger [
 	debuggers

--- a/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
@@ -1,0 +1,84 @@
+"
+I am a dummy debugger.
+My instances simulate debugger classes that are named, and can handle any context.
+"
+Class {
+	#name : #DSDummyDebugger,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'tag',
+		'deferred'
+	],
+	#category : #'Debuggers-SelectionStrategies-Tests'
+}
+
+{ #category : #'instance creation' }
+DSDummyDebugger class >> named: aString [
+	^self new name: aString
+]
+
+{ #category : #'instance creation' }
+DSDummyDebugger >> debugSession: aDebugSession [
+	tag := aDebugSession
+	
+]
+
+{ #category : #'deferred message' }
+DSDummyDebugger >> defer: aBlock [
+	aBlock value.
+	deferred := true 
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> deferred [
+	^ deferred ifNil:[deferred := false]
+]
+
+{ #category : #testing }
+DSDummyDebugger >> handlesContext: aContext [
+	^true
+]
+
+{ #category : #helpers }
+DSDummyDebugger >> methodToDebug [
+	| i |
+	i := 0.
+	10 timesRepeat: [ i := i + 1 ].
+	^ i
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> name [
+	^ name
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> name: anObject [
+	name := anObject
+]
+
+{ #category : #debugging }
+DSDummyDebugger >> signalDebuggerError: exception [
+	(DebuggerFailure of: self on: exception) signal
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> tag [
+	^ tag
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> tag: anObject [
+	tag := anObject
+]
+
+{ #category : #'ui requests' }
+DSDummyDebugger >> warningDefaultAction: aWarningException [
+	tag := aWarningException
+]
+
+{ #category : #helpers }
+DSDummyDebugger >> zeroDivide [
+	1/0
+]

--- a/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
@@ -9,7 +9,8 @@ Class {
 		'name',
 		'tag',
 		'deferred',
-		'usable'
+		'usable',
+		'error'
 	],
 	#category : #'Debuggers-SelectionStrategies-Tests'
 }
@@ -20,14 +21,23 @@ DSDummyDebugger class >> named: aString [
 ]
 
 { #category : #accessing }
+DSDummyDebugger >> beError [
+	error := true
+]
+
+{ #category : #accessing }
 DSDummyDebugger >> beUnusable [
 	usable := false
 ]
 
 { #category : #'instance creation' }
 DSDummyDebugger >> debugSession: aDebugSession [
-	tag := aDebugSession
-	
+	self isError
+		ifFalse: [ tag := aDebugSession.
+			^ self ].
+	tag := Error new.
+	tag signalIn: thisContext.
+	tag signal
 ]
 
 { #category : #'deferred message' }
@@ -43,7 +53,17 @@ DSDummyDebugger >> deferred [
 
 { #category : #testing }
 DSDummyDebugger >> handlesContext: aContext [
-	^usable ifNil:[true]
+	^self isUsable 
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> isError [
+	^ error ifNil: [ error := false ]
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> isUsable [
+	^ usable ifNil: [ usable := true ]
 ]
 
 { #category : #helpers }

--- a/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
@@ -15,6 +15,28 @@ Class {
 	#category : #'Debuggers-SelectionStrategies-Tests'
 }
 
+{ #category : #helpers }
+DSDummyDebugger class >> dummyDebuggerList [
+	^ OrderedCollection
+		withAll:
+			{(self named: #A).
+			(self named: #B).
+			(self named: #C)}
+]
+
+{ #category : #helpers }
+DSDummyDebugger class >> dummySession [
+	| context process session |
+	context := [ Set new ] asContext.
+	process := Process
+		forContext: context
+		priority: Processor userInterruptPriority.
+	session := process
+		newDebugSessionNamed: 'test session'
+		startedAt: context.
+	^ session
+]
+
 { #category : #'instance creation' }
 DSDummyDebugger class >> named: aString [
 	^self new name: aString

--- a/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSDummyDebugger.class.st
@@ -8,7 +8,8 @@ Class {
 	#instVars : [
 		'name',
 		'tag',
-		'deferred'
+		'deferred',
+		'usable'
 	],
 	#category : #'Debuggers-SelectionStrategies-Tests'
 }
@@ -16,6 +17,11 @@ Class {
 { #category : #'instance creation' }
 DSDummyDebugger class >> named: aString [
 	^self new name: aString
+]
+
+{ #category : #accessing }
+DSDummyDebugger >> beUnusable [
+	usable := false
 ]
 
 { #category : #'instance creation' }
@@ -37,7 +43,7 @@ DSDummyDebugger >> deferred [
 
 { #category : #testing }
 DSDummyDebugger >> handlesContext: aContext [
-	^true
+	^usable ifNil:[true]
 ]
 
 { #category : #helpers }

--- a/src/Debuggers-SelectionStrategies-Tests/DSSingleDebuggerSelectorTest.class.st
+++ b/src/Debuggers-SelectionStrategies-Tests/DSSingleDebuggerSelectorTest.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : #DSSingleDebuggerSelectorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'debuggers',
+		'debuggerSelector'
+	],
+	#category : #'Debuggers-SelectionStrategies-Tests'
+}
+
+{ #category : #running }
+DSSingleDebuggerSelectorTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+
+	super setUp.
+	debuggers := DSDummyDebugger dummyDebuggerList.
+	debuggerSelector := DSSingleDebuggerSelector with: debuggers copy
+]
+
+{ #category : #running }
+DSSingleDebuggerSelectorTest >> tearDown [
+	debuggers
+		do: [ :dbg | 
+			(dbg tag isKindOf: DebugSession)
+				ifTrue: [ dbg tag terminate ] ].
+	super tearDown
+]
+
+{ #category : #tests }
+DSSingleDebuggerSelectorTest >> testNextDebugger [
+	self
+		assert: debuggerSelector nextDebugger
+		identicalTo: debuggers first.
+	self
+		assert: debuggerSelector nextDebugger
+		identicalTo: debuggers first.
+	self
+		assert: debuggerSelector nextDebugger
+		identicalTo: debuggers first
+]
+
+{ #category : #tests }
+DSSingleDebuggerSelectorTest >> testOpenDebuggerForSession [
+	| session |
+	session := DSDummyDebugger dummySession.
+	
+	debuggerSelector openDebuggerForSession: session.
+	self assert: debuggers first tag identicalTo: session.	
+	
+	debuggers first tag: nil.
+	debuggerSelector openDebuggerForSession: session.
+	self assert: debuggers first tag identicalTo: session.	
+	self assert: debuggers second tag equals: nil.
+	
+	debuggers first tag: nil.
+	debuggerSelector openDebuggerForSession: session.
+	self assert: debuggers first tag identicalTo: session.	
+	self assert: debuggers third tag equals: nil.
+]

--- a/src/Debuggers-SelectionStrategies-Tests/package.st
+++ b/src/Debuggers-SelectionStrategies-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Debuggers-SelectionStrategies-Tests' }

--- a/src/Debuggers-SelectionStrategies/DSAbstractDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSAbstractDebuggerSelector.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #DSAbstractDebuggerSelector,
+	#superclass : #Object,
+	#category : #'Debuggers-SelectionStrategies'
+}
+
+{ #category : #iterating }
+DSAbstractDebuggerSelector >> nextDebugger [
+	^ self subclassResponsibility
+]

--- a/src/Debuggers-SelectionStrategies/DSAbstractDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSAbstractDebuggerSelector.class.st
@@ -1,10 +1,35 @@
 Class {
 	#name : #DSAbstractDebuggerSelector,
 	#superclass : #Object,
+	#instVars : [
+		'debuggers'
+	],
 	#category : #'Debuggers-SelectionStrategies'
 }
+
+{ #category : #instance }
+DSAbstractDebuggerSelector class >> with: aCollection [
+	^ self new
+		debuggers: aCollection;
+		yourself
+]
+
+{ #category : #accessing }
+DSAbstractDebuggerSelector >> debuggers [
+	^ debuggers
+]
+
+{ #category : #accessing }
+DSAbstractDebuggerSelector >> debuggers: aCollection [ 
+	debuggers := aCollection
+]
 
 { #category : #iterating }
 DSAbstractDebuggerSelector >> nextDebugger [
 	^ self subclassResponsibility
+]
+
+{ #category : #debuggers }
+DSAbstractDebuggerSelector >> openDebuggerForSession: aDebugSession [
+	self subclassResponsibility 
 ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
@@ -4,8 +4,33 @@ Class {
 	#instVars : [
 		'debuggers'
 	],
+	#classInstVars : [
+		'debuggerSelectionStrategy'
+	],
 	#category : #'Debuggers-SelectionStrategies'
 }
+
+{ #category : #settings }
+DSDebuggerSelectionStrategy class >> debuggeSelectionStrategySettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder pickOne: #debuggerSelectionStrategy)
+		label: 'Debugger selection strategy';
+		target: DSDebuggerSelectionStrategy;
+		default: DSSingleDebuggerSelector;
+		parent: #debugging;
+		domainValues: (DSDebuggerSelectionStrategy allSubclasses);
+		description: 'Sets the strategy to open a debugger.'
+]
+
+{ #category : #settings }
+DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy [
+	^debuggerSelectionStrategy ifNil:[debuggerSelectionStrategy := DSSingleDebuggerSelector]
+]
+
+{ #category : #settings }
+DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy: aClass [
+	debuggerSelectionStrategy := aClass
+]
 
 { #category : #instance }
 DSDebuggerSelectionStrategy class >> with: aCollection [

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #DSAbstractDebuggerSelector,
+	#name : #DSDebuggerSelectionStrategy,
 	#superclass : #Object,
 	#instVars : [
 		'debuggers'
@@ -8,28 +8,28 @@ Class {
 }
 
 { #category : #instance }
-DSAbstractDebuggerSelector class >> with: aCollection [
+DSDebuggerSelectionStrategy class >> with: aCollection [
 	^ self new
 		debuggers: aCollection;
 		yourself
 ]
 
 { #category : #accessing }
-DSAbstractDebuggerSelector >> debuggers [
+DSDebuggerSelectionStrategy >> debuggers [
 	^ debuggers
 ]
 
 { #category : #accessing }
-DSAbstractDebuggerSelector >> debuggers: aCollection [ 
+DSDebuggerSelectionStrategy >> debuggers: aCollection [ 
 	debuggers := aCollection
 ]
 
 { #category : #iterating }
-DSAbstractDebuggerSelector >> nextDebugger [
+DSDebuggerSelectionStrategy >> nextDebugger [
 	^ self subclassResponsibility
 ]
 
 { #category : #debuggers }
-DSAbstractDebuggerSelector >> openDebuggerForSession: aDebugSession [
+DSDebuggerSelectionStrategy >> openDebuggerForSession: aDebugSession [
 	self subclassResponsibility 
 ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelectionStrategy.class.st
@@ -11,7 +11,17 @@ Class {
 }
 
 { #category : #settings }
-DSDebuggerSelectionStrategy class >> debuggeSelectionStrategySettingsOn: aBuilder [
+DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy [
+	^debuggerSelectionStrategy ifNil:[debuggerSelectionStrategy := DSSingleDebuggerSelector]
+]
+
+{ #category : #settings }
+DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy: aClass [
+	debuggerSelectionStrategy := aClass
+]
+
+{ #category : #settings }
+DSDebuggerSelectionStrategy class >> debuggerSelectionStrategySettingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder pickOne: #debuggerSelectionStrategy)
 		label: 'Debugger selection strategy';
@@ -20,16 +30,6 @@ DSDebuggerSelectionStrategy class >> debuggeSelectionStrategySettingsOn: aBuilde
 		parent: #debugging;
 		domainValues: (DSDebuggerSelectionStrategy allSubclasses);
 		description: 'Sets the strategy to open a debugger.'
-]
-
-{ #category : #settings }
-DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy [
-	^debuggerSelectionStrategy ifNil:[debuggerSelectionStrategy := DSSingleDebuggerSelector]
-]
-
-{ #category : #settings }
-DSDebuggerSelectionStrategy class >> debuggerSelectionStrategy: aClass [
-	debuggerSelectionStrategy := aClass
 ]
 
 { #category : #instance }

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -48,7 +48,8 @@ DSDebuggerSelector >> nextDebugger [
 DSDebuggerSelector >> nextDebuggerForSession: aDebugSession [
 	| debugger |
 	debugger := self nextDebugger.
-	[ debugger handlesContext: aDebugSession context ]
+	[ (debugger handlesContext: aDebugSession context)
+		and: [ aDebugSession exception isHandleableBy: debugger ] ]
 		whileFalse: [ debugger := self nextDebugger ].
 	^ debugger
 ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #DSDebuggerSelector,
+	#superclass : #DSAbstractDebuggerSelector,
+	#instVars : [
+		'debuggers'
+	],
+	#category : #'Debuggers-SelectionStrategies'
+}
+
+{ #category : #instance }
+DSDebuggerSelector class >> with: aCollection [
+	^ self new
+		debuggers: aCollection;
+		yourself
+]
+
+{ #category : #accessing }
+DSDebuggerSelector >> debuggers [
+	^ debuggers
+]
+
+{ #category : #accessing }
+DSDebuggerSelector >> debuggers: aCollection [
+	debuggers := Stack newFrom: aCollection
+]
+
+{ #category : #iterating }
+DSDebuggerSelector >> nextDebugger [
+	debuggers isEmpty
+		ifTrue: [ ^ Transcripter ].
+	^ debuggers pop
+]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -30,3 +30,12 @@ DSDebuggerSelector >> nextDebugger [
 		ifTrue: [ ^ Transcripter ].
 	^ debuggers pop
 ]
+
+{ #category : #debuggers }
+DSDebuggerSelector >> nextDebuggerForSession: aDebugSession [
+	| debugger |
+	debugger := self nextDebugger.
+	[ debugger handlesContext: aDebugSession context ]
+		whileFalse: [ debugger := self nextDebugger ].
+	^ debugger
+]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -5,7 +5,7 @@ Class {
 		'debuggers',
 		'handled',
 		'debuggerError',
-		'handleDebuggerErrors'
+		'handlesDebuggerErrors'
 	],
 	#category : #'Debuggers-SelectionStrategies'
 }
@@ -28,18 +28,18 @@ DSDebuggerSelector >> debuggers: aCollection [
 ]
 
 { #category : #accessing }
-DSDebuggerSelector >> handleDebuggerErrors [
-	^handleDebuggerErrors ifNil:[handleDebuggerErrors := false]
-]
-
-{ #category : #accessing }
-DSDebuggerSelector >> handleDebuggerErrors: aBoolean [ 
-	handleDebuggerErrors := aBoolean
-]
-
-{ #category : #accessing }
 DSDebuggerSelector >> handled [
 	^handled ifNil:[handled := false]
+]
+
+{ #category : #accessing }
+DSDebuggerSelector >> handlesDebuggerErrors [
+	^handlesDebuggerErrors ifNil:[handlesDebuggerErrors := false]
+]
+
+{ #category : #accessing }
+DSDebuggerSelector >> handlesDebuggerErrors: aBoolean [ 
+	handlesDebuggerErrors := aBoolean
 ]
 
 { #category : #iterating }
@@ -74,7 +74,7 @@ DSDebuggerSelector >> tryOpen: aDebugSession with: aDebugger [
 	handled := true ]
 		on: Error , UnhandledException
 		do: [ :err | 
-			(self handleDebuggerErrors
+			(self handlesDebuggerErrors
 				and: [ aDebugSession exception isDebuggerFailure not ])
 				ifTrue: [ (DebuggerFailure of: aDebugger on: err) signal ] ]
 ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -2,7 +2,10 @@ Class {
 	#name : #DSDebuggerSelector,
 	#superclass : #DSAbstractDebuggerSelector,
 	#instVars : [
-		'debuggers'
+		'debuggers',
+		'handled',
+		'debuggerError',
+		'handleDebuggerErrors'
 	],
 	#category : #'Debuggers-SelectionStrategies'
 }
@@ -24,6 +27,16 @@ DSDebuggerSelector >> debuggers: aCollection [
 	debuggers := Stack newFrom: aCollection
 ]
 
+{ #category : #accessing }
+DSDebuggerSelector >> handleDebuggerErrors [
+	^handleDebuggerErrors ifNil:[handleDebuggerErrors := false]
+]
+
+{ #category : #accessing }
+DSDebuggerSelector >> handleDebuggerErrors: aBoolean [ 
+	handleDebuggerErrors := aBoolean
+]
+
 { #category : #iterating }
 DSDebuggerSelector >> nextDebugger [
 	debuggers isEmpty
@@ -38,4 +51,21 @@ DSDebuggerSelector >> nextDebuggerForSession: aDebugSession [
 	[ debugger handlesContext: aDebugSession context ]
 		whileFalse: [ debugger := self nextDebugger ].
 	^ debugger
+]
+
+{ #category : #debuggers }
+DSDebuggerSelector >> openDebuggerForSession: aDebugSession [
+	handled := false.
+	[ handled ]
+		whileFalse: [ self
+				tryOpen: aDebugSession
+				with: (self nextDebuggerForSession: aDebugSession) ]
+]
+
+{ #category : #debuggers }
+DSDebuggerSelector >> tryOpen: aDebugSession with: aDebugger [
+	[ aDebugger debugSession: aDebugSession.
+	handled := true ]
+		on: Error , UnhandledException
+		do: [ :err | debuggerError := err ]
 ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -2,25 +2,11 @@ Class {
 	#name : #DSDebuggerSelector,
 	#superclass : #DSAbstractDebuggerSelector,
 	#instVars : [
-		'debuggers',
 		'handled',
-		'debuggerError',
 		'handlesDebuggerErrors'
 	],
 	#category : #'Debuggers-SelectionStrategies'
 }
-
-{ #category : #instance }
-DSDebuggerSelector class >> with: aCollection [
-	^ self new
-		debuggers: aCollection;
-		yourself
-]
-
-{ #category : #accessing }
-DSDebuggerSelector >> debuggers [
-	^ debuggers
-]
 
 { #category : #accessing }
 DSDebuggerSelector >> debuggers: aCollection [

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -16,8 +16,32 @@ Class {
 		'handled',
 		'handlesDebuggerErrors'
 	],
+	#classInstVars : [
+		'handleDebuggerErrors'
+	],
 	#category : #'Debuggers-SelectionStrategies'
 }
+
+{ #category : #settings }
+DSDebuggerSelector class >> handleDebuggerErrors [
+	^ handleDebuggerErrors ifNil: [ handleDebuggerErrors := false ]
+]
+
+{ #category : #settings }
+DSDebuggerSelector class >> handleDebuggerErrors: aBoolean [
+	handleDebuggerErrors := aBoolean
+]
+
+{ #category : #settings }
+DSDebuggerSelector class >> handleDebuggerErrorsSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #handleDebuggerErrors)
+		label: 'Handle debugger errors';
+		target: self;
+		default: false;
+		parent: #debugging;
+		description: 'Try to debug debugger errors when they occur.'
+]
 
 { #category : #accessing }
 DSDebuggerSelector >> debuggers: aCollection [

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -55,7 +55,8 @@ DSDebuggerSelector >> handled [
 
 { #category : #accessing }
 DSDebuggerSelector >> handlesDebuggerErrors [
-	^handlesDebuggerErrors ifNil:[handlesDebuggerErrors := false]
+	^ handlesDebuggerErrors
+		ifNil: [ handlesDebuggerErrors := self class handleDebuggerErrors ]
 ]
 
 { #category : #accessing }

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -1,6 +1,17 @@
+"
+I take as input a sorted list of debuggers and a debug session.
+I will try to open the debug session with the first applicable debugger in this list.
+
+If this first applicable debugger encounters an error, I will either try the next applicable debugger or if I am configured to handle debugger errors (see handlesDebuggerErrors:) I will raise a DebuggerFailure exception.
+
+When I try to open a debug session created from a DebuggerFailure, I exclude the debugger that produced the debugger failure from my debugger list.
+
+When I succeeded to open a debugger, my instance variable ""handled"" becomes true. 
+If I failed to find any debugger, or to open the debug session with any debugger, ""handled"" stays false. This is the responsibility of my clients to deal with this situation (i.e., the system was unable to open a debugger).
+"
 Class {
 	#name : #DSDebuggerSelector,
-	#superclass : #DSAbstractDebuggerSelector,
+	#superclass : #DSDebuggerSelectionStrategy,
 	#instVars : [
 		'handled',
 		'handlesDebuggerErrors'
@@ -30,8 +41,6 @@ DSDebuggerSelector >> handlesDebuggerErrors: aBoolean [
 
 { #category : #iterating }
 DSDebuggerSelector >> nextDebugger [
-	debuggers isEmpty
-		ifTrue: [ ^ Transcripter ].
 	^ debuggers pop
 ]
 
@@ -48,7 +57,7 @@ DSDebuggerSelector >> nextDebuggerForSession: aDebugSession [
 { #category : #debuggers }
 DSDebuggerSelector >> openDebuggerForSession: aDebugSession [
 	handled := false.
-	[ handled ]
+	[ handled or:[self debuggers isEmpty ]]
 		whileFalse: [ self
 				tryOpen: aDebugSession
 				with: (self nextDebuggerForSession: aDebugSession) ]

--- a/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSDebuggerSelector.class.st
@@ -37,6 +37,11 @@ DSDebuggerSelector >> handleDebuggerErrors: aBoolean [
 	handleDebuggerErrors := aBoolean
 ]
 
+{ #category : #accessing }
+DSDebuggerSelector >> handled [
+	^handled ifNil:[handled := false]
+]
+
 { #category : #iterating }
 DSDebuggerSelector >> nextDebugger [
 	debuggers isEmpty
@@ -68,5 +73,8 @@ DSDebuggerSelector >> tryOpen: aDebugSession with: aDebugger [
 	[ aDebugger debugSession: aDebugSession.
 	handled := true ]
 		on: Error , UnhandledException
-		do: [ :err | debuggerError := err ]
+		do: [ :err | 
+			(self handleDebuggerErrors
+				and: [ aDebugSession exception isDebuggerFailure not ])
+				ifTrue: [ (DebuggerFailure of: aDebugger on: err) signal ] ]
 ]

--- a/src/Debuggers-SelectionStrategies/DSSingleDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSSingleDebuggerSelector.class.st
@@ -1,0 +1,21 @@
+"
+I select the first available debugger in the system and try to open a debug session with that debugger.
+I do not care about the possible existence of any other debugger.
+
+I am equivalent to the debugger selection strategy encoded in MorphicUIManager prior to the integration of DebuggerSelector.
+"
+Class {
+	#name : #DSSingleDebuggerSelector,
+	#superclass : #DSAbstractDebuggerSelector,
+	#category : #'Debuggers-SelectionStrategies'
+}
+
+{ #category : #iterating }
+DSSingleDebuggerSelector >> nextDebugger [
+	^ debuggers first
+]
+
+{ #category : #debuggers }
+DSSingleDebuggerSelector >> openDebuggerForSession: aDebugSession [
+	self nextDebugger debugSession: aDebugSession
+]

--- a/src/Debuggers-SelectionStrategies/DSSingleDebuggerSelector.class.st
+++ b/src/Debuggers-SelectionStrategies/DSSingleDebuggerSelector.class.st
@@ -6,7 +6,7 @@ I am equivalent to the debugger selection strategy encoded in MorphicUIManager p
 "
 Class {
 	#name : #DSSingleDebuggerSelector,
-	#superclass : #DSAbstractDebuggerSelector,
+	#superclass : #DSDebuggerSelectionStrategy,
 	#category : #'Debuggers-SelectionStrategies'
 }
 

--- a/src/Debuggers-SelectionStrategies/Transcripter.extension.st
+++ b/src/Debuggers-SelectionStrategies/Transcripter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Transcripter }
+
+{ #category : #'*Debuggers-SelectionStrategies' }
+Transcripter class >> handlesContext: aContext [
+	^true	
+]

--- a/src/Debuggers-SelectionStrategies/package.st
+++ b/src/Debuggers-SelectionStrategies/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Debuggers-SelectionStrategies' }

--- a/src/NewTools-DebuggerSelector/DebuggerFailure.class.st
+++ b/src/NewTools-DebuggerSelector/DebuggerFailure.class.st
@@ -46,7 +46,6 @@ DebuggerFailure >> isDebuggerFailure [
 { #category : #testing }
 DebuggerFailure >> isHandleableBy: aDebugger [
 	^ aDebugger ~= failedDebugger
-		and: [ innerException isHandleableBy: aDebugger ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
For @dupriezt @cdlm 
And it's working :)

* Use `DSDebuggerSelectionStrategy>>debuggerSelectionStrategy` to get the strategy to use to open a debugger
* Instantiate it using `with:`, passing a list of debuggers
* Call `openDebuggerForSession:` passing your session as a parameter
* The `handled` instance variable is set to `true` if the opening was successful, `false`otherwise

**Constraints:**

* You have to take care that if an error occurs while calling `openDebuggerForSession:` the emergency is opened (this **cannot** be done in the strategies classes (do it in `DebuggerSystem`)
* You have to deal with what to do in case `handled` is `false`: for now @dupriezt just display an info message, we'll deal with that later, what is nice is that it cannot freeze if no debugger is applicable or if all fail
* `DebugSession` instances must be correclty configured with their exception, especially if it is a `DebuggerFailure` instance
* All debuggers must implement a class method `debugSession:` that is called by `DebuggerSelector` instances to open them on a session.

I prefixed my classes with `DS` for **D**ebugger**S**ystem. We should do the same for all our classes, rename properly the packages (we should discuss how) and then we'll be able to push this easily in the main `NewTool` branch, although I wonder if this is necessary. Given the system modifications, we should attempt a direct PR into Pharo.

In addition there are two settings for: 
* Select the debugger strategy 
* Handle or not debugger errors

![Screenshot 2020-06-28 at 17 19 58](https://user-images.githubusercontent.com/26929529/85951457-9c18e700-b963-11ea-8665-fd7d7339fe09.png)
