### PR TITLE
[Spotter] Increasing to 2000 maximum number of items in view for a single category

### DIFF
--- a/src/NewTools-Spotter-Extensions/Collection.extension.st
+++ b/src/NewTools-Spotter-Extensions/Collection.extension.st
@@ -9,7 +9,7 @@ Collection >> spotterItemsFor: aStep [
 	processor := aStep previousProcessorFrom: self.
 	^ aStep listProcessor
 		title: processor title;
-		candidatesLimit: 2000;
+		candidatesLimit: StSpotterPragmaBasedProcessor defaultNestedItemsLimit;
 		items: [ self collect: [ :each | each asStSpotterCandidateLink value ] as: OrderedCollection ];
 		itemName: processor itemName;
 		itemIcon: processor itemIcon;

--- a/src/NewTools-Spotter-Extensions/Collection.extension.st
+++ b/src/NewTools-Spotter-Extensions/Collection.extension.st
@@ -9,7 +9,7 @@ Collection >> spotterItemsFor: aStep [
 	processor := aStep previousProcessorFrom: self.
 	^ aStep listProcessor
 		title: processor title;
-		candidatesLimit: 100;
+		candidatesLimit: 2000;
 		items: [ self collect: [ :each | each asStSpotterCandidateLink value ] as: OrderedCollection ];
 		itemName: processor itemName;
 		itemIcon: processor itemIcon;

--- a/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
@@ -7,7 +7,8 @@ Class {
 		'running'
 	],
 	#classVars : [
-		'DefaultItemsLimit'
+		'DefaultItemsLimit',
+		'DefaultNestedItemsLimit'
 	],
 	#category : #'NewTools-Spotter-Processors'
 }
@@ -25,6 +26,18 @@ StSpotterPragmaBasedProcessor class >> defaultItemsLimit: aValue [
 ]
 
 { #category : #'accessing - defaults' }
+StSpotterPragmaBasedProcessor class >> defaultNestedItemsLimit [
+
+	^ DefaultNestedItemsLimit ifNil: [ DefaultNestedItemsLimit := 2000 ]
+]
+
+{ #category : #'accessing - defaults' }
+StSpotterPragmaBasedProcessor class >> defaultNestedItemsLimit: aValue [
+
+	DefaultNestedItemsLimit := aValue
+]
+
+{ #category : #'accessing - defaults' }
 StSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
 	<systemsettings>
 
@@ -34,7 +47,15 @@ StSpotterPragmaBasedProcessor class >> settingsOn: aBuilder [
 		label: 'Number of results per category';
 		default: 25;
 		order: 100;
-		description: 'Number of results per category to show in Spotter'
+		description: 'Number of results per category to show in Spotter'.
+	
+	(aBuilder setting: #defaultNestedItemsLimit)
+		target: self;
+		parent: #spotter;
+		label: 'Number of nested results per category';
+		default: 2000;
+		order: 101;
+		description: 'Number of total results per of category to show in Spotter'
 ]
 
 { #category : #public }

--- a/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
@@ -133,8 +133,11 @@ StSpotterProcessor >> actLogic [
 { #category : #'spotter-api' }
 StSpotterProcessor >> allFilteredCandidates [
 
-	self configureFilter.		
-	^ self filter upToEnd
+	| result |
+	self configureFilter  .
+	result := OrderedCollection new: 2000.
+	[ self filter atEnd or: [ result size > 2000 ]] whileFalse: [ result add: self filter next ].
+	^ result
 ]
 
 { #category : #filtering }

--- a/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
@@ -135,8 +135,8 @@ StSpotterProcessor >> allFilteredCandidates [
 
 	| result |
 	self configureFilter  .
-	result := OrderedCollection new: 2000.
-	[ self filter atEnd or: [ result size > 2000 ]] whileFalse: [ result add: self filter next ].
+	result := OrderedCollection new.
+	[ self filter atEnd or: [ result size > StSpotterPragmaBasedProcessor defaultNestedItemsLimit ]] whileFalse: [ result add: self filter next ].
 	^ result
 ]
 


### PR DESCRIPTION
Increasing from 100 to 2000 the maximum amount of items in the nested view (where a single category is shown).
This amount is included as a parameter in Pharo settings.
I tested the query "test", which has more than 2000 matches, and it took less than half a second to load 2000 results.

Also, fixing efficiency problem produced when stepping into nested view, old implementation iterated over every result and then extracted 100 items. This solution fetches only 2000.

This solution is not dynamic, but it is a partial Fix #10267 