### PR TITLE
Fix/275

### DIFF
--- a/src/NewTools-Inspector-Tests/StInspectorMockObject.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectorMockObject.class.st
@@ -12,3 +12,75 @@ StInspectorMockObject >> inspectionMock1 [
 		label: 'Test';
 		yourself
 ]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithDnuingContext [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithDNUingContext'>
+
+	^ SpLabelPresenter new
+		label: 'Test';
+		yourself
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithDnuingContextContext: aContext [
+	
+	"This selector is automatically called by concatenating Context: to an inspector presentation"
+	
+	self iShouldNotUnderstandThis
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithDnuingPresentation [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithDNUingContext'>
+
+	self iShouldNotUnderstandThis
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithFailingContext [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithFailingContext'>
+
+	^ SpLabelPresenter new
+		label: 'Test';
+		yourself
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithFailingContextContext: aContext [
+	
+	"This selector is automatically called by concatenating Context: to an inspector presentation"
+	
+	self error
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithFailingPresentation [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithFailingPresentation'>
+
+	self error
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithHaltingContext [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithHaltingContext'>
+
+	^ SpLabelPresenter new
+		label: 'Test';
+		yourself
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithHaltingContextContext: aContext [
+	
+	"This selector is automatically called by concatenating Context: to an inspector presentation"
+	
+	self halt
+]
+
+{ #category : #'inspector extensions' }
+StInspectorMockObject >> methodWithHaltingPresentation [
+	<inspectorPresentationOrder: 0 title: 'PresentationWithHaltingContext'>
+
+	self halt
+]

--- a/src/NewTools-Inspector-Tests/StInspectorMockObject.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectorMockObject.class.st
@@ -74,6 +74,7 @@ StInspectorMockObject >> methodWithHaltingContext [
 StInspectorMockObject >> methodWithHaltingContextContext: aContext [
 	
 	"This selector is automatically called by concatenating Context: to an inspector presentation"
+	<haltOrBreakpointForTesting>
 	
 	self halt
 ]
@@ -81,6 +82,7 @@ StInspectorMockObject >> methodWithHaltingContextContext: aContext [
 { #category : #'inspector extensions' }
 StInspectorMockObject >> methodWithHaltingPresentation [
 	<inspectorPresentationOrder: 0 title: 'PresentationWithHaltingContext'>
-
+	<haltOrBreakpointForTesting>
+	
 	self halt
 ]

--- a/src/NewTools-Inspector-Tests/StInspectorTest.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectorTest.class.st
@@ -24,6 +24,84 @@ StInspectorTest >> tearDown [
 ]
 
 { #category : #tests }
+StInspectorTest >> testBuildPresentationWithDoesNotUndertandShouldReturnCodePresenter [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithDnuingPresentation) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	
+	"Smoke test -> creating an inspection presenter should not fail. Instead it should create an error presenter"
+	context newInspectionPresenter
+]
+
+{ #category : #tests }
+StInspectorTest >> testBuildPresentationWithFailureShouldReturnCodePresenter [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithFailingPresentation) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	
+	"Smoke test -> creating an inspection presenter should not fail. Instead it should create an error presenter"
+	context newInspectionPresenter
+]
+
+{ #category : #tests }
+StInspectorTest >> testBuildPresentationWithHaltShouldReturnCodePresenter [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithHaltingPresentation) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	
+	"Smoke test -> creating an inspection presenter should not fail. Instead it should create an error presenter"
+	context newInspectionPresenter
+]
+
+{ #category : #tests }
+StInspectorTest >> testConfigureContextWithDoesNotUnderstandShouldMarkContextAsError [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithDnuingContext) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	self assert: context isErrorContext
+]
+
+{ #category : #tests }
+StInspectorTest >> testConfigureContextWithErrorShouldMarkContextAsError [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithFailingContext) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	self assert: context isErrorContext
+]
+
+{ #category : #tests }
+StInspectorTest >> testConfigureContextWithHaltShouldMarkContextAsError [
+
+
+	| collector pragma context |
+	collector := StInspectionCollector on: StInspectorMockObject new.
+	pragma := (StInspectorMockObject >> #methodWithHaltingContext) pragmas first.
+
+	context := collector contextFromPragma: pragma.
+	self assert: context isErrorContext
+]
+
+{ #category : #tests }
 StInspectorTest >> testDefaultKeyboardFocus [
 
 	inspector openWithSpec.

--- a/src/NewTools-Inspector/StErrorContext.class.st
+++ b/src/NewTools-Inspector/StErrorContext.class.st
@@ -1,0 +1,37 @@
+"
+I represent an erroneous inspector context.
+I arrive when an inspector context fails with an exception.
+In that case, I force the inspection presenter to be a debug inspection presenter.
+"
+Class {
+	#name : #StErrorContext,
+	#superclass : #StInspectionContext,
+	#instVars : [
+		'error'
+	],
+	#category : #'NewTools-Inspector-Model'
+}
+
+{ #category : #initialization }
+StErrorContext >> basicNewInspectionPresenter [
+
+	^ self debugInspectorPresenter
+]
+
+{ #category : #initialization }
+StErrorContext >> getError [
+
+	^ error
+]
+
+{ #category : #testing }
+StErrorContext >> isErrorContext [
+	
+	^ true
+]
+
+{ #category : #initialization }
+StErrorContext >> setError: anError [
+
+	error := anError
+]

--- a/src/NewTools-Inspector/StInspectionCollector.class.st
+++ b/src/NewTools-Inspector/StInspectionCollector.class.st
@@ -37,6 +37,23 @@ StInspectionCollector class >> on: anObject [
 		yourself
 ]
 
+{ #category : #private }
+StInspectionCollector >> basicContextFromPragma: aPragma [
+	
+	"Get the context for a pragma or fail if an error happens"
+	| context |
+	
+	context := StInspectionContext fromPragma: aPragma.
+	context inspectedObject: self inspectedObject.
+	
+	(aPragma methodClass includesSelector: context contextMethodSelector) ifTrue: [ 
+		self inspectedObject 
+			perform: context contextMethodSelector
+			with: context ].
+
+	^ context
+]
+
 { #category : #accessing }
 StInspectionCollector >> collectInspectionContexts [
 	| pragmas |
@@ -62,17 +79,16 @@ StInspectionCollector >> collectPragmas: aPragmaName [
 
 { #category : #private }
 StInspectionCollector >> contextFromPragma: aPragma [
-	| context |
-	
-	context := StInspectionContext fromPragma: aPragma.
-	context inspectedObject: self inspectedObject.
-	
-	(aPragma methodClass includesSelector: context contextMethodSelector) ifTrue: [ 
-		self inspectedObject 
-			perform: context contextMethodSelector
-			with: context ].
 
-	^ context
+	"Return the inspection context for a pragma.
+	Safe version: Return an error context if the context cannot be obtained"
+	[ ^ self basicContextFromPragma: aPragma ]
+		on: Exception
+		do: [ :error | 
+			^ (StErrorContext fromPragma: aPragma)
+				  inspectedObject: self inspectedObject;
+				  setError: error freeze;
+				  yourself ]
 ]
 
 { #category : #private }

--- a/src/NewTools-Inspector/StInspectionContext.class.st
+++ b/src/NewTools-Inspector/StInspectionContext.class.st
@@ -89,7 +89,7 @@ StInspectionContext >> debugInspectorPresenter [
 			nextPutAll: methodSelector;
 			nextPutAll: ') pragmas first.'; cr.
 		str nextPutAll: 'context := collector basicContextFromPragma: pragma.'; cr.
-		str nextPutAll: 'context newInspectionPresenter'.
+		str nextPutAll: 'context basicNewInspectionPresenter'.
 	].
 
 	"I am itself an evaluator, no need to some other one."

--- a/src/NewTools-Inspector/StInspectionContext.class.st
+++ b/src/NewTools-Inspector/StInspectionContext.class.st
@@ -2,6 +2,8 @@
 An object to control the visibility and properties of inspections. 
 It will be passed to the objects defining the inspections, in case they implement the method defined in `StInspectionContext>>#contextMethodSelector`.
 
+If I fail to create a presentation, I provide a debug presentation instead.
+
 ## Example
 If you define a method `Object>>#inspectionMeta`, you can define a context method `Object>>#inspectionMetaContext:`.
 "
@@ -33,6 +35,18 @@ StInspectionContext >> active: aBoolean [
 	active := aBoolean
 ]
 
+{ #category : #'private - factory' }
+StInspectionContext >> basicNewInspectionPresenter [
+
+	^ self methodSelectorNeedsBuilder 
+		ifTrue: [ 
+			self inspectedObject 
+				inspectorPerform: self methodSelector 
+				with: self newPresenterBuilder ]
+		ifFalse: [ 
+			self inspectedObject inspectorPerform: self methodSelector ]
+]
+
 { #category : #accessing }
 StInspectionContext >> beActive [
 
@@ -53,6 +67,37 @@ StInspectionContext >> contextMethodSelector [
 		ifTrue: [ self methodSelector allButLast ]
 		ifFalse: [ self methodSelector ].
 	^ (self methodSelector, 'Context:') asSymbol
+]
+
+{ #category : #initialization }
+StInspectionContext >> debugInspectorPresenter [
+
+	"Create a debug inspector presenter.
+	
+	I create a code presenter that contains code to recreate this presenter.
+	This is useful for debugging and reporting errors when rendering/building"
+
+	| debugExpression |
+	debugExpression := String streamContents: [ :str |
+		str nextPutAll: '"Error while creating the inspector. Debug it by executing the following:"'; cr.
+		str nextPutAll: '| collector pragma context |'; cr.
+		str nextPutAll: 'collector := StInspectionCollector on: self.'; cr.
+		str
+			nextPutAll: 'pragma := (';
+			nextPutAll: inspectedObject class name;
+			nextPutAll: ' lookupSelector: #';
+			nextPutAll: methodSelector;
+			nextPutAll: ') pragmas first.'; cr.
+		str nextPutAll: 'context := collector basicContextFromPragma: pragma.'; cr.
+		str nextPutAll: 'context newInspectionPresenter'.
+	].
+
+	"I am itself an evaluator, no need to some other one."
+	self withoutEvaluator.
+	^ SpCodePresenter new
+		beForObject: self inspectedObject;
+		text: (Text string: debugExpression attribute: TextColor red);
+		yourself
 ]
 
 { #category : #accessing }
@@ -123,13 +168,11 @@ StInspectionContext >> methodSelectorNeedsBuilder [
 { #category : #'private - factory' }
 StInspectionContext >> newInspectionPresenter [
 
-	^ self methodSelectorNeedsBuilder 
-		ifTrue: [ 
-			self inspectedObject 
-				inspectorPerform: self methodSelector 
-				with: self newPresenterBuilder ]
-		ifFalse: [ 
-			self inspectedObject inspectorPerform: self methodSelector ]
+	"Create an inspection presenter for the current object and pragma.
+	If creation fails, create a debug inspector instead"
+	^ [self basicNewInspectionPresenter]
+		on: Exception do: [ :error |
+			self debugInspectorPresenter ]
 ]
 
 { #category : #factory }


### PR DESCRIPTION
Fix #275

- Handling errors during inspector context creation
- Handling errors during inspector presentation creation
- Provide a debugInspectorPresentation when failure happens