### PR TITLE
StInspectorTempNode-rawValue-hardening

### DIFF
--- a/src/NewTools-Inspector/StInspectorTempNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTempNode.class.st
@@ -49,8 +49,10 @@ StInspectorTempNode >> key [
 StInspectorTempNode >> rawValue [
 	"Answer the object value of this object variable (slot, indexed attribute, computed value)."
 
-	^ [ tempVariable readInContext: self hostObject ]
-		  on: SubscriptOutOfBounds
+	^ [ 
+		"we use #tempNamed: to force a re-lookup of the variable"
+		self hostObject tempNamed: tempVariable name]
+		  on: Error
 		  do: [ :err | 'cannot read ' , tempVariable name ]
 ]
 


### PR DESCRIPTION
This PR makes #rawValue more forgiving for failure cases:
- trap all Errors, as, e.g. when something goes wrong with looking up temps stored in the temp vector, we could have other error.
- use ##tempNamed: to force a re-lookup of the variable object used to read the data from the context.

