### PR TITLE
Simplify StDebuggerContext>>#buildInspectorNodes

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -19,26 +19,14 @@ StDebuggerContext class >> context: aContext [
 		  yourself
 ]
 
-{ #category : #nodes }
-StDebuggerContext >> argumentsNodes [
-
-	| argNames |
-	argNames := self context sourceNode arguments.
-	^ (argNames collect: [ :argName | 
-		   (StDebuggerInspectorTempNode hostObject: self context) 
-			   argVariable: (self context temporaryVariableNamed: argName name) ])
-		  asOrderedCollection
-]
-
 { #category : #accessing }
 StDebuggerContext >> buildInspectorNodes [
 
-	| nodes argsNodes argsKeys tempsNodes |
+	| nodes argsNodes tempsNodes tempsAndArgs |
 	nodes := OrderedCollection new.
-	argsNodes := self argumentsNodes.
-	argsKeys := argsNodes collect: [ :node | node key ].
-	tempsNodes := self temporaryVariablesNodes reject: [ :tempNode | 
-		              argsKeys includes: tempNode key ].
+	tempsAndArgs := self temporaryVariablesNodes.
+	argsNodes := tempsAndArgs select: [ :tempNode | tempNode tempVariable isArgumentVariable ].
+	tempsNodes := tempsAndArgs select: [ :tempNode | tempNode tempVariable isTempVariable ].
 	nodes add: self selfNode.
 	nodes addAll: argsNodes.
 	nodes addAll: tempsNodes.

--- a/src/NewTools-Debugger/StDebuggerInspectorTempNode.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspectorTempNode.class.st
@@ -22,13 +22,6 @@ StDebuggerInspectorTempNode >> = anObject [
 ]
 
 { #category : #accessing }
-StDebuggerInspectorTempNode >> argVariable: aVariable [
-
-	super tempVariable: aVariable.
-	variableTag := 'arg'
-]
-
-{ #category : #accessing }
 StDebuggerInspectorTempNode >> children [
 	^ #()
 ]
@@ -66,7 +59,9 @@ StDebuggerInspectorTempNode >> tempVariable [
 StDebuggerInspectorTempNode >> tempVariable: aVariable [
 
 	super tempVariable: aVariable.
-	variableTag := 'temp'
+	variableTag := aVariable isArgumentVariable 
+		ifTrue: [ 'arg' ]
+		ifFalse: [ 'temp' ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- we do not need to query the AST for the arguments, the #temporaryVariablesNodes returns both args and temps and we can filter them
- StDebuggerInspectorTempNode can set the tag by checking which kind of var was handed to it, no need for a #argVariable: setter

more can be done later, e.g. StDebuggerInspectorTempNode might not need the tag but could ask the Variable for the tag.
