### PR TITLE
349-Raw-inspector-on-Array-breakpoint-menus-should-be-disabled

### DIFF
--- a/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
@@ -21,3 +21,9 @@ StBreakpointCommand >> appliesTo: aTool [
 		on: Error
 		do: [ false ]
 ]
+
+{ #category : #testing }
+StBreakpointCommand >> canBeExecuted [
+
+	^ context selectedItem class == StInspectorSlotNode
+]


### PR DESCRIPTION
fixes  #349 by  implementing #canBeExecuted