### PR TITLE
AST inspector: The pane in the inspector showing the Dump is highlighting strangely

### DIFF
--- a/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
@@ -6,6 +6,7 @@ RBProgramNode >> inspectionASTDump [
 
 	^ SpCodePresenter new 
 		text: (RBParser parseExpression: self dump) formattedCode; 
+		beForScripting; "this is an expression"
 		yourself
 ]
 


### PR DESCRIPTION
The reason is that the SpCodePresenter is highlighting it as a method, but it is an expression.

#beForScripting" sets it up correctly.
