### PR TITLE
Re enable keybinds on the stack panel of the debugger

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -340,15 +340,15 @@ StDebugger >> buildContextMenus [
 	
 	debuggerCommandGroup := self rootCommandsGroup.
 	"Stack"
-	stackGroup := debuggerCommandGroup / StDebuggerStackCommandTreeBuilder groupName.
+	stackGroup := debuggerCommandGroup / StDebuggerStackCommandTreeBuilder groupName. 
 	stackTable contextMenu: stackGroup beRoot asMenuPresenter.
-
+	stackTable contextKeyBindings: (self keybindsForFromContextMenu: stackGroup).
+	 
 	"Toolbar"
 	toolbarCommandGroup := debuggerCommandGroup / StDebuggerToolbarCommandTreeBuilder groupName.
 	SpToolbarPresenterBuilder new
 		toolbarPresenter: toolbar;
 		visit: toolbarCommandGroup.
-	self updateToolbar.
 
 	"Code"
 	codeCommands := debuggerCommandGroup / StDebuggerCodeCommandTreeBuilder groupName.
@@ -791,6 +791,23 @@ StDebugger >> interruptedContext [
 StDebugger >> interruptedProcess [
 
 	^ self session interruptedProcess
+]
+
+{ #category : #'commands - support' }
+StDebugger >> keybindsForFromContextMenu: aGroupElement [
+	| keybinds keybindsCommands |
+	keybinds := KMCategory new.
+	
+	keybindsCommands := aGroupElement allCommands select: [ :aCommand | aCommand hasShortcutKey ].
+	
+	keybindsCommands do: [ :aCommand | | action |
+		action := [ :aSelectedElement | aCommand execute ]. 
+		keybinds addKeymapEntry: (KMKeymap
+			shortcut: aCommand shortcutKey
+			action: action).
+		].
+	
+	^ keybinds
 ]
 
 { #category : #'instance creation' }

--- a/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
+++ b/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
@@ -157,7 +157,6 @@ StDebuggerStackCommandTreeBuilder >> stackContextNavigationCommands [
 		beDisplayedAsGroup;
 		register: ((SpBrowseClassCommand forSpecContext: stDebuggerInstance)
 			name: 'method';
-			shortcutKey: nil;
 			yourself);
 		register: (((SpBrowseClassCommand forContext: stDebuggerInstance)
 			selector: #doBrowseReceiverClass;


### PR DESCRIPTION
The keybinds are now gathered from the active context menu, and registered to the stack panel.
@estebanlm I think this might interest you.
We were speaking with Christophe, and this could be fairly easily added to SpPresenter, which would simplify definition of keybinds.
(there are caveats in this very simple form of course, but the idea)
@maxwills could you try this out with your PR to check whether they indeed work well together ?
@StevenCostiou Thank you :)

Done with the help of @DelGaylord , @sambegou and @adri09070 :)