### PR TITLE
Fix debugger improvement method creation

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -468,6 +468,22 @@ StDebuggerTest >> testReceiverUnchangedAfterStepOver [
 
 ]
 
+{ #category : #'tests - actions' }
+StDebuggerTest >> testReclassifyMethod [
+	|method|
+	debugger := self debuggerOn: session.
+	debugger protocolRequestor: StMockProtocolRequestor.
+	debugger application: debugger class currentApplication.
+	debugger initialize.
+	
+	StTestDebuggerProvider compile: 'foobar ^self'.
+	method := (StTestDebuggerProvider>>#foobar).	
+	self assert: method protocol equals: Protocol unclassified.
+	
+	debugger reclassifyMethod: method.
+	self assert: method protocol equals: StMockProtocolRequestor stDebuggerTestProtocol
+]
+
 { #category : #'tests - code pane' }
 StDebuggerTest >> testRecordUnsavedCodeChanges [
 	| dbg lastContext |
@@ -495,10 +511,12 @@ StDebuggerTest >> testRequestClassFrom [
 
 { #category : #'tests - actions' }
 StDebuggerTest >> testRequestProtocolIn [
+	debugger := self debugger.
+	debugger protocolRequestor: StMockProtocolRequestor.
 
 	self
-		assert: (self debugger requestProtocolIn: self class)
-		equals: Protocol unclassified
+		assert: (debugger requestProtocolFor: (StTestDebuggerProvider >> #session))
+		equals: StMockProtocolRequestor stDebuggerTestProtocol 
 ]
 
 { #category : #'tests - session' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -67,8 +67,9 @@ StDebuggerTest >> tearDown [
 	self debuggerClass fastTDD: oldFastTDD.
 	debugger ifNotNil: [ 
 		debugger unsubscribeFromSystemAnnouncer.
+		debugger session ifNotNil: [ :s | s clear ].
 		debugger close.
-		debugger session ifNotNil: [ :s | s clear ] ].
+		].
 	StTestDebuggerProvider removeSelector: #foobar. 
 	StDebuggerObjectForTests compile: 'haltingMethod <haltOrBreakpointForTesting> self halt. ^self' classified: 'util'.
 	super tearDown
@@ -283,6 +284,35 @@ StDebuggerTest >> testCopyStackToClipboard [
 		assert: Clipboard clipboardText string
 		equals: (String streamContents: [ :s | 
 				 session interruptedContext shortDebugStackOn: s ])
+]
+
+{ #category : #'tests - actions' }
+StDebuggerTest >> testCreateMissingMethod [ 
+	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
+	debugger application: self debuggerClass currentApplication.
+	debugger initialize.
+	
+	self assert: (StTestDebuggerProvider lookupSelector: #foobar) isNil.
+	
+	debugger createMissingMethod.
+	self assert: debugger selectedContext method equals: (StTestDebuggerProvider>>#foobar).
+	
+	self flag: 'The next test somehow does no pass, see https://github.com/pharo-spec/NewTools/issues/306'
+	"self assert: debugger code hasKeyboardFocus"
+]
+
+{ #category : #'tests - actions' }
+StDebuggerTest >> testCreateMissingMethodForMessageInClass [
+	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
+	debugger application: self debuggerClass currentApplication.
+	debugger initialize.
+	
+	self assert: (StTestDebuggerProvider lookupSelector: #foobar) isNil.
+	
+	debugger createMissingMethodFor: debugger session exception message in: StTestDebuggerProvider.
+	self assert: debugger selectedContext method equals: (StTestDebuggerProvider>>#foobar).
+	self assert: debugger stackTable selection selectedIndex equals: 1
+	
 ]
 
 { #category : #'tests - initialization' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -175,7 +175,7 @@ StDebuggerTest >> testCodeSelectionAfterRestart [
 	
 	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
 	segments := dbg code adapter widget segments.
-	self assert: segments size equals: 1.
+	self assert: segments size equals: 2.
 	highlightSegment := segments first.	
 	
 	self
@@ -199,7 +199,7 @@ StDebuggerTest >> testCodeSelectionAfterStepping [
 	
 	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
 	segments := dbg code adapter widget segments.
-	self assert: segments size equals: 1.
+	self assert: segments size equals: 2.
 	highlightSegment := segments first.	
 	
 	self
@@ -376,13 +376,47 @@ StDebuggerTest >> testInitialCodeSelectionAfterStepping [
 	
 	pcRangeForContext := (session pcRangeForContext: dbg currentContext).
 	segments := dbg code adapter widget segments.
-	self assert: segments size equals: 1.
+	self assert: segments size equals: 2.
 	highlightSegment := segments first.	
 	
 	self
 		assert:  (highlightSegment firstIndex to: highlightSegment lastIndex)
 		equals: (pcRangeForContext first to: pcRangeForContext last + 1)
 	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
+]
+
+{ #category : #'tests - code pane' }
+StDebuggerTest >> testMethodProtocolIcon [
+
+	| adapter method segments protocolSegment |
+	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
+	debugger application: self debuggerClass currentApplication.
+	debugger initialize.	
+	
+	adapter := SpMorphicCodeAdapter new.
+	adapter adapt: debugger code.	
+	debugger code adapter: adapter.
+	debugger code adapter buildWidget.
+	
+	debugger createMissingMethod.
+	debugger protocolRequestor: StMockProtocolRequestor.
+	
+	
+	method := StTestDebuggerProvider>>#foobar.
+	
+	self assert: method protocol equals: 'accessing'.
+
+	segments := debugger code adapter widget segments.
+	self assert: segments size equals: 2.
+	protocolSegment := segments second.	
+	
+	self
+		assert:  (protocolSegment firstIndex to: protocolSegment lastIndex)
+		equals: (0 to: 1).
+	
+	self assert: protocolSegment label equals: ('Protocol: ', debugger session interruptedContext method method protocol).
+	protocolSegment iconBlock value: debugger.
+	self assert: method protocol equals: StMockProtocolRequestor stDebuggerTestProtocol
 ]
 
 { #category : #'tests - context inspector' }

--- a/src/NewTools-Debugger-Tests/StMockProtocolRequestor.class.st
+++ b/src/NewTools-Debugger-Tests/StMockProtocolRequestor.class.st
@@ -1,0 +1,18 @@
+"
+I override GUI requests of protocol for testing by returning a default value.
+"
+Class {
+	#name : #StMockProtocolRequestor,
+	#superclass : #StDebuggerProtocolRequestor,
+	#category : #'NewTools-Debugger-Tests-Utils'
+}
+
+{ #category : #'ui requests' }
+StMockProtocolRequestor class >> requestProtocolFor: aMethod [
+	^self stDebuggerTestProtocol
+]
+
+{ #category : #'ui requests' }
+StMockProtocolRequestor class >> stDebuggerTestProtocol [
+	^'StDebugger test protocol'
+]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -491,7 +491,7 @@ StDebugger >> createMissingMethod [
 
 { #category : #actions }
 StDebugger >> createMissingMethodFor: aMessage in: aClass [
-	self flag: #DBG_MISSINGTEST.
+
 	self debuggerActionModel
 		implement: aMessage
 		classified: Protocol unclassified

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1184,25 +1184,25 @@ StDebugger >> updateCodeFromContext: aContext [
 
 { #category : #'updating - widgets' }
 StDebugger >> updateCodeTextSegmentDecoratorsIn: aContext forInterval: selectionInterval [
-	
+
+	| methodProtocol |
 	self code removeAllTextSegmentDecorations.
-	
-	"This decorates the receiver and the next node with an underline"
-	"self code
-		addTextSegmentDecoration:
-			(SpTextPresenterDecorator new
-				underlineColor: Color orange;
-				interval: (aContext currentNode start to: aContext currentNode stop + 1);
-				yourself)."
-				
+
 	"This decorates the next executing node"
-	self code addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
-		interval: (selectionInterval first to: selectionInterval last + 1);
-		yourself)
-				
-	"	icon: (self iconNamed: #warning);
-		iconBlock: [ :n | n inspect ];
-		title: 'Click me!';"
+	self code addTextSegmentDecoration: (SpTextPresenterDecorator new
+			 highlightColor: (Color orange alpha: 0.5);
+			 underlineColor: (Color white alpha: 0);
+			 interval: (selectionInterval first to: selectionInterval last + 1);
+			 yourself).
+
+	methodProtocol := aContext method method protocol.
+	methodProtocol ifNil: [ ^ self ].
+	self code addTextSegmentDecoration: (SpTextPresenterDecorator new
+			 interval: (0 to: 1);
+			 icon: (self iconNamed: #edit);
+			 iconBlock: [ :n | self reclassifyMethod: aContext method method ];
+			 title: 'Protocol: ' , methodProtocol;
+			 yourself)
 ]
 
 { #category : #'updating - actions' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -87,7 +87,8 @@ Class {
 		'toolbarCommandGroup',
 		'debuggerActionModel',
 		'unsavedCodeChanges',
-		'programmaticallyClosed'
+		'programmaticallyClosed',
+		'protocolRequestor'
 	],
 	#classVars : [
 		'ActivateDebuggerExtensions',
@@ -873,6 +874,32 @@ StDebugger >> proceedDebugSession [
 	self close
 ]
 
+{ #category : #accessing }
+StDebugger >> protocolRequestor [
+
+	^ protocolRequestor ifNil:[protocolRequestor := StDebuggerProtocolRequestor ]
+]
+
+{ #category : #accessing }
+StDebugger >> protocolRequestor: anObject [
+
+	protocolRequestor := anObject
+]
+
+{ #category : #actions }
+StDebugger >> reclassifyMethod: aCompiledMethod [
+
+	| newProtocol |
+	newProtocol := [ self requestProtocolFor: aCompiledMethod ]
+		               on: Abort
+		               do: [ ^ self ].
+	aCompiledMethod methodClass
+		addAndClassifySelector: aCompiledMethod selector
+		withMethod: aCompiledMethod
+		inProtocol: newProtocol.
+	self updateCodeFromContext
+]
+
 { #category : #actions }
 StDebugger >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
 
@@ -939,26 +966,9 @@ StDebugger >> requestClassFrom: aClass [
 ]
 
 { #category : #'ui requests' }
-StDebugger >> requestProtocolIn: aClass [
+StDebugger >> requestProtocolFor: aMethod [
 
-	| entryCompletion applicants choice |
-	self class fastTDD ifTrue: [ ^ Protocol unclassified ].
-	applicants := AbstractTool protocolSuggestionsFor: aClass.
-	entryCompletion := EntryCompletion new
-		                   dataSourceBlock: [ :currText | applicants ];
-		                   filterBlock: [ :currApplicant :currText | 
-			                   currText size > 3 and: [ 
-					                   currApplicant asLowercase includesSubstring:
-							                   currText asString asLowercase ] ].
-
-	choice := (UIManager default
-		           request:
-		           'Start typing for suggestions (3 characters minimum)'
-		           initialAnswer: Protocol unclassified
-		           title: 'Choose a protocol'
-		           entryCompletion: entryCompletion) ifNil: [ Abort signal ].
-
-	^ choice ifEmpty: [ Protocol unclassified ]
+		^ self protocolRequestor requestProtocolFor: aMethod
 ]
 
 { #category : #'ui requests' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -482,7 +482,7 @@ StDebugger >> createMissingMethod [
 	msg := self session exception message.
 	[ 
 	chosenClass := self requestClassFrom:
-		               self interruptedContext receiver class.
+		                self session exception receiver class.
 	self createMissingMethodFor: msg in: chosenClass ]
 		on: Abort
 		do: [ ^ self ].

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -478,16 +478,15 @@ StDebugger >> createMissingClass [
 StDebugger >> createMissingMethod [
 
 	| msg chosenClass |
-	self flag: #DBG_MISSINGTEST.
-	msg := self interruptedContext tempAt: 1.
+	msg := self session exception message.
 	[ 
 	chosenClass := self requestClassFrom:
 		               self interruptedContext receiver class.
 	self createMissingMethodFor: msg in: chosenClass ]
 		on: Abort
 		do: [ ^ self ].
-		
-	code takeKeyboardFocus 
+
+	code takeKeyboardFocus
 ]
 
 { #category : #actions }
@@ -495,7 +494,7 @@ StDebugger >> createMissingMethodFor: aMessage in: aClass [
 	self flag: #DBG_MISSINGTEST.
 	self debuggerActionModel
 		implement: aMessage
-		classified: (self requestProtocolIn: aClass)
+		classified: Protocol unclassified
 		inClass: aClass
 		forContext: self interruptedContext.
 	self selectTopContext

--- a/src/NewTools-Debugger/StDebuggerProtocolRequestor.class.st
+++ b/src/NewTools-Debugger/StDebuggerProtocolRequestor.class.st
@@ -1,0 +1,30 @@
+"
+I provide utility methods to request protocols from users. 
+"
+Class {
+	#name : #StDebuggerProtocolRequestor,
+	#superclass : #Object,
+	#category : #'NewTools-Debugger-View'
+}
+
+{ #category : #'ui requests' }
+StDebuggerProtocolRequestor class >> requestProtocolFor: aMethod [
+
+	| entryCompletion applicants choice |
+	applicants := AbstractTool protocolSuggestionsFor: aMethod methodClass.
+	entryCompletion := EntryCompletion new
+		                   dataSourceBlock: [ :currText | applicants ];
+		                   filterBlock: [ :currApplicant :currText | 
+			                   currText size > 3 and: [ 
+					                   currApplicant asLowercase includesSubstring:
+							                   currText asString asLowercase ] ].
+
+	choice := (UIManager default
+		           request:
+		           'Start typing for suggestions (3 characters minimum)'
+		           initialAnswer: (aMethod protocol)
+		           title: 'Choose a protocol'
+		           entryCompletion: entryCompletion) ifNil: [ Abort signal ].
+
+	^ choice ifEmpty: [ Protocol unclassified ]
+]


### PR DESCRIPTION
- protocol is not asked anymore when creating a method in TDD
- protocol can be modified at anytime using the icon near the method name in the code pane
- some refactoring
- testing and more testing

https://user-images.githubusercontent.com/26929529/138465914-b75fab96-0c82-49c2-b944-0dcc43f0fd62.mov

