### PR TITLE
StDummyTestClassWithHalts-add-Accessor

### DIFF
--- a/src/NewTools-Debugger-Breakpoints-Tools/StDummyTestClassWithHalts.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StDummyTestClassWithHalts.class.st
@@ -10,3 +10,9 @@ Class {
 	],
 	#category : #'NewTools-Debugger-Breakpoints-Tools-Tests'
 }
+
+{ #category : #accessing }
+StDummyTestClassWithHalts >> var [
+	"the var is used for testing, this accessor us just here so that it has one user"
+	^var
+]


### PR DESCRIPTION
StDummyTestClassWithHalts had an unused ivar. The variable is used in tests. We add an accessor to reduce the number of classes with unused ivars.

Another step for https://github.com/pharo-spec/NewTools/issues/162

