### PR TITLE
Fix-Debugger-Browse-method-menu

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerStackCommandTreeBuilderTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerStackCommandTreeBuilderTest.class.st
@@ -251,7 +251,7 @@ StDebuggerStackCommandTreeBuilderTest >> testStackMethodNavigationCommands [
 	self
 		assertCommandGroup: builder stackMethodNavigationCommands
 		hasSameCommands: builder stackMethodCommandsClasses
-		withContext: debugger stackTable selection selectedItem method
+		withContext: debugger stackTable selection selectedItem home method
 		displayStrategy: CmUIDisplayAsGroup
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1068,7 +1068,7 @@ StDebugger >> stackIconForContext: context [
 { #category : #'commands - support' }
 StDebugger >> stackSelectionMethodContext [
 
-	^ [ stackTable selection selectedItem method ]
+	^ [ stackTable selection selectedItem home method ]
 ]
 
 { #category : #'commands - support' }


### PR DESCRIPTION
This fixes the "browse method" menu in the debugger, see https://github.com/pharo-project/pharo/issues/10858

