### PR TITLE
Spotter filtering does not split the search string accordingly to camel syntax 

### DIFF
--- a/src/NewTools-Spotter-Processors-Tests/StImplementorsProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StImplementorsProcessorTest.class.st
@@ -27,6 +27,13 @@ StImplementorsProcessorTest >> testFindThisMethodAfterAddingText [
 ]
 
 { #category : #tests }
+StImplementorsProcessorTest >> testFindThisMethodRespectingSearchStringTokensOrder [
+
+	self runForText: 'testFindMethodThis'.
+	self denyResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
 StImplementorsProcessorTest >> testPopularStringDoesReturnOnlyTenResults [
 
 	self runForText: 'test'.

--- a/src/NewTools-Spotter-Processors-Tests/StIteratorsTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StIteratorsTest.class.st
@@ -210,55 +210,6 @@ StIteratorsTest >> testSubstringFilterReturnsValidResultsWithTheSameFilter [
 ]
 
 { #category : #tests }
-StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCase [
-
-	| inner it |
-	
-	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
-	it := StWordsAwareFilter new
-		inner: inner;
-		yourself.
-		
-	it filteringText: 'xxxBbb'.
-	
-	self assert: it next equals: 'xxxyyybbb'.
-	self assert: it next equals: 'xxxcccbbb'	
-]
-
-{ #category : #tests }
-StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCaseMixingCase [
-
-	| inner it |
-	
-	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyyBBB'. 'XXXcccbbb'. 'xxxcccbbb' }) asSubstringFilter.
-	it := StWordsAwareFilter new
-		inner: inner;
-		yourself.
-		
-	it filteringText: 'xxxBbb'.
-	
-	self assert: it next equals: 'xxxyyyBBB'.
-	self assert: it next equals: 'XXXcccbbb'.
-	self assert: it next equals: 'xxxcccbbb'	
-]
-
-{ #category : #tests }
-StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfCamelCaseWithUppercase [
-
-	| inner it |
-	
-	inner := (StCollectionIterator on: { 'aaa'. 'xxxyyybbb'. 'xxxcccbbb' }) asSubstringFilter.
-	it := StWordsAwareFilter new
-		inner: inner;
-		yourself.
-		
-	it filteringText: 'XxxBbb'.
-	
-	self assert: it next equals: 'xxxyyybbb'.
-	self assert: it next equals: 'xxxcccbbb'	
-]
-
-{ #category : #tests }
 StIteratorsTest >> testWordsAwareIteratorFiltersByASequenceOfWords [
 
 	| inner it |

--- a/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
@@ -58,6 +58,13 @@ StUnifiedProcessorTest >> testFindThisMethodAfterAddingText [
 ]
 
 { #category : #tests }
+StUnifiedProcessorTest >> testFindThisMethodRespectingSearchStringTokensOrder [
+
+	self runForText: 'testFindMethodThis'.
+	self denyResultsIncludes: thisContext method
+]
+
+{ #category : #tests }
 StUnifiedProcessorTest >> testFindThisMethodWithFullClass [
 
 	self runForText: 'StUnifiedProcessorTest >> #testFindThisMethod'.

--- a/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
+++ b/src/NewTools-Spotter-Processors-Tests/StUnifiedProcessorTest.class.st
@@ -139,17 +139,17 @@ StUnifiedProcessorTest >> testLookingForDiskStoreWithSpaceReturnsDiskStore [
 ]
 
 { #category : #tests }
+StUnifiedProcessorTest >> testLookingForStoreDiskDoesntReturnDiskStore [
+
+	self runForText: 'StoreDisk'.
+	self denyResultsIncludes: DiskStore
+]
+
+{ #category : #tests }
 StUnifiedProcessorTest >> testLookingForStoreDiskLowercaseReturnsThisMethod [
 
 	self runForText: 'store disk'.
 	self assertResultsIncludes: StUnifiedProcessorTest >> #testLookingForStoreDiskLowercaseReturnsThisMethod
-]
-
-{ #category : #tests }
-StUnifiedProcessorTest >> testLookingForStoreDiskReturnsDiskStore [
-
-	self runForText: 'StoreDisk'.
-	self assertResultsIncludes: DiskStore
 ]
 
 { #category : #tests }

--- a/src/NewTools-Spotter-Processors/StWordsAwareFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StWordsAwareFilter.class.st
@@ -1,9 +1,9 @@
 "
 I implement a complex filter on top of my inner iterator.
-I will take the filtering text and split it on the spaces, $: and camel case syntax to try to detect all the elements that have those words.
+I will take the filtering text and split it on the spaces, and $: to try to detect all the elements that have those words.
 
 My iterator is query with the first word of the filtering text and the filtering the elements that have all the words in any part. 
-For example, doing the query StoreDisk will answer also DiskStore 
+For example, doing the query 'Store Disk' will answer `DiskStore` 
 "
 Class {
 	#name : #StWordsAwareFilter,
@@ -50,5 +50,5 @@ StWordsAwareFilter >> inner: anIterator [
 StWordsAwareFilter >> splitWords: aString [
 
 	^ (aString substrings: ' :-')
-		flatCollect: [ :each | each splitCamelCase  ]
+		"flatCollect: [ :each | each splitCamelCase  ]"
 ]


### PR DESCRIPTION
This change makes the query results more precise by preventing spotter to split the search string accordingly to camel case.

For example:
Before: the query 'StoreDisk' returned 'DiskStore'
Now: the query 'StoreDisk' does not return 'DiskStore'