### PR TITLE
sindarin-should-use-pharo10-branch

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -158,6 +158,6 @@ BaselineOfNewTools >> sindarin: spec [
 	spec baseline: 'Sindarin' with: [ 
 		spec
 			repository: (self packageRepositoryURL 
-				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger' ]);
+				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo-10' ]);
 			loads: 'Core' ]
 ]


### PR DESCRIPTION
NewTools should not point directly to Master. It is loaded from Pharo, so it should be a controlled branch