### PR TITLE
StDebuggerContextInteractionModel>>#bindingOf: needs to check for nil

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,8 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ (context lookupVar: aString) asDoItVariableFrom: context
+	^ (context lookupVar: aString) ifNotNil: [ :var | 
+		  var asDoItVariableFrom: context ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
lookupVar: returns nil if it does not find a var, which of course can happen.

(testing this is not easy... have not yet found a way)