### PR TITLE
Adding `debuggerLayout` in TStDebuggerExtensionLayout` to be able to choose the layout the debugger extension should have

### DIFF
--- a/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
+++ b/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
@@ -49,6 +49,12 @@ StDummyDebuggerPresenter >> debuggerExtensionToolName [
 	
 ]
 
+{ #category : #layout }
+StDummyDebuggerPresenter >> defaultLayout [
+
+	^ SpBoxLayout newVertical 
+]
+
 { #category : #mocks }
 StDummyDebuggerPresenter >> fileOutSelectedContext [
 tag := thisContext method selector.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -775,6 +775,7 @@ StDebugger >> initializeWindow: aWindowPresenter [
 StDebugger >> instantiateExtensionToolsPage: aToolClass [
 	| toolInstance |
 	toolInstance := self instantiate: aToolClass on: self.
+	toolInstance layout: toolInstance debuggerLayout.
 	self registerExtensionTool: toolInstance.
 	^ SpNotebookPage
 		title: toolInstance debuggerExtensionToolName

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -52,6 +52,12 @@ TStDebuggerExtension >> debuggerExtensionToolName [
 	^self explicitRequirement 
 ]
 
+{ #category : #layout }
+TStDebuggerExtension >> debuggerLayout [
+
+	^ self defaultLayout
+]
+
 { #category : #'debugger extension' }
 TStDebuggerExtension >> displayOrder [
 	^self class displayOrder


### PR DESCRIPTION
Fixes #375 
Any debugger extension was bound to have its default layout in the debugger.

I've made an improvement so that any debugger extension can specify the layout it will have in the debugger, which is the default layout by default, but could be a totally different layout