### PR TITLE
Improving the inspection of compiled methods

### DIFF
--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -27,7 +27,7 @@ CompiledCode >> inspectionAST [
 
 { #category : #'*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionBytecode [
-	<inspectorPresentationOrder: 20 title: 'Bytecode'>
+	<inspectorPresentationOrder: 30 title: 'Bytecode'>
 
 	^ SpListPresenter new 
 		items: self symbolicBytecodes;
@@ -46,8 +46,15 @@ CompiledCode >> inspectionHeader [
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }
+CompiledCode >> inspectionItemsContext: aContext [
+
+	"Disable items view on compiled code"
+	aContext active: false
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionPragmas [
-	<inspectorPresentationOrder: 30 title: 'Pragmas'> 
+	<inspectorPresentationOrder: 50 title: 'Pragmas'> 
 
 	^ SpListPresenter new
 		items: self pragmas;
@@ -63,7 +70,7 @@ CompiledCode >> inspectionPragmasContext: aContext [
 
 { #category : #'*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionSource [
-	<inspectorPresentationOrder: 30 title: 'Source'>
+	<inspectorPresentationOrder: 20 title: 'Source'>
 	
 	^ SpCodePresenter new 
 		beForBehavior: self methodClass;

--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -92,7 +92,12 @@ CompiledCode >> inspectorNodes [
 	| nodes |
 
 	nodes := OrderedCollection new.
-	nodes addAll: (self literals 
+	nodes add: (StInspectorDynamicNode 
+				hostObject: self 
+				label: 'literal0'
+				value: self header).
+	
+	nodes addAll: (self allLiterals 
 		collectWithIndex: [ :aLiteral :anIndex | 
 			StInspectorDynamicNode 
 				hostObject: self 

--- a/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
+++ b/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #SymbolicBytecode }
 { #category : #'*NewTools-Inspector-Extensions' }
 SymbolicBytecode >> inspectionSourceCode [
 	<inspectorPresentationOrder: 30 title: 'Source'>
-1haltOnce.
+
 	^ SpCodePresenter new 
 		beForBehavior: self method methodClass;
 		text: self method sourceCode;

--- a/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
+++ b/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #SymbolicBytecode }
 { #category : #'*NewTools-Inspector-Extensions' }
 SymbolicBytecode >> inspectionSourceCode [
 	<inspectorPresentationOrder: 30 title: 'Source'>
-
+1haltOnce.
 	^ SpCodePresenter new 
 		beForBehavior: self method methodClass;
 		text: self method sourceCode;

--- a/src/NewTools-Inspector-Tests/StInspectorMockObjectSubclass.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectorMockObjectSubclass.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #StInspectorMockObjectSubclass,
+	#superclass : #StInspectorMockObject,
+	#category : #'NewTools-Inspector-Tests'
+}
+
+{ #category : #'as yet unclassified' }
+StInspectorMockObjectSubclass >> inspectionMock1Context: aContext [
+
+	aContext active: false
+]

--- a/src/NewTools-Inspector-Tests/StInspectorTest.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectorTest.class.st
@@ -24,12 +24,43 @@ StInspectorTest >> tearDown [
 ]
 
 { #category : #tests }
+StInspectorTest >> testContextSelectorForBuilderSelector [
+
+	| c |
+	c := StInspectionContext new methodSelector: #selectorWithArgument:.
+	
+	self 
+		assert: c contextMethodSelector
+		equals: #selectorWithArgumentContext:
+]
+
+{ #category : #tests }
+StInspectorTest >> testContextSelectorForNonBuilderSelector [
+
+	| c |
+	c := StInspectionContext new methodSelector: #selectorWithoutArgument.
+	
+	self 
+		assert: c contextMethodSelector
+		equals: #selectorWithoutArgumentContext:
+]
+
+{ #category : #tests }
 StInspectorTest >> testDefaultKeyboardFocus [
 
 	inspector openWithSpec.
 	self 
 		assert: inspector defaultKeyboardFocus 
 		equals: inspector millerList presenters first
+]
+
+{ #category : #tests }
+StInspectorTest >> testDefineContextInSubclass [
+
+	| c |
+	c := StInspectionCollector on: StInspectorMockObjectSubclass new.
+
+	self deny: (c contextFromPragma: (StInspectorMockObject >> #inspectionMock1) pragmas first) isActive
 ]
 
 { #category : #tests }

--- a/src/NewTools-Inspector/StInspectionCollector.class.st
+++ b/src/NewTools-Inspector/StInspectionCollector.class.st
@@ -66,8 +66,8 @@ StInspectionCollector >> contextFromPragma: aPragma [
 	
 	context := StInspectionContext fromPragma: aPragma.
 	context inspectedObject: self inspectedObject.
-	
-	(aPragma methodClass includesSelector: context contextMethodSelector) ifTrue: [ 
+
+	(self inspectedObject respondsTo: context contextMethodSelector) ifTrue: [ 
 		self inspectedObject 
 			perform: context contextMethodSelector
 			with: context ].

--- a/src/NewTools-Inspector/StInspectionContext.class.st
+++ b/src/NewTools-Inspector/StInspectionContext.class.st
@@ -52,7 +52,7 @@ StInspectionContext >> contextMethodSelector [
 	selector := self methodSelectorNeedsBuilder
 		ifTrue: [ self methodSelector allButLast ]
 		ifFalse: [ self methodSelector ].
-	^ (self methodSelector, 'Context:') asSymbol
+	^ (selector, 'Context:') asSymbol
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- Hide the "Items" view that showed only a collection with itself
- raw presentation should really be raw, showing all literals including header and binding

Improve the inspector also to
 - do context selection using the correct selector (seems like it was a typo)
 - make context selector to be searched from the receiver object and not from the class