### PR TITLE
StNodeCollector>>tempNodesForContext: is only used by Sindarin

### DIFF
--- a/src/NewTools-Inspector/StNodeCollector.class.st
+++ b/src/NewTools-Inspector/StNodeCollector.class.st
@@ -83,10 +83,3 @@ StNodeCollector >> slotNodes [
 				hostObject: self object 
 				slot: each ]
 ]
-
-{ #category : #building }
-StNodeCollector >> tempNodesForContext: aContext [
-
-	^ aContext astScope allTemps collect: [ :temp | 
-		  (StInspectorTempNode hostObject: aContext) tempVariable: temp ]
-]

--- a/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SindarinDebugger }
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger class >> debuggerExtensionKey [
-	^ #sindarin
+SindarinDebugger >> debuggerExtensionKey [
+	^self class debuggerExtensionKey
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger >> debuggerExtensionKey [
-	^self class debuggerExtensionKey
+SindarinDebugger class >> debuggerExtensionKey [
+	^ #sindarin
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.class.st
@@ -28,7 +28,9 @@ StSindarinBytecodeContextInspectorModel >> contextReceiverSlotNodes [
 
 { #category : #'*NewTools-Sindarin-Tools' }
 StSindarinBytecodeContextInspectorModel >> contextTempNodes [
-	^ StNodeCollector new tempNodesForContext: self inspectedObject
+	^ self inspectedObject astScope allTemps collect: [ :temp | 
+		  (StInspectorTempNode hostObject: self inspectedObject) tempVariable: temp ]
+
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.extension.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeContextInspectorModel.extension.st
@@ -11,5 +11,7 @@ StSindarinBytecodeContextInspectorModel >> contextReceiverSlotNodes [
 
 { #category : #'*NewTools-Sindarin-Tools' }
 StSindarinBytecodeContextInspectorModel >> contextTempNodes [
-	^ StNodeCollector new tempNodesForContext: self inspectedObject
+	^ self inspectedObject astScope allTemps collect: [ :temp | 
+		  (StInspectorTempNode hostObject: self inspectedObject) tempVariable: temp ]
+
 ]


### PR DESCRIPTION
Iinline it into #contextTempNodes there so that it works the same as the main Debugger