### PR TITLE
Improving the debugger extension mechanism to hold a variable to debuggers

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerExtensionMechanismTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerExtensionMechanismTest.class.st
@@ -60,6 +60,7 @@ StDebuggerExtensionMechanismTest >> testInstantiateExtensionToolsPage [
 	self assert: toolPage class identicalTo: SpNotebookPage.
 	self assert: toolPage presenterProvider value class identicalTo: StDummyDebuggerPresenter.
 	self assert: toolPage title equals: StDummyDebuggerPresenter new debuggerExtensionToolName.
+	self assert: toolPage presenterProvider value debugger identicalTo: dbg.
 	self assertCollection: dbg extensionTools includesAll: { toolPage presenterProvider value}.
 	 
 ]

--- a/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
+++ b/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
@@ -6,6 +6,8 @@ The debugger interface itself is tested in the debugger test class.
 Class {
 	#name : #StDummyDebuggerPresenter,
 	#superclass : #SpPresenter,
+	#traits : 'TStDebuggerExtension',
+	#classTraits : 'TStDebuggerExtension classTrait',
 	#instVars : [
 		'tag'
 	],

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -1,5 +1,12 @@
+"
+All Spec presenters using me will be recognised as debugger extensions when opening a debugger.
+
+"
 Trait {
 	#name : #TStDebuggerExtension,
+	#instVars : [
+		'debugger'
+	],
 	#classInstVars : [
 		'showDebuggerExtension',
 		'debuggerExtensionDisplayOrder'
@@ -35,6 +42,11 @@ TStDebuggerExtension classSide >> showInDebugger: aBoolean [
 	showDebuggerExtension := aBoolean
 ]
 
+{ #category : #accessing }
+TStDebuggerExtension >> debugger [
+	^debugger
+]
+
 { #category : #'debugger extension' }
 TStDebuggerExtension >> debuggerExtensionToolName [
 	^self explicitRequirement 
@@ -43,4 +55,9 @@ TStDebuggerExtension >> debuggerExtensionToolName [
 { #category : #'debugger extension' }
 TStDebuggerExtension >> displayOrder [
 	^self class displayOrder
+]
+
+{ #category : #initialization }
+TStDebuggerExtension >> setModelBeforeInitialization: aDebugger [
+	 debugger := aDebugger
 ]

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -32,11 +32,6 @@ TStDebuggerExtension classSide >> displayOrder: anInteger [
 	debuggerExtensionDisplayOrder := anInteger
 ]
 
-{ #category : #'as yet unclassified' }
-TStDebuggerExtension classSide >> showInContext: aContext [
-	^true
-]
-
 { #category : #'debugger extension' }
 TStDebuggerExtension classSide >> showInDebugger [
 	^showDebuggerExtension ifNil: [showDebuggerExtension := false]

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -32,6 +32,11 @@ TStDebuggerExtension classSide >> displayOrder: anInteger [
 	debuggerExtensionDisplayOrder := anInteger
 ]
 
+{ #category : #'as yet unclassified' }
+TStDebuggerExtension classSide >> showInContext: aContext [
+	^true
+]
+
 { #category : #'debugger extension' }
 TStDebuggerExtension classSide >> showInDebugger [
 	^showDebuggerExtension ifNil: [showDebuggerExtension := false]

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
@@ -8,7 +8,6 @@ Class {
 		'bcContextInspection',
 		'toolbar',
 		'sindarinDebugger',
-		'stDebugger',
 		'bytecodeList',
 		'currentPC'
 	],
@@ -28,11 +27,6 @@ StSindarinBytecodeDebuggerPresenter class >> defaultLayout [
 		add: #bytecode;		
 		add: #bcContextInspection;
 		yourself
-]
-
-{ #category : #accessing }
-StSindarinBytecodeDebuggerPresenter >> debugger [ 
-	^stDebugger
 ]
 
 { #category : #'debugger extension' }
@@ -61,7 +55,7 @@ StSindarinBytecodeDebuggerPresenter >> initializeToolbar [
 { #category : #accessing }
 StSindarinBytecodeDebuggerPresenter >> setModelBeforeInitialization: aStDebugger [
 	"My original model is the debugger presenter that I extend"
-	stDebugger := aStDebugger.
+	debugger := aStDebugger.
 	sindarinDebugger := aStDebugger sindarinDebugger
 ]
 

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
@@ -16,8 +16,7 @@ Class {
 		'code',
 		'resultInspection',
 		'toolbar',
-		'sindarinDebugger',
-		'stDebugger'
+		'sindarinDebugger'
 	],
 	#category : #'NewTools-Sindarin-Tools'
 }
@@ -38,11 +37,6 @@ StSindarinDebuggerScriptingPresenter class >> defaultLayout [
 { #category : #actions }
 StSindarinDebuggerScriptingPresenter >> createCommandFromScript [
 	self flag: 'todo'
-]
-
-{ #category : #accessing }
-StSindarinDebuggerScriptingPresenter >> debugger [ 
-	^stDebugger
 ]
 
 { #category : #'debugger extension' }
@@ -115,7 +109,7 @@ StSindarinDebuggerScriptingPresenter >> saveScript [
 { #category : #accessing }
 StSindarinDebuggerScriptingPresenter >> setModelBeforeInitialization: aStDebugger [
 	"My original model is the debugger presenter that I extend"
-	stDebugger := aStDebugger.
+	debugger := aStDebugger.
 	sindarinDebugger := aStDebugger sindarinDebugger
 ]
 


### PR DESCRIPTION
This PR is an improvment to the Trait definign debugger extensions for presenters extending the debugger (or plugins) to automatically own a reference to the debugger that instantiated those presenters.
This debugger is then the model for the plugin to provide extended debugging features.