### PR TITLE
Fix pharo project issue 10519

### DIFF
--- a/src/NewTools-Playground-Tests/StPlaygroundPageTest.class.st
+++ b/src/NewTools-Playground-Tests/StPlaygroundPageTest.class.st
@@ -15,17 +15,17 @@ StPlaygroundPageTest >> newPage [
 
 { #category : #tests }
 StPlaygroundPageTest >> testContents [
-	| page |
-	
+
+	| page waitMock |
 	page := self newPage.
+	waitMock := StPlaygroundPageTestMockedWaitable new.
+	page timeToWait: waitMock.
 	page contents: 'test'.
-	5 milliSeconds wait.
 	self assert: page contents isEmpty.
 	page contents: 'test 2'.
 	self assert: page contents isEmpty.
-	20 milliSeconds wait.
-	self assert: page contents equals: 'test 2'.
-
+	waitMock resume.
+	self assert: page contents equals: 'test 2'
 ]
 
 { #category : #tests }

--- a/src/NewTools-Playground-Tests/StPlaygroundPageTestMockedWaitable.class.st
+++ b/src/NewTools-Playground-Tests/StPlaygroundPageTestMockedWaitable.class.st
@@ -1,0 +1,46 @@
+"
+A Mock class to deterministically perform tests instead on relying on the system clock and process scheduler's grace.
+When wait is called on this object from a secondary thread (<=IMPORTANT), it will be blocked until the resume method is called or its timeout(default 500 ms) is reached.
+
+This is essentially a Semaphore, with a built-in timeout and specific for these kind of tests.
+"
+Class {
+	#name : #StPlaygroundPageTestMockedWaitable,
+	#superclass : #Object,
+	#instVars : [
+		'sem',
+		'sem2',
+		'timeout'
+	],
+	#category : #'NewTools-Playground-Tests'
+}
+
+{ #category : #initialization }
+StPlaygroundPageTestMockedWaitable >> initialize [
+
+	sem := Semaphore new.
+	sem2 := Semaphore new.
+	timeout := 500
+]
+
+{ #category : #accessing }
+StPlaygroundPageTestMockedWaitable >> resume [
+
+	sem signal.
+	^ sem2 wait: (Duration milliSeconds: timeout)
+]
+
+{ #category : #accessing }
+StPlaygroundPageTestMockedWaitable >> timeout: aNumberMiliseconds [
+
+	timeout := aNumberMiliseconds
+]
+
+{ #category : #accessing }
+StPlaygroundPageTestMockedWaitable >> wait [
+
+	| semRes |
+	semRes := sem wait: (Duration milliSeconds: timeout).
+	sem2 signal.
+	^ semRes
+]


### PR DESCRIPTION
Fix for https://github.com/pharo-project/pharo/issues/10519
Uses a more deterministic "wait" mechanism for the test, instead of relying on common delays.
Should prevent erratic test behavior.
Note that I don't understand (or intended to understand) the behavior of StPlaygroundPage. I just changed the test so it can be performed deterministically.