### PR TITLE
Fixes context menu commands of the StDebugger stack.

### DIFF
--- a/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
@@ -105,3 +105,9 @@ StDebuggerCommand >> initialize [
 			<< ': '
 			<< self class defaultDescription ])
 ]
+
+{ #category : #'as yet unclassified' }
+StDebuggerCommand >> transform: aBlock [
+
+	^ self
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerStackCommandTreeBuilderTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerStackCommandTreeBuilderTest.class.st
@@ -59,11 +59,13 @@ StDebuggerStackCommandTreeBuilderTest >> testGroupName [
 
 { #category : #tests }
 StDebuggerStackCommandTreeBuilderTest >> testNavigationCommandForContext [
+
 	| cmd |
-	
-	cmd := builder buildSpecCommand: StMockDebugCommand forContext: self.
+	cmd := builder
+		       buildSpecCommand: StMockDebugCommand
+		       forContext: debugger.
 	self assert: cmd innerCommand class identicalTo: StMockDebugCommand.
-	self assert: cmd context identicalTo: self
+	self assert: cmd context identicalTo: debugger
 ]
 
 { #category : #tests }
@@ -147,10 +149,10 @@ StDebuggerStackCommandTreeBuilderTest >> testStackContextMenuExplorationCommands
 		assertCommands:
 			{cmdEntries first.
 			cmdEntries second}
-		haveContext: debugger stackTable selection selectedItem receiver class.
+		haveContext: debugger.
 	self
 		assertCommands: {cmdEntries last}
-		haveContext: debugger stackTable selection selectedItem receiver 
+		haveContext: debugger 
 ]
 
 { #category : #tests }
@@ -251,7 +253,7 @@ StDebuggerStackCommandTreeBuilderTest >> testStackMethodNavigationCommands [
 	self
 		assertCommandGroup: builder stackMethodNavigationCommands
 		hasSameCommands: builder stackMethodCommandsClasses
-		withContext: debugger stackTable selection selectedItem home method
+		withContext: debugger
 		displayStrategy: CmUIDisplayAsGroup
 ]
 
@@ -277,7 +279,7 @@ StDebuggerStackCommandTreeBuilderTest >> testStackMethodSelectorNavigationComman
 	self
 		assertCommandGroup: builder stackMethodSelectorNavigationCommands
 		hasSameCommands: builder stackMethodSelectorCommandsClasses
-		withContext: debugger stackTable selection selectedItem method selector
+		withContext: debugger
 		displayStrategy: CmUIDisplayAsGroup
 ]
 
@@ -302,7 +304,7 @@ StDebuggerStackCommandTreeBuilderTest >> testStackReceiverClassNavigationCommand
 	self
 		assertCommandGroup: builder stackReceiverClassNavigationCommands
 		hasSameCommands: builder stackReceiverCommandsClasses
-		withContext: debugger stackTable selection selectedItem receiver class
+		withContext: debugger
 		displayStrategy: CmUIDisplayAsGroup
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -553,13 +553,85 @@ StDebugger >> discardCodeChangesFor: aContext [
 { #category : #commands }
 StDebugger >> doBrowseClass [
 
-	self systemNavigation browse: self stackSelectionMethodContext value
+	self systemNavigation browse:
+		(self stackSelectionMethodContext value: self)
+]
+
+{ #category : #'presenter - code' }
+StDebugger >> doBrowseClassReferences [
+
+	| cls |
+	cls := self stackSelectionReceiverClassContext value: self.
+	cls isTrait
+		ifTrue: [ self systemNavigation browseAllUsersOfTrait: cls ]
+		ifFalse: [ self systemNavigation browseAllCallsOnClass: cls ]
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseHierarchy [
+
+	self systemNavigation browseHierarchy:
+		(self stackSelectionReceiverClassContext value: self)
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseImplementors [
+
+	self systemNavigation browseAllImplementorsOf:
+		(self stackSelectionMethodSelectorContext value: self)
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseMethodInheritance [
+
+	| cls |
+	(self stackSelectionMethodContext value: self) method isDoIt ifTrue: [ 
+		^ self ].
+	cls := self stackSelectionReceiverClassContext value: self.
+	cls isBlock ifTrue: [ 
+		cls := (self stackSelectionMethodContext value: self) methodClass ].
+	self systemNavigation
+		methodHierarchyBrowserForClass:
+		(self stackSelectionReceiverClassContext value: self)
+		selector: (self stackSelectionMethodSelectorContext value: self)
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseMethodReferences [
+
+	self systemNavigation browseAllSendersOrUsersOf:
+		(self stackSelectionMethodSelectorContext value: self)
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseMethodVersions [
+
+	| target |
+	target := self stackSelectionMethodContext.
+	target isBlock ifTrue: [ target := target method ].
+	Smalltalk tools versionBrowser
+		browseVersionsForClass: target methodClass
+		selector: target selector
 ]
 
 { #category : #commands }
 StDebugger >> doBrowseReceiverClass [
 
-	self systemNavigation browse: self stackSelectionReceiverClassContext value
+	self systemNavigation browse:
+		(self stackSelectionReceiverClassContext value: self)
+]
+
+{ #category : #commands }
+StDebugger >> doBrowseSenders [
+
+	self systemNavigation browseAllSendersOf:
+		(self stackSelectionMethodSelectorContext value: self)
+]
+
+{ #category : #accessing }
+StDebugger >> environment [
+
+^ self class environment
 ]
 
 { #category : #stack }
@@ -1068,28 +1140,31 @@ StDebugger >> stackIconForContext: context [
 { #category : #'commands - support' }
 StDebugger >> stackSelectionMethodContext [
 
-	^ [ stackTable selection selectedItem home method ]
+	^ [ :dbg | stackTable selection selectedItem home method ]
 ]
 
 { #category : #'commands - support' }
 StDebugger >> stackSelectionMethodSelectorContext [
 
-	^ [ stackTable selection selectedItem method selector ]
+	^ [ :dbg | stackTable selection selectedItem method selector ]
 ]
 
 { #category : #'commands - support' }
 StDebugger >> stackSelectionReceiverClassContext [
-	^ [ stackTable selection selectedItem receiver class ]
+
+	^ [ :dbg | stackTable selection selectedItem receiver class ]
 ]
 
 { #category : #'commands - support' }
 StDebugger >> stackSelectionReceiverContext [
-	^ [ stackTable selection selectedItem receiver ]
+
+	^ [ :dbg | stackTable selection selectedItem receiver ]
 ]
 
 { #category : #'accessing - widgets' }
 StDebugger >> stackTable [
-	^stackTable
+
+	^ stackTable
 ]
 
 { #category : #actions }

--- a/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
+++ b/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
@@ -50,10 +50,13 @@ StDebuggerStackCommandTreeBuilder >> buildDebuggerCommandGroup [
 ]
 
 { #category : #building }
-StDebuggerStackCommandTreeBuilder >> buildSpecCommand: aCommandClass forContext: anObject [
+StDebuggerStackCommandTreeBuilder >> buildSpecCommand: aCommandClass forContext: aBlock [
+
 	| cmd |
-	cmd := super buildSpecCommand: aCommandClass forContext: anObject.
+	cmd := super buildSpecCommand: aCommandClass forContext: stDebuggerInstance.
 	cmd name: aCommandClass shortName.
+	cmd innerCommand transform: aBlock.
+	
 	^ cmd
 ]
 
@@ -211,15 +214,16 @@ StDebuggerStackCommandTreeBuilder >> stackMethodCommandsClasses [
 
 { #category : #commands }
 StDebuggerStackCommandTreeBuilder >> stackMethodNavigationCommands [
-	"Commands to navigate the selected context's method "
-	| group |
 
-	group := (CmCommandGroup named: self stackMethodNavigationGroupName) asSpecGroup.
+	"Commands to navigate the selected context's method "
+
+	| group |
+	group := (CmCommandGroup named: self stackMethodNavigationGroupName)
+		         asSpecGroup.
 	group beDisplayedAsGroup.
 	self stackMethodCommandsClasses do: [ :navCmdClass | 
-		group register: (self
-			buildSpecCommand: navCmdClass
-			forContext: stDebuggerInstance stackSelectionMethodContext) ].
+		group register:
+			(self buildSpecCommand: navCmdClass forContext: stDebuggerInstance) ].
 	^ group
 ]
 
@@ -251,7 +255,7 @@ StDebuggerStackCommandTreeBuilder >> stackMethodSelectorNavigationCommands [
 				register:
 					(self
 						buildSpecCommand: navCmdClass
-						forContext: stDebuggerInstance stackSelectionMethodSelectorContext) ].
+						forContext: stDebuggerInstance "stackSelectionMethodSelectorContext") ].
 	^ group
 ]
 
@@ -282,7 +286,7 @@ StDebuggerStackCommandTreeBuilder >> stackReceiverClassNavigationCommands [
 				register:
 					(self
 						buildSpecCommand: navCmdClass
-						forContext: stDebuggerInstance stackSelectionReceiverClassContext) ].
+						forContext: stDebuggerInstance "stackSelectionReceiverClassContext") ].
 	^ group
 ]
 


### PR DESCRIPTION
These work now when clicking them. I didn't tested the keyboard shortcuts. @hogoww was working on keyboard shortcuts on #371. I checked the changes in his PR, and it looks like there shouldn't have any conflicts with mine.

![Screen Shot 2022-05-23 at 16 05 42](https://user-images.githubusercontent.com/1684221/169837816-fd66636c-4ed4-4d2a-9712-6b60c0126891.png)

Closes #372