### PR TITLE
Fixing odd behaviour in debugger inspector filters

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenter.extension.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenter.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #StDebuggerTreeTablePresenter }
+
+{ #category : #'*NewTools-Debugger-Tests' }
+StDebuggerTreeTablePresenter >> filter: anObject [
+
+	filter := anObject
+]
+
+{ #category : #'*NewTools-Debugger-Tests' }
+StDebuggerTreeTablePresenter >> isFiltered: anObject [
+
+	isFiltered := anObject
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
@@ -66,14 +66,6 @@ StDebuggerTreeTablePresenterTest >> testApplyFilterDoesntFilterWhenFilterIsNil [
 ]
 
 { #category : #tests }
-StDebuggerTreeTablePresenterTest >> testApplyFilterDoesntFilterWhenHasActiveFilterIsFalse [
-
-	presenter filter: 'toto'.
-	presenter applyFilter.
-	self assert: presenter roots equals: inspectorNodes
-]
-
-{ #category : #tests }
 StDebuggerTreeTablePresenterTest >> testInitialization [
 
 	self deny: presenter hasActiveFilter.

--- a/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
@@ -1,0 +1,134 @@
+Class {
+	#name : #StDebuggerTreeTablePresenterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'presenter',
+		'inspectorNodes'
+	],
+	#category : #'NewTools-Debugger-Tests-Presenters'
+}
+
+{ #category : #running }
+StDebuggerTreeTablePresenterTest >> setUp [
+
+	| node |
+	super setUp.
+
+	presenter := StDebuggerTreeTablePresenter new.
+	inspectorNodes := OrderedCollection new.
+
+	node := StInspectorDynamicNode basicNew variableTag: 'toto'.
+	node rawValue: node; hostObject: 'toto'.
+	inspectorNodes add: (node rawValue: node).
+
+	node := StInspectorDynamicNode basicNew variableTag: 'tata'.
+	node rawValue: node; hostObject: 'tata'.
+	inspectorNodes add: node.
+	
+	presenter roots: inspectorNodes.
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testApplyFilterDoesFilterWhenHasActiveFilterIsTrueAndFilterIsNotNil [
+
+	| rejectedItems filteredItems |
+	rejectedItems := inspectorNodes reject: [ :item | 
+		                 item variableTag = 'toto' ].
+	presenter filter: 'toto'.
+	presenter isFiltered: true.
+
+	filteredItems := presenter applyFilter.
+
+	filteredItems do: [ :filteredItem | 
+		self
+			deny: (rejectedItems includes: filteredItem);
+			assert: filteredItem variableTag equals: 'toto' ].
+	self
+		assert: filteredItems size + rejectedItems size
+		equals: inspectorNodes size
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testApplyFilterDoesntFilterAndRemovesFilterWhenHasActiveFilterIsFalse [
+
+	presenter filter: 'toto'.
+	presenter applyFilter.
+	self 	assert: presenter roots equals: inspectorNodes;
+			assert: presenter filter isNil
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testApplyFilterDoesntFilterWhenFilterIsNil [
+
+	presenter isFiltered: true.
+	presenter applyFilter.
+	self assert: presenter roots equals: inspectorNodes
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testApplyFilterDoesntFilterWhenHasActiveFilterIsFalse [
+
+	presenter filter: 'toto'.
+	presenter applyFilter.
+	self assert: presenter roots equals: inspectorNodes
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testInitialization [
+
+	self deny: presenter hasActiveFilter.
+	self assert: presenter filter isNil.
+	self assert: presenter roots equals: inspectorNodes
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testRootsActualisesRootsByApplyingFilter [
+
+	| filteredItems |
+	presenter isFiltered: true.
+	presenter filter: 'tata'.
+	filteredItems := presenter applyFilter.
+
+	presenter roots: presenter roots.
+
+	self assert: presenter roots equals: filteredItems
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testToggleDoesNotFilterWhenFilteredButFilterIsNil [
+
+	presenter toggleFilter: nil.
+	self assert: presenter roots equals: inspectorNodes;
+		assert: presenter hasActiveFilter
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testToggleFiltersWhenFilteredAndFilterIsNotNil [
+
+	| rejectedItems |
+	rejectedItems := inspectorNodes reject: [:item | item variableTag = 'toto'].
+	presenter toggleFilter: 'toto'.
+
+	presenter roots do: [ :filteredItem | 
+		self 	deny: (rejectedItems includes: filteredItem);
+				assert: filteredItem variableTag equals: 'toto' ].
+	self
+		assert: presenter roots size + rejectedItems size equals: inspectorNodes size;
+		assert: presenter filter equals: 'toto';
+		assert: presenter hasActiveFilter
+]
+
+{ #category : #tests }
+StDebuggerTreeTablePresenterTest >> testToggleUnFiltersWhenToggledTwice [
+
+	| rejectedItems |
+	rejectedItems := inspectorNodes reject: [ :item | 
+		                 item variableTag = 'toto' ].
+	presenter toggleFilter: 'toto'.
+	presenter toggleFilter: 'toto'.
+
+	self
+		assert: presenter roots equals: inspectorNodes;
+		assert: presenter filter isNil;
+		deny: presenter hasActiveFilter
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTreeTablePresenterTest.class.st
@@ -40,12 +40,9 @@ StDebuggerTreeTablePresenterTest >> testApplyFilterDoesFilterWhenHasActiveFilter
 	filteredItems := presenter applyFilter.
 
 	filteredItems do: [ :filteredItem | 
-		self
-			deny: (rejectedItems includes: filteredItem);
-			assert: filteredItem variableTag equals: 'toto' ].
+		self assert: filteredItem variableTag equals: 'toto' ].
 	self
-		assert: filteredItems size + rejectedItems size
-		equals: inspectorNodes size
+		assertCollection: inspectorNodes hasSameElements: filteredItems , rejectedItems
 ]
 
 { #category : #tests }
@@ -102,10 +99,9 @@ StDebuggerTreeTablePresenterTest >> testToggleFiltersWhenFilteredAndFilterIsNotN
 	presenter toggleFilter: 'toto'.
 
 	presenter roots do: [ :filteredItem | 
-		self 	deny: (rejectedItems includes: filteredItem);
-				assert: filteredItem variableTag equals: 'toto' ].
+		self assert: filteredItem variableTag equals: 'toto' ].
 	self
-		assert: presenter roots size + rejectedItems size equals: inspectorNodes size;
+		assertCollection: presenter roots , rejectedItems hasSameElements: inspectorNodes;
 		assert: presenter filter equals: 'toto';
 		assert: presenter hasActiveFilter
 ]
@@ -113,9 +109,6 @@ StDebuggerTreeTablePresenterTest >> testToggleFiltersWhenFilteredAndFilterIsNotN
 { #category : #tests }
 StDebuggerTreeTablePresenterTest >> testToggleUnFiltersWhenToggledTwice [
 
-	| rejectedItems |
-	rejectedItems := inspectorNodes reject: [ :item | 
-		                 item variableTag = 'toto' ].
 	presenter toggleFilter: 'toto'.
 	presenter toggleFilter: 'toto'.
 

--- a/src/NewTools-Debugger/StDebuggerTreeTablePresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerTreeTablePresenter.class.st
@@ -1,3 +1,10 @@
+"
+I represent an attribute table specialized for debuggers.
+
+I'm used to display all variables that are my roots. I can filter these variables by their variable tag. 
+
+In the debugger, I'm used to display all variables in the selected context and you can filter/unfilter them by clicking/double-clicking one of their variable tag.
+"
 Class {
 	#name : #StDebuggerTreeTablePresenter,
 	#superclass : #SpTreeTablePresenter,
@@ -12,10 +19,12 @@ Class {
 { #category : #api }
 StDebuggerTreeTablePresenter >> applyFilter [
 
-	filter ifNil: [ ^items ].
-	isFiltered ifFalse:  [ filter := nil. ^items ].
+	filter ifNil: [ ^ items ].
+	isFiltered ifFalse: [ 
+		filter := nil.
+		^ items ].
 
-	^items select: [:item| item variableTag = filter]
+	^ items select: [ :item | item variableTag = filter ]
 ]
 
 { #category : #accessing }
@@ -45,9 +54,6 @@ StDebuggerTreeTablePresenter >> roots: aCollection [
 { #category : #api }
 StDebuggerTreeTablePresenter >> toggleFilter: aVariableTag [
 
-"	filter := filter = aVariableTag
-		          ifTrue: [ nil ]
-		          ifFalse: [ aVariableTag ]."
 	filter := aVariableTag.
 	isFiltered := isFiltered not.
 

--- a/src/NewTools-Debugger/StDebuggerTreeTablePresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerTreeTablePresenter.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'items',
 		'filter',
-		'counter'
+		'isFiltered'
 	],
 	#category : #'NewTools-Debugger-View'
 }
@@ -13,8 +13,7 @@ Class {
 StDebuggerTreeTablePresenter >> applyFilter [
 
 	filter ifNil: [ ^items ].
-	self flag: 'Ugly hack because links presenter trigger 2 times their action. But for now it works'.
-	counter > 3 ifTrue:  [ counter := 0. filter := nil. ^items ].
+	isFiltered ifFalse:  [ filter := nil. ^items ].
 
 	^items select: [:item| item variableTag = filter]
 ]
@@ -26,13 +25,13 @@ StDebuggerTreeTablePresenter >> filter [
 
 { #category : #api }
 StDebuggerTreeTablePresenter >> hasActiveFilter [
-	^counter > 0
+	^isFiltered 
 ]
 
 { #category : #initialization }
 StDebuggerTreeTablePresenter >> initialize [
 	super initialize.
-	counter := 0
+	isFiltered := false
 ]
 
 { #category : #api }
@@ -50,7 +49,7 @@ StDebuggerTreeTablePresenter >> toggleFilter: aVariableTag [
 		          ifTrue: [ nil ]
 		          ifFalse: [ aVariableTag ]."
 	filter := aVariableTag.
-	counter := counter + 1.
+	isFiltered := isFiltered not.
 
 	self roots: items
 ]


### PR DESCRIPTION
Fixes #358 
In the class `StDebuggerTreeTablePresenter`, we had to click 4 times to filter/unfilter the debugger tree table.
This has been fixed so that we just have to click one time to filter/unfilter this table.

Furthermore, I've added some tests for this class because it wasn't tested until now