### PR TITLE
fix #290: Update StObjectPrinterTest>>testPrintDoesNotUnderstand to remove string literal

### DIFF
--- a/src/NewTools-Inspector-Tests/StObjectPrinterTest.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectPrinterTest.class.st
@@ -14,10 +14,13 @@ StObjectPrinterTest >> assertIsError: aCollection expectedMessage: aMessage [
 { #category : #tests }
 StObjectPrinterTest >> testPrintDoesNotUnderstand [
 
-	| printedValue |
-	printedValue := StObjectPrinter asTruncatedTextFrom: StObjectWithPrintDoesNotUnderstand new.
+	| printedValue selector error |
+	selector := #iShouldNotUnderstandThis.
 	
-	self assertIsError: printedValue expectedMessage: 'StObjectWithPrintDoesNotUnderstand>> #iShouldNotUnderstandThis'
+	error := MessageNotUnderstood new message: ((Message selector: selector) lookupClass: StObjectWithPrintDoesNotUnderstand).
+	printedValue := StObjectPrinter asTruncatedTextFrom: (StObjectWithPrintDoesNotUnderstand withMissingMessageSelector: selector).
+	
+	self assertIsError: printedValue expectedMessage: error messageText
 ]
 
 { #category : #tests }

--- a/src/NewTools-Inspector-Tests/StObjectWithPrintDoesNotUnderstand.class.st
+++ b/src/NewTools-Inspector-Tests/StObjectWithPrintDoesNotUnderstand.class.st
@@ -1,11 +1,24 @@
 Class {
 	#name : #StObjectWithPrintDoesNotUnderstand,
 	#superclass : #Object,
+	#instVars : [
+		'selector'
+	],
 	#category : #'NewTools-Inspector-Tests'
 }
+
+{ #category : #'instance creation' }
+StObjectWithPrintDoesNotUnderstand class >> withMissingMessageSelector: aString [ 
+	^ self new missingMessageSelector: aString
+]
+
+{ #category : #accessing }
+StObjectWithPrintDoesNotUnderstand >> missingMessageSelector: aString [ 
+	selector := aString
+]
 
 { #category : #printing }
 StObjectWithPrintDoesNotUnderstand >> printOn: aString [
 
-	^ self iShouldNotUnderstandThis
+	^ self perform: selector
 ]


### PR DESCRIPTION
Removes the string and replaces it with the `messageText` of the expected MessageNotUnderstood error.