### PR TITLE
Use "accessing - context" instead of "accessing context" to fit and a…

### DIFF
--- a/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
+++ b/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
@@ -36,7 +36,7 @@ tag := thisContext method selector.
 ^true
 ]
 
-{ #category : #'accessing context' }
+{ #category : #'accessing - context' }
 StDummyDebuggerPresenter >> currentContext [
 	^self
 ]


### PR DESCRIPTION
…lign with all the other "accessing - ..." protocols