### PR TITLE
Moves class side `#reset` methods into the `initialization` protocol.

### DIFF
--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltCache.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltCache.class.st
@@ -64,7 +64,7 @@ StHaltCache class >> refresh [
 	self defaultCache refreshCache
 ]
 
-{ #category : #'accessing - cache' }
+{ #category : #'class initialization' }
 StHaltCache class >> reset [
 	<script>
 	DefaultCache

--- a/src/NewTools-Spotter-Processors/StSourceFactory.class.st
+++ b/src/NewTools-Spotter-Processors/StSourceFactory.class.st
@@ -46,7 +46,7 @@ StSourceFactory class >> priority [
 	^ self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : #'class initialization' }
 StSourceFactory class >> reset [
 
 	Current := nil

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -174,7 +174,7 @@ StSpotter class >> registerToolsOn: registry [
 	registry register: self as: #spotter
 ]
 
-{ #category : #private }
+{ #category : #'class initialization' }
 StSpotter class >> reset [
 	
 	spotter ifNotNil: [ 


### PR DESCRIPTION
Hi! 👋 - this PR moves all class side `#reset` methods in this repo over to the `initialization` protocol. This is to move https://github.com/pharo-project/pharo/issues/2607 forward.

Hope that makes sense!