### PR TITLE
adding-extension-to-stylesheets

### DIFF
--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -91,6 +91,14 @@ StPharoApplication >> start [
 StPharoApplication >> startUp: resuming [
 ]
 
+{ #category : #'accessing resources' }
+StPharoApplication >> styleSheet [
+
+	^ StPharoStyleContributor allSubclasses 
+			inject: super styleSheet 
+			into: [ :accum :each | accum , (each new styleSheetContribution) ]
+]
+
 { #category : #settings }
 StPharoApplication >> toolbarDisplayMode [
 

--- a/src/NewTools-Core/StPharoStyleContributor.class.st
+++ b/src/NewTools-Core/StPharoStyleContributor.class.st
@@ -1,0 +1,24 @@
+"
+This class presents an entry point to extend the stylesheet used by the Pharo application.
+Subclasses of it should implement #styleSheetContribution returning a StyleSheet that is composed with the default one. 
+
+Also subclasses are able to extend the #isApplicable method in the class side and decide to apply or not in different scenarios (e.g., different Operating Systems)
+"
+Class {
+	#name : #StPharoStyleContributor,
+	#superclass : #Object,
+	#category : #'NewTools-Core-Application'
+}
+
+{ #category : #testing }
+StPharoStyleContributor class >> isApplicable [ 
+
+	^ true
+]
+
+{ #category : #styles }
+StPharoStyleContributor >> styleSheetContribution [
+	
+	^ self subclassResponsibility
+
+]


### PR DESCRIPTION
Adding a contribution point for the applications that might extend the default pharo stylesheet.

This is required for Iceberg.