### PR TITLE
Fix visibility of workspace variables in debugIt expressions

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,7 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ (context lookupVar: aString) asForeignVariableFrom: context
+	^context lookupVar: aString
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,7 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ self doItReceiver bindingOf: aString
+	^ (context lookupVar: aString) asForeignVariableFrom: context
 ]
 
 { #category : #accessing }
@@ -51,7 +51,7 @@ StDebuggerContextInteractionModel >> doItReceiver [
 { #category : #testing }
 StDebuggerContextInteractionModel >> hasBindingOf: aString [
 
-	^ self doItReceiver hasBindingOf: aString
+	^ (context lookupVar: aString) notNil
 ]
 
 { #category : #testing }

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,7 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^context lookupVar: aString
+	^ (context lookupVar: aString) asForeignVariableFrom: context
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,7 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ (context lookupVar: aString) asForeignVariableFrom: context
+	^ (context lookupVar: aString) asDoItVariableFrom: context
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Debugger interaction model should use context #lookupVar: instead of receiver to extract bindings.
Found variables are converted to foreignVariable to be compatible to any evaluation context.

The fix requires PR for Spec2 to have an affect: https://github.com/pharo-spec/Spec/pull/955