### PR TITLE
Fixes pharo-spec/pharo#10255 Slow inspector on large Strings

### DIFF
--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -14,6 +14,6 @@ String >> inspectionString [
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	
 	^ SpTextPresenter new
-		text: (self truncateWithElipsisTo: 10000);
+		text: (self truncateWithElipsisTo: 1000);
 		yourself
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -1,10 +1,19 @@
 Extension { #name : #String }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-String >> inspectionString [
-	<inspectorPresentationOrder: -10 title: 'String'>
+String >> inspectionFullString [
+	<inspectorPresentationOrder: 100 title: 'Full Content'>
 	
 	^ SpTextPresenter new
-		text: (self truncateWithElipsisTo: 100000);
+		text: self;
+		yourself
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+String >> inspectionString [
+	<inspectorPresentationOrder: -10 title: 'Preview'>
+	
+	^ SpTextPresenter new
+		text: (self truncateWithElipsisTo: 10000);
 		yourself
 ]

--- a/src/NewTools-Inspector/StObjectPrinter.class.st
+++ b/src/NewTools-Inspector/StObjectPrinter.class.st
@@ -5,6 +5,9 @@ This is a utility class for printing objects to Text or String.
 Class {
 	#name : #StObjectPrinter,
 	#superclass : #Object,
+	#classVars : [
+		'DisplayStringLength'
+	],
 	#category : #'NewTools-Inspector-Model'
 }
 
@@ -23,9 +26,32 @@ StObjectPrinter class >> asTruncatedTextFrom: anObject [
 	"I return a truncated representation of the receiver in which all lines breaks 
 	are replaced by spaces. I return a String unless there is an error printing the
 	object. In this case I return a Text highlighted in red."
-	^ [ (anObject displayString copyReplaceAll: String cr with: String space) replaceAll: String lf with: String space ]
+	^ [ ((anObject displayStringLimitedTo: self displayStringLength) copyReplaceAll: String cr with: String space) replaceAll: String lf with: String space ]
 		on: Exception
 		do: [ :error | self textFromError: error ]
+]
+
+{ #category : #settings }
+StObjectPrinter class >> displayStringLength [
+	^ DisplayStringLength ifNil: [ DisplayStringLength := 100 ]
+]
+
+{ #category : #settings }
+StObjectPrinter class >> displayStringLength: anInteger [ 
+	
+	DisplayStringLength := anInteger
+]
+
+{ #category : #settings }
+StObjectPrinter class >> settingsOn: aBuilder [
+	<systemsettings>
+		
+	(aBuilder setting: #displayStringLength)
+		parent: #inspector;
+		default: 100;
+		target: self;
+		description: 'The length of the display string shown in the inspector';
+		label: 'Display String length in Collection'
 ]
 
 { #category : #converting }


### PR DESCRIPTION
Limiting string display length in inspector when inspecting a String and a Collection of Strings.
Improves efficiency