### PR TITLE
Define default empty inspector icon for all objects

### DIFF
--- a/src/NewTools-Inspector-Extensions/ProtoObject.extension.st
+++ b/src/NewTools-Inspector-Extensions/ProtoObject.extension.st
@@ -27,6 +27,12 @@ ProtoObject >> inspectionRaw [
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }
+ProtoObject >> inspectorIcon [
+
+	^ nil
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectorNodes [ 
 	"Answer a list of attributes as nodes"
 


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/9951

Before:

![image](https://user-images.githubusercontent.com/708322/133751234-bb548e2c-887e-45a9-b634-bf70457d428f.png)

After:

![image](https://user-images.githubusercontent.com/708322/133751186-26b66580-f408-4b78-90da-aafd8108b3a5.png)
