### PR TITLE
Fix-Debugger-Playground-Bindings

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,7 +22,7 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ (context lookupVar: aString) ifNotNil: [ :var | 
+	^ (context lookupVar: aString declare: false) ifNotNil: [ :var | 
 		  var asDoItVariableFrom: context ]
 ]
 
@@ -51,8 +51,8 @@ StDebuggerContextInteractionModel >> doItReceiver [
 
 { #category : #testing }
 StDebuggerContextInteractionModel >> hasBindingOf: aString [
-
-	^ (context lookupVar: aString) notNil
+	"The debugger does not define new bindings"
+	^nil
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This PR fixes https://github.com/pharo-project/pharo/issues/8803

The idea is that StDebuggerContextInteractionModel does not define any bindings by itself, therefore, #hasBindingOf: should return nil. #bindingOf: forwards the lookup to the context. It now makes sure to
not create a new binding in the requestor (should there be one) by using #lookupVar:declare: with false.
