### PR TITLE
tempNodesForContext: gets all the names of temps to then look up the …

### DIFF
--- a/src/NewTools-Inspector/StNodeCollector.class.st
+++ b/src/NewTools-Inspector/StNodeCollector.class.st
@@ -91,7 +91,7 @@ StNodeCollector >> slotNodes [
 
 { #category : #building }
 StNodeCollector >> tempNodesForContext: aContext [
-	^ aContext tempNames collect: [ :name | 
-		  (StInspectorTempNode hostObject: aContext) tempVariable:
-			  (aContext temporaryVariableNamed: name) ]
+^ aContext astScope allTemps collect: [ :temp |
+(StInspectorTempNode hostObject: aContext) tempVariable: temp]
+
 ]


### PR DESCRIPTION
tempNodesForContext: gets all the names of temps to then look up the variables. Instead we can directly get the variables.


Not sure if this helps to speed up things for https://github.com/pharo-spec/NewTools/issues/96

(this shows that we need a nicer API on context to get these variables, I added that to my backlog)