### PR TITLE
Automatically scroll stack to selected index

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1250,10 +1250,12 @@ StDebugger >> updateSourceCodeFor: aContext [
 
 { #category : #stack }
 StDebugger >> updateStackFromSession: aSession [
-	|stack|
-	stack := (self filterStack: aSession stack).
+	| stack |
+	stack := self filterStack: aSession stack.
 	stackTable items: stack.
-	stackTable selectIndex: (self findFirstRelevantStackIndexIn: stack)
+	stackTable
+		selectIndex: (self findFirstRelevantStackIndexIn: stack)
+		scrollToSelection: true
 ]
 
 { #category : #'updating - actions' }


### PR DESCRIPTION
Hello there

Pretty small improvement: I noticed when the first relevant stack context is too far away from top of the stack, the user has to scroll to find selected stack
Now scrolling is done automatically