### PR TITLE
Improve-Debugger-Playground-Bindings

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -22,8 +22,11 @@ StDebuggerContextInteractionModel >> behavior [
 { #category : #binding }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
-	^ (context lookupVar: aString declare: false) ifNotNil: [ :var | 
-		  var asDoItVariableFrom: context ]
+	"we can not call #lookupVar: without checking first as it would create the variable"
+
+	^ (self hasBindingOf: aString)
+		  ifTrue: [ (context lookupVar: aString) asDoItVariableFrom: context ]
+		  ifFalse: [ nil ]
 ]
 
 { #category : #accessing }
@@ -51,8 +54,8 @@ StDebuggerContextInteractionModel >> doItReceiver [
 
 { #category : #testing }
 StDebuggerContextInteractionModel >> hasBindingOf: aString [
-	"The debugger does not define new bindings"
-	^ false
+	"we lookup the name without creating a new variable"
+	^ (context lookupVar: aString declare: false) notNil
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This is an improved version of https://github.com/pharo-spec/NewTools/pull/215

This makes syntax highlighting work correctly.

- the non-creating lookup is now done in hasBindingOf:
- #bindingOf: now first calls # hasBindingOf: to avoid creating new bindings in the requestor
