### PR TITLE
Fix/276

### DIFF
--- a/src/NewTools-Inspector-Extensions/Object.extension.st
+++ b/src/NewTools-Inspector-Extensions/Object.extension.st
@@ -35,11 +35,7 @@ Object >> inspectorNodes [
 { #category : #'*NewTools-Inspector-Extensions' }
 Object >> stDisplayString [
 
-	[ self displayString linesDo: [ :each | ^ each contractTo: 200 ] ]
-		on: Error
-		do: [ :err | ^ err stDisplayString ].
-
-	^ ''
+	^ StObjectPrinter asTruncatedTextFrom: self
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }

--- a/src/NewTools-Inspector-Tests/StObjectPrinterTest.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectPrinterTest.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #StObjectPrinterTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-Inspector-Tests'
+}
+
+{ #category : #assertions }
+StObjectPrinterTest >> assertIsError: aCollection expectedMessage: aMessage [
+	
+	self assert: aCollection asString equals: 'Error printing: ', aMessage.
+	self assert: aCollection runs anyOne first color equals: Color red
+]
+
+{ #category : #tests }
+StObjectPrinterTest >> testPrintDoesNotUnderstand [
+
+	| printedValue |
+	printedValue := StObjectPrinter asTruncatedTextFrom: StObjectWithPrintDoesNotUnderstand new.
+	
+	self assertIsError: printedValue expectedMessage: 'StObjectWithPrintDoesNotUnderstand>> #iShouldNotUnderstandThis'
+]
+
+{ #category : #tests }
+StObjectPrinterTest >> testPrintError [
+
+	| printedValue |
+	printedValue := StObjectPrinter asTruncatedTextFrom: StObjectWithPrintError new.
+	
+	self assertIsError: printedValue expectedMessage: 'Some error message'
+]
+
+{ #category : #tests }
+StObjectPrinterTest >> testPrintHalt [
+
+	| printedValue |
+	printedValue := StObjectPrinter asTruncatedTextFrom: StObjectWithPrintHalt new.
+	
+	self assertIsError: printedValue expectedMessage: 'Halt'
+]

--- a/src/NewTools-Inspector-Tests/StObjectWithPrintDoesNotUnderstand.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectWithPrintDoesNotUnderstand.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #StObjectWithPrintDoesNotUnderstand,
+	#superclass : #Object,
+	#category : #'NewTools-Inspector-Tests'
+}
+
+{ #category : #printing }
+StObjectWithPrintDoesNotUnderstand >> printOn: aString [
+
+	^ self iShouldNotUnderstandThis
+]

--- a/src/NewTools-Inspector-Tests/StObjectWithPrintError.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectWithPrintError.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #StObjectWithPrintError,
+	#superclass : #Object,
+	#category : #'NewTools-Inspector-Tests'
+}
+
+{ #category : #printing }
+StObjectWithPrintError >> printOn: aString [
+
+	^ self error: 'Some error message'
+]

--- a/src/NewTools-Inspector-Tests/StObjectWithPrintHalt.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectWithPrintHalt.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #StObjectWithPrintHalt,
+	#superclass : #Object,
+	#category : #'NewTools-Inspector-Tests'
+}
+
+{ #category : #printing }
+StObjectWithPrintHalt >> printOn: aString [
+
+	^ self halt
+]

--- a/src/NewTools-Inspector-Tests/StObjectWithPrintHalt.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectWithPrintHalt.class.st
@@ -7,5 +7,7 @@ Class {
 { #category : #printing }
 StObjectWithPrintHalt >> printOn: aString [
 
+	<haltOrBreakpointForTesting>
+
 	^ self halt
 ]

--- a/src/NewTools-Inspector/StObjectPrinter.class.st
+++ b/src/NewTools-Inspector/StObjectPrinter.class.st
@@ -14,7 +14,7 @@ StObjectPrinter class >> asNonTruncatedTextFrom: anObject [
 	are replaced by spaces. I return a String unless there is an error 
 	printing the object. In this case I return a Text highlighted in red."
 	^ [ anObject asString replaceAll: String cr with: String space ] 
-			on: Error 
+			on: Exception 
 			do: [ Text string: 'error printing' attribute: TextColor red ]
 ]
 
@@ -24,8 +24,16 @@ StObjectPrinter class >> asTruncatedTextFrom: anObject [
 	are replaced by spaces. I return a String unless there is an error printing the
 	object. In this case I return a Text highlighted in red."
 	^ [ (anObject displayString copyReplaceAll: String cr with: String space) replaceAll: String lf with: String space ]
-		on: Error
-		do: [ Text string: 'error printing' attribute: TextColor red ]
+		on: Exception
+		do: [ :error | self textFromError: error ]
+]
+
+{ #category : #converting }
+StObjectPrinter class >> textFromError: anError [
+
+	| message |
+	message := anError messageText ifEmpty: [ anError class name ].
+	^ Text string: 'Error printing: ', message attribute: TextColor red
 ]
 
 { #category : #printing }


### PR DESCRIPTION
Use StObjectPrinter to correctly display errors when printing inspector values
Added tests for halt, error and DNU printing