### PR TITLE
createMissingClass-use-createdclass

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -461,13 +461,13 @@ StDebugger >> createMissingClass [
 	message := self interruptedContext tempAt: 1.
 	exception := self interruptedContext tempAt: 2.
 	variableNode := exception variableNode.
-	[ 
-	OCUndeclaredVariableWarning new
+	[ | newClassBinding | 
+	newClassBinding := OCUndeclaredVariableWarning new
 		node: variableNode;
-		defineClass: variableNode name.
+		defineClass: variableNode name. 
 	self
 		createMissingMethodFor: message
-		in: self interruptedContext receiver class ]
+		in: newClassBinding value ]
 		on: Abort
 		do: [ ^ self ].
 


### PR DESCRIPTION
While debugging https://github.com/pharo-project/pharo/issues/3211 I found that #createMissingClass was not adding the new method to the correct class, it was adding it to UndefinedObject.

This PR makes sure to create the method on the class that we created.


