### PR TITLE
Fixing initial window size in debugger presenter

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -605,10 +605,6 @@ StDebugger >> forceSessionUpdate [
 
 { #category : #api }
 StDebugger >> initialExtent [ 
-	"This code was taken from the old debugger to get the same behavior. Fell free to refactor"
-	self flag: 'Do it better'.
-	"RealEstateAgent standardWindowExtent y < 400"true "a tiny screen" 
-		ifTrue: [ ^ 1000@800 ].
 	
 	^ [ | w h |
 		w := Display width.


### PR DESCRIPTION
Fixes #360 
In the method StDebugger >> initialExtent, the initial size of the debugger window was hard coded and the former code of the method was unreachable.

Historically, this was hard coded because of a bug: a small window was opened for the debugger, even on large screens. However, this bug doesn't seem to be there anymore so this can be removed