### PR TITLE
Avoid errors when inspecting objects that cannot be printed

### DIFF
--- a/src/NewTools-Inspector/StInspectorModel.class.st
+++ b/src/NewTools-Inspector/StInspectorModel.class.st
@@ -101,5 +101,7 @@ StInspectorModel >> smallDescriptionString [
 { #category : #accessing }
 StInspectorModel >> windowTitle [
 
-	^ 'Inspector on {1}' format: { self inspectedObject gtDisplayString }
+	^ 'Inspector on {1}' format: { 
+		[ self inspectedObject gtDisplayString ] on: Error do: [ :e |
+			e printString ] }
 ]


### PR DESCRIPTION
Inspecting an object that fails on printing opens a debugger.
Try to be a bit more robust (ideally I'd like to be able to inspect, and to debug if I want later, but...).

