### PR TITLE
362 accesses to debugger session from debugger need refactoring

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -244,9 +244,11 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 ]
 
 { #category : #tests }
-StDebuggerActionModelTest >> testExceptionProvidesSameExceptionAsTheSessionOne [ 
+StDebuggerActionModelTest >> testExceptionProvidesSameExceptionAsTheSessionOne [
 
-self assert: debugActionModel exception equals: debugActionModel session exception
+	self
+		assert: debugActionModel exception
+		equals: debugActionModel session exception
 ]
 
 { #category : #'tests - actions' }
@@ -496,6 +498,33 @@ StDebuggerActionModelTest >> testProceedDebugSession [
 	debugActionModel proceedDebugSession.
 	self assert: session interruptedContext isNil.
 	self assert: result equals: 4
+]
+
+{ #category : #tests }
+StDebuggerActionModelTest >> testRecompileMethodToInContextNotifyingUpdatesSourceCodeAndContext [
+
+	| oldStack contextChanged expectedNewStack rejectedFromOldStack |
+	contextChanged := debugActionModel topContext.
+
+	debugActionModel session stepIntoUntil: [ :currentContext | 
+		currentContext selector = #squared ].
+	debugActionModel updateTopContext.
+	oldStack := debugActionModel sessionStack.
+	rejectedFromOldStack := { debugActionModel topContext }.
+
+	expectedNewStack := oldStack copyWithoutFirst.
+
+	debugActionModel
+		recompileMethodTo: contextChanged method sourceCode
+		inContext: contextChanged
+		notifying: nil.
+
+	self
+		denyCollection: debugActionModel sessionStack
+		includesAny: rejectedFromOldStack.
+	self
+		assertCollection: debugActionModel sessionStack
+		hasSameElements: expectedNewStack
 ]
 
 { #category : #'tests - actions' }

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -511,6 +511,12 @@ StDebuggerActionModelTest >> testRunToSelectionInContext [
 	self assert: (method sourceNodeForPC: session interruptedContext pc) identicalTo: node
 ]
 
+{ #category : #tests }
+StDebuggerActionModelTest >> testSessionStackProvidesSameStackAsTheSessionOne [
+
+	self assert: debugActionModel sessionStack equals: debugActionModel session stack
+]
+
 { #category : #'tests - actions' }
 StDebuggerActionModelTest >> testStepInto [
 	|ctx|

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -388,6 +388,12 @@ StDebuggerActionModelTest >> testInitialization [
 ]
 
 { #category : #tests }
+StDebuggerActionModelTest >> testInterruptedContextProvidesSameContextAsTheSessionOne [
+
+	self assert: debugActionModel interruptedContext equals: debugActionModel session interruptedContext 
+]
+
+{ #category : #tests }
 StDebuggerActionModelTest >> testInterruptedProcessProvidesSameProcessAsTheSessionOne [
 
 	self

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -387,6 +387,14 @@ StDebuggerActionModelTest >> testInitialization [
 		identicalTo: session interruptedContext
 ]
 
+{ #category : #tests }
+StDebuggerActionModelTest >> testInterruptedProcessProvidesSameProcessAsTheSessionOne [
+
+	self
+		assert: debugActionModel interruptedProcess
+		equals: debugActionModel session interruptedProcess
+]
+
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsContextAnAssertionFailure [
 	self changeSession: StTestDebuggerProvider new debuggerWithFailingAssertionContext session.

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -561,6 +561,30 @@ StDebuggerActionModelTest >> testRunToSelectionInContext [
 ]
 
 { #category : #tests }
+StDebuggerActionModelTest >> testSelectedCodeRangeForContext [
+
+	| method node |
+	method := self class >> #setResult.
+	node := method ast statements second.
+
+	self
+		assert: (debugActionModel selectedCodeRangeForContext:
+				 debugActionModel interruptedContext)
+		equals:
+		(session selectedCodeRangeForContext: session interruptedContext).
+
+	debugActionModel
+		runToSelection: (node start to: node stop)
+		inContext: session interruptedContext.
+
+	self
+		assert: (debugActionModel selectedCodeRangeForContext:
+				 debugActionModel interruptedContext)
+		equals:
+		(session selectedCodeRangeForContext: session interruptedContext)
+]
+
+{ #category : #tests }
 StDebuggerActionModelTest >> testSessionStackProvidesSameStackAsTheSessionOne [
 
 	self assert: debugActionModel sessionStack equals: debugActionModel session stack

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -243,6 +243,12 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 	
 ]
 
+{ #category : #tests }
+StDebuggerActionModelTest >> testExceptionProvidesSameExceptionAsTheSessionOne [ 
+
+self assert: debugActionModel exception equals: debugActionModel session exception
+]
+
 { #category : #'tests - actions' }
 StDebuggerActionModelTest >> testFileOutMethod [
 	debugActionModel fileOutMethod: self.

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -509,7 +509,7 @@ StDebuggerActionModelTest >> testRecompileMethodToInContextNotifyingUpdatesSourc
 	debugActionModel session stepIntoUntil: [ :currentContext | 
 		currentContext selector = #squared ].
 	debugActionModel updateTopContext.
-	oldStack := debugActionModel sessionStack.
+	oldStack := debugActionModel stack.
 	rejectedFromOldStack := { debugActionModel topContext }.
 
 	expectedNewStack := oldStack copyWithoutFirst.
@@ -518,13 +518,15 @@ StDebuggerActionModelTest >> testRecompileMethodToInContextNotifyingUpdatesSourc
 		recompileMethodTo: contextChanged method sourceCode
 		inContext: contextChanged
 		notifying: nil.
+	debugActionModel updateTopContext.
 
 	self
-		denyCollection: debugActionModel sessionStack
+		denyCollection: debugActionModel stack
 		includesAny: rejectedFromOldStack.
 	self
-		assertCollection: debugActionModel sessionStack
-		hasSameElements: expectedNewStack
+		assertCollection: debugActionModel stack
+		hasSameElements: expectedNewStack.
+	self assert: debugActionModel topContext identicalTo: contextChanged
 ]
 
 { #category : #'tests - actions' }
@@ -587,7 +589,7 @@ StDebuggerActionModelTest >> testSelectedCodeRangeForContext [
 { #category : #tests }
 StDebuggerActionModelTest >> testSessionStackProvidesSameStackAsTheSessionOne [
 
-	self assert: debugActionModel sessionStack equals: debugActionModel session stack
+	self assert: debugActionModel stack equals: debugActionModel session stack
 ]
 
 { #category : #tests }
@@ -597,6 +599,7 @@ StDebuggerActionModelTest >> testStackOfSizeWhenStackIsBigger [
 	oldStack := debugActionModel session stack.
 
 	debugActionModel stepInto: debugActionModel interruptedContext.
+	"We did a step into, so the size of the stack should be increased by 1. Here, I chose to increase the size of the stack by 13 but it could have any number greater than 1. The idea here is just to check that the size of the stack has been increased by only 1 and not more than necessary."
 	newStack := debugActionModel stackOfSize: oldStack size + 13.
 
 	self assert: newStack size - oldStack size equals: 1.
@@ -611,7 +614,7 @@ StDebuggerActionModelTest >> testStackOfSizeWhenStackIsNotBigger [
 
 	| oldStack newStack |
 	oldStack := debugActionModel session stack.
-
+	"Here, I chose to increase the size of the stack by 13 but it could have any number greater than 0. The idea here is just to check that the size of the stack is its exact size, although we provided a greater size as an argument."
 	newStack := debugActionModel stackOfSize: oldStack size + 13.
 
 	self assert: newStack size - oldStack size equals: 0.

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -590,6 +590,36 @@ StDebuggerActionModelTest >> testSessionStackProvidesSameStackAsTheSessionOne [
 	self assert: debugActionModel sessionStack equals: debugActionModel session stack
 ]
 
+{ #category : #tests }
+StDebuggerActionModelTest >> testStackOfSizeWhenStackIsBigger [
+
+	| oldStack newStack |
+	oldStack := debugActionModel session stack.
+
+	debugActionModel stepInto: debugActionModel interruptedContext.
+	newStack := debugActionModel stackOfSize: oldStack size + 13.
+
+	self assert: newStack size - oldStack size equals: 1.
+	self
+		assertCollection: oldStack
+		equals:
+		(newStack collect: [ :obj | obj ] from: 2 to: oldStack size + 1)
+]
+
+{ #category : #tests }
+StDebuggerActionModelTest >> testStackOfSizeWhenStackIsNotBigger [
+
+	| oldStack newStack |
+	oldStack := debugActionModel session stack.
+
+	newStack := debugActionModel stackOfSize: oldStack size + 13.
+
+	self assert: newStack size - oldStack size equals: 0.
+	self
+		assertCollection: oldStack
+		equals: (newStack collect: [ :obj | obj ] from: 1 to: oldStack size)
+]
+
 { #category : #'tests - actions' }
 StDebuggerActionModelTest >> testStepInto [
 	|ctx|

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -695,6 +695,15 @@ StDebuggerTest >> testSelectLastStackElementWithoutMoreElements [
 ]
 
 { #category : #tests }
+StDebuggerTest >> testSessionProvidesSameAsTheActionModelOne [
+
+	debugger := self debuggerOn: session.
+	self
+		assert: debugger session
+		identicalTo: debugger debuggerActionModel session
+]
+
+{ #category : #tests }
 StDebuggerTest >> testSessionStackProvidesSameStackAsTheActionModelOne [
 
 	debugger := self debuggerOn: session.

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -365,7 +365,7 @@ StDebuggerTest >> testExceptionProvidesSameExceptionAsTheActionModelOne [
 	debugger := self debuggerOn: session.
 	self
 		assert: debugger exception
-		equals: debugger debuggerActionModel exception
+		identicalTo: debugger debuggerActionModel exception
 ]
 
 { #category : #'tests - initialization' }
@@ -402,7 +402,7 @@ StDebuggerTest >> testInterruptedContextProvidesSameContextAsTheActionModelOne [
 	debugger := self debuggerOn: session.
 	self
 		assert: debugger interruptedContext
-		equals: debugger debuggerActionModel interruptedContext
+		identicalTo: debugger debuggerActionModel interruptedContext
 ]
 
 { #category : #tests }
@@ -411,7 +411,7 @@ StDebuggerTest >> testInterruptedProcessProvidesSameProcessAsTheActionModelOne [
 	debugger := self debuggerOn: session.
 	self
 		assert: debugger interruptedProcess
-		equals: debugger debuggerActionModel interruptedProcess
+		identicalTo: debugger debuggerActionModel interruptedProcess
 ]
 
 { #category : #'tests - context inspector' }
@@ -708,8 +708,8 @@ StDebuggerTest >> testSessionStackProvidesSameStackAsTheActionModelOne [
 
 	debugger := self debuggerOn: session.
 	self
-		assert: debugger sessionStack
-		equals: debugger debuggerActionModel sessionStack
+		assertCollection: debugger stack
+		equals: debugger debuggerActionModel stack
 ]
 
 { #category : #'tests - stack table' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -388,6 +388,15 @@ StDebuggerTest >> testInitialCodeSelectionAfterStepping [
 ]
 
 { #category : #tests }
+StDebuggerTest >> testInterruptedContextProvidesSameContextAsTheActionModelOne [
+
+	debugger := self debuggerOn: session.
+	self
+		assert: debugger interruptedContext
+		equals: debugger debuggerActionModel interruptedContext
+]
+
+{ #category : #tests }
 StDebuggerTest >> testInterruptedProcessProvidesSameProcessAsTheActionModelOne [
 
 	debugger := self debuggerOn: session.

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -667,6 +667,15 @@ StDebuggerTest >> testSelectLastStackElementWithoutMoreElements [
 	self assert: stackTable items size equals: startingStackSize
 ]
 
+{ #category : #tests }
+StDebuggerTest >> testSessionStackProvidesSameStackAsTheActionModelOne [
+
+	debugger := self debuggerOn: session.
+	self
+		assert: debugger sessionStack
+		equals: debugger debuggerActionModel sessionStack
+]
+
 { #category : #'tests - stack table' }
 StDebuggerTest >> testStackTableAfterReturn [
 	| stackTableItems stackSizeAfterStepIn |

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -359,6 +359,15 @@ StDebuggerTest >> testDiscardCodeChangesFor [
 	
 ]
 
+{ #category : #tests }
+StDebuggerTest >> testExceptionProvidesSameExceptionAsTheActionModelOne [
+
+	debugger := self debuggerOn: session.
+	self
+		assert: debugger exception
+		equals: debugger debuggerActionModel exception
+]
+
 { #category : #'tests - initialization' }
 StDebuggerTest >> testFastTDD [
 	self debuggerClass fastTDD: nil.

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -387,6 +387,15 @@ StDebuggerTest >> testInitialCodeSelectionAfterStepping [
 	"The pc range is highlighted with an additionnal index to encompass the full text of the node (why?)"
 ]
 
+{ #category : #tests }
+StDebuggerTest >> testInterruptedProcessProvidesSameProcessAsTheActionModelOne [
+
+	debugger := self debuggerOn: session.
+	self
+		assert: debugger interruptedProcess
+		equals: debugger debuggerActionModel interruptedProcess
+]
+
 { #category : #'tests - context inspector' }
 StDebuggerTest >> testNewDebuggerContext [
 	| debuggerContext |

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -790,7 +790,7 @@ StDebugger >> interruptedContext [
 { #category : #accessing }
 StDebugger >> interruptedProcess [
 
-	^ self session interruptedProcess
+	^ self debuggerActionModel  interruptedProcess
 ]
 
 { #category : #'instance creation' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -879,11 +879,7 @@ StDebugger >> proceedDebugSession [
 { #category : #actions }
 StDebugger >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
 
-	aContext ifNil: [ ^ self ].
-	self session
-		recompileMethodTo: aString
-		inContext: aContext
-		notifying: aNotifyer
+	^ self debuggerActionModel recompileMethodTo: aString inContext: aContext notifying: aNotifyer.
 ]
 
 { #category : #'presenter - code' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -562,7 +562,7 @@ StDebugger >> doBrowseReceiverClass [
 	self systemNavigation browse: self stackSelectionReceiverClassContext value
 ]
 
-{ #category : #accessing }
+{ #category : #'stack - helpers' }
 StDebugger >> exception [
 	^ self debuggerActionModel exception
 ]
@@ -1016,6 +1016,12 @@ StDebugger >> selectTopContext [
 	stackTable selectIndex: 1
 ]
 
+{ #category : #'updating - actions' }
+StDebugger >> selectedCodeRangeForContext: aContext [
+
+	^ self debuggerActionModel selectedCodeRangeForContext: aContext
+]
+
 { #category : #'accessing - context' }
 StDebugger >> selectedContext [
 
@@ -1037,12 +1043,6 @@ StDebugger >> sessionHolder [
 	^ sessionHolder ifNil: [ sessionHolder := nil asValueHolder ]
 ]
 
-{ #category : #'accessing - variables' }
-StDebugger >> sessionStack [
-	^ self debuggerActionModel sessionStack 
-
-]
-
 { #category : #initialization }
 StDebugger >> setModelBeforeInitialization: aSession [
 
@@ -1061,7 +1061,13 @@ StDebugger >> setSessionHolderSubscriptions [
 
 { #category : #actions }
 StDebugger >> showFullStack [
-	stackTable items: (self filterStack: self sessionStack)
+	stackTable items: (self filterStack: self stack)
+
+]
+
+{ #category : #'accessing - variables' }
+StDebugger >> stack [
+	^ self debuggerActionModel stack 
 
 ]
 
@@ -1072,7 +1078,7 @@ StDebugger >> stackIconForContext: context [
 	^ self iconNamed: #overlayDirty
 ]
 
-{ #category : #'presenter - code' }
+{ #category : #'stack - helpers' }
 StDebugger >> stackOfSize: anInteger [
 
 	^ self debuggerActionModel stackOfSize: anInteger
@@ -1172,9 +1178,7 @@ StDebugger >> updateCodeFromContext: aContext [
 	aContext ifNil: [ ^ self clearCode ].
 
 	self recordUnsavedCodeChanges.
-	selectionInterval := selectionInterval := self debuggerActionModel 
-		                                          selectedCodeRangeForContext:
-		                                          aContext.
+	selectionInterval := self selectedCodeRangeForContext: aContext.
 	aContext sourceCode = self code text ifFalse: [ 
 		self updateSourceCodeFor: aContext ].
 	self code beForContext: aContext.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1036,6 +1036,12 @@ StDebugger >> sessionHolder [
 	^ sessionHolder ifNil: [ sessionHolder := nil asValueHolder ]
 ]
 
+{ #category : #'accessing - variables' }
+StDebugger >> sessionStack [
+	^ self debuggerActionModel sessionStack 
+
+]
+
 { #category : #initialization }
 StDebugger >> setModelBeforeInitialization: aSession [
 
@@ -1054,7 +1060,7 @@ StDebugger >> setSessionHolderSubscriptions [
 
 { #category : #actions }
 StDebugger >> showFullStack [
-	stackTable items: (self filterStack: self session stack)
+	stackTable items: (self filterStack: self sessionStack)
 
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -456,7 +456,7 @@ StDebugger >> copyStackToClipboard [
 StDebugger >> createMissingClass [
 
 	| variableNode |
-	variableNode := self session exception variableNode.
+	variableNode := self exception variableNode.
 	[ 
 	| newClassBinding |
 	self flag: 'This method is actually hard to test because it requires user input to complete. How to test that automatically?'.
@@ -560,6 +560,11 @@ StDebugger >> doBrowseClass [
 StDebugger >> doBrowseReceiverClass [
 
 	self systemNavigation browse: self stackSelectionReceiverClassContext value
+]
+
+{ #category : #accessing }
+StDebugger >> exception [
+	^ self debuggerActionModel exception
 ]
 
 { #category : #stack }
@@ -797,7 +802,7 @@ StDebugger >> interruptedProcess [
 StDebugger >> newDebuggerContext [
 
 	^ self class debuggerContextClass new
-		  exception: self session exception;
+		  exception: self exception;
 		  yourself
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1161,20 +1161,22 @@ StDebugger >> updateCodeFromContext [
 
 { #category : #'presenter - code' }
 StDebugger >> updateCodeFromContext: aContext [
-	| selectionInterval |
 
+	| selectionInterval |
 	aContext ifNil: [ ^ self clearCode ].
-	
+
 	self recordUnsavedCodeChanges.
-	selectionInterval := self session selectedCodeRangeForContext: aContext.
-	aContext sourceCode = self code text 
-		ifFalse: [ self updateSourceCodeFor: aContext ].
+	selectionInterval := selectionInterval := self debuggerActionModel 
+		                                          selectedCodeRangeForContext:
+		                                          aContext.
+	aContext sourceCode = self code text ifFalse: [ 
+		self updateSourceCodeFor: aContext ].
 	self code beForContext: aContext.
-	self code selectionInterval: (selectionInterval last to: selectionInterval last - 1).
+	self code selectionInterval:
+		(selectionInterval last to: selectionInterval last - 1).
 	self
 		updateCodeTextSegmentDecoratorsIn: aContext
-		forInterval: selectionInterval.
-	
+		forInterval: selectionInterval
 ]
 
 { #category : #'updating - widgets' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -573,7 +573,7 @@ StDebugger >> expandStackIfLastItemIsSelected [
 	selection := stackTable selection.
 	selection selectedItem == stackTable items last ifFalse: [ ^ self ].
 	stackTable items: (self filterStack:
-			 (self session stackOfSize: 2 * stackTable items size)).
+			 (self stackOfSize: 2 * stackTable items size)).
 	stackTable selectIndex: selection selectedIndex
 ]
 
@@ -1070,6 +1070,12 @@ StDebugger >> stackIconForContext: context [
 
 	self unsavedCodeChanges at: context ifAbsent: [ ^ nil ].
 	^ self iconNamed: #overlayDirty
+]
+
+{ #category : #'presenter - code' }
+StDebugger >> stackOfSize: anInteger [
+
+	^ self debuggerActionModel stackOfSize: anInteger
 ]
 
 { #category : #'commands - support' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -784,7 +784,7 @@ StDebugger >> instantiateExtensionToolsPage: aToolClass [
 { #category : #'accessing - context' }
 StDebugger >> interruptedContext [
 
-	^ self session interruptedContext
+	^ self debuggerActionModel interruptedContext
 ]
 
 { #category : #accessing }
@@ -1213,7 +1213,7 @@ StDebugger >> updateExtensionsFrom: newSession [
 StDebugger >> updateInspectorFromContext: aContext [
 
 	inspector
-		updateLayoutForContexts: self session interruptedContext
+		updateLayoutForContexts: self interruptedContext
 		isAssertionFailure:
 		self debuggerActionModel isInterruptedContextAnAssertEqualsFailure.
 	inspector updateWith: (self newDebuggerContextFor: aContext).

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -275,6 +275,15 @@ StDebuggerActionModel >> proceedDebugSession [
 		clear
 ]
 
+{ #category : #actions }
+StDebuggerActionModel >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
+	aContext ifNil: [ ^ self ].
+	self session
+		recompileMethodTo: aString
+		inContext: aContext
+		notifying: aNotifyer
+]
+
 { #category : #context }
 StDebuggerActionModel >> referenceContext [
 	"The reference context is the context that we wish to see in the debugger's stack.

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -308,6 +308,11 @@ StDebuggerActionModel >> session: aDebugSession [
 	session := aDebugSession
 ]
 
+{ #category : #'accessing - variables' }
+StDebuggerActionModel >> sessionStack [
+	^ self session stack
+]
+
 { #category : #'debug - stack' }
 StDebuggerActionModel >> shouldFilterStack [
 

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -317,6 +317,11 @@ StDebuggerActionModel >> runToSelection: aSelectionInterval inContext: aContext 
 	self updateTopContext
 ]
 
+{ #category : #actions }
+StDebuggerActionModel >> selectedCodeRangeForContext: aContext [ 
+	^ self session selectedCodeRangeForContext: aContext
+]
+
 { #category : #accessing }
 StDebuggerActionModel >> session [
 	^session

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -111,6 +111,11 @@ StDebuggerActionModel >> copyStackToClipboard [
 				streamContents: [ :s | self interruptedContext shortDebugStackOn: s ])
 ]
 
+{ #category : #accessing }
+StDebuggerActionModel >> exception [
+	^ self session exception
+]
+
 { #category : #'debug - stack' }
 StDebuggerActionModel >> fileOutMethod: aMethod [
 	aMethod methodClass fileOutMethod: aMethod selector

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -111,7 +111,7 @@ StDebuggerActionModel >> copyStackToClipboard [
 				streamContents: [ :s | self interruptedContext shortDebugStackOn: s ])
 ]
 
-{ #category : #accessing }
+{ #category : #'stack - helpers' }
 StDebuggerActionModel >> exception [
 	^ self session exception
 ]
@@ -332,18 +332,18 @@ StDebuggerActionModel >> session: aDebugSession [
 	session := aDebugSession
 ]
 
-{ #category : #'accessing - variables' }
-StDebuggerActionModel >> sessionStack [
-	^ self session stack
-]
-
 { #category : #'debug - stack' }
 StDebuggerActionModel >> shouldFilterStack [
 
 	^ self filterStack and: [ self class shouldFilterStack ]
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - variables' }
+StDebuggerActionModel >> stack [
+	^ self session stack
+]
+
+{ #category : #'stack - helpers' }
 StDebuggerActionModel >> stackOfSize: anInteger [ 
 	^ self session stackOfSize: anInteger
 ]

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -167,6 +167,11 @@ StDebuggerActionModel >> interruptedContext [
 	^self session interruptedContext
 ]
 
+{ #category : #accessing }
+StDebuggerActionModel >> interruptedProcess [
+	^ self session interruptedProcess
+]
+
 { #category : #'debug - predicates' }
 StDebuggerActionModel >> isContextAnAssertionFailure [
 

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -343,6 +343,11 @@ StDebuggerActionModel >> shouldFilterStack [
 	^ self filterStack and: [ self class shouldFilterStack ]
 ]
 
+{ #category : #accessing }
+StDebuggerActionModel >> stackOfSize: anInteger [ 
+	^ self session stackOfSize: anInteger
+]
+
 { #category : #context }
 StDebuggerActionModel >> statusStringForContext [
 


### PR DESCRIPTION
Fixes #362
In the class `StDebugger` which represents the GUI of the debugger, the debug session was sometimes manipulated directly by the GUI.

This shouldn't be the case as the logic of the debugger shouldn't be mixed with the GUI, as a debugger should be able to exist without a GUI. Furthermore, the logic of the debugger should be in a completely different object, so that we can change the GUI of the debugger without the risk of breaking the debugger's logic.

As a result, all direct session accesses and manipulations are done through the debugger action model, whose goal is to perform actions on the debug session. Thus, the `StDebugger` now delegates to the action model that accesses/manipulates the session; where before `StDebugger` accessed/manipulated the debug session directly.

Furthermore, all these accesses/manipulations are tested