### PR TITLE
RBProgramNode-inspectionSourceCode-noSource

### DIFF
--- a/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
@@ -14,8 +14,8 @@ RBProgramNode >> inspectionSourceCode [
 	<inspectorPresentationOrder: 30 title: 'Source code'>
 
 	^ SpCodePresenter new 
-		beForBehavior: (self withAllParents  first compilationContext ifNotNil: [ :ctx | ctx getClass ]);
-		text: self source;
+		beForBehavior: (self methodNode compilationContext ifNotNil: [ :ctx | ctx getClass ]);
+		text: (self source ifNil: [self formattedCode]);
 		selectionInterval: self sourceInterval;
 		yourself
 ]


### PR DESCRIPTION
- if the source if nil, call #formattedCode
- use "self methodNode" instead of  "self withAllParents  first"

To not having to do the nil check, we have to wait for the main image to fix https://github.com/pharo-project/pharo/issues/8117, thus this is another PR


