### PR TITLE
Adding possibility to add bindings in debugger context interaction model

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
@@ -1,14 +1,154 @@
 Class {
 	#name : #StDebuggerContextInteractionModelTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'instanceVariableForTest',
+		'model'
+	],
 	#category : #'NewTools-Debugger-Tests-Model'
 }
+
+{ #category : #running }
+StDebuggerContextInteractionModelTest >> setUp [
+
+	| context |
+	super setUp.
+	context := [ self helperMethodForBindings ] asContext.
+	context := context stepToCallee.
+	model := StDebuggerContextInteractionModel new.
+	model context: context.
+	model addBinding: (WorkspaceVariable key: 'toto' value: 41)
+
+	"Put here a common initialization logic for tests"
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testAddBinding [
+
+	self assert: (model bindingOf: 'tata') equals: nil.
+
+	model addBinding: (WorkspaceVariable key: 'tata' value: 'titi').
+
+	self
+		assert: ((model bindingOf: 'tata') readInContext: model context)
+		equals: 'titi'
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testAddBindingDeletesOldBindingIfSameKey [
+
+	self
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 41.
+
+	model addBinding: (WorkspaceVariable key: 'toto' value: 42).
+
+	self
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 42
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testBindingOf [
+
+	"These are values given in the setUp method and in the helper method"
+
+	self
+		assert:
+			((model bindingOf: 'tempVariableForTest') readInContext:
+					 model context)
+		equals: nil;
+		assert:
+			((model bindingOf: 'instanceVariableForTest') readInContext:
+					 model context)
+		equals: nil;
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 41.
+	"we step until variables are assigned in context"
+	model context
+		step;
+		step;
+		step;
+		step.
+
+	self
+		assert:
+			((model bindingOf: 'tempVariableForTest') readInContext:
+					 model context)
+		equals: 43;
+		assert:
+			((model bindingOf: 'instanceVariableForTest') readInContext:
+					 model context)
+		equals: 42;
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 41
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testBindingOfPrioritizesContextBindingsToInteractionModelBindings [
+
+	"These are values given in the setUp method and in the helper method"
+
+	"we step until variables are assigned in context"
+
+	model context
+		step;
+		step;
+		step;
+		step.
+
+	self
+		assert:
+			((model bindingOf: 'instanceVariableForTest') readInContext:
+				 model context)
+		equals: 42.
+		
+	model addBinding: (WorkspaceVariable key: 'instanceVariableForTest' value: 'toto').
+	
+	self
+		assert:
+			((model bindingOf: 'instanceVariableForTest') readInContext:
+				 model context)
+		equals: 42.
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testHasBindingsInContextOf [
+
+	self
+		assert: (model hasBindingInContextOf: 'tempVariableForTest');
+		assert: (model hasBindingInContextOf: 'instanceVariableForTest');
+		assert: (model hasBindingInContextOf: 'toto') not;
+		assert: (model hasBindingInContextOf: 'tata') not
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testHasBindingsInInteractionModelOf [
+
+	self
+		assert:
+			(model hasBindingInInteractionModelOf: 'tempVariableForTest') not;
+		assert:
+			(model hasBindingInInteractionModelOf: 'instanceVariableForTest')
+				not;
+		assert: (model hasBindingInInteractionModelOf: 'toto');
+		assert: (model hasBindingInInteractionModelOf: 'tata') not
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testHasBindingsReturnsTrueWhenVariableIsInContextOrInInteractionModel [
+
+	self
+		assert: (model hasBindingOf: 'tempVariableForTest');
+		assert: (model hasBindingOf: 'instanceVariableForTest');
+		assert: (model hasBindingOf: 'toto');
+		assert: (model hasBindingOf: 'tata') not
+]
 
 { #category : #tests }
 StDebuggerContextInteractionModelTest >> testHasUnsavedCodeChanges [
 
-	| model code |
-	model := StDebuggerContextInteractionModel new.
+	| code |
 	model context: [  ] asContext.
 	code := SpCodePresenter new text: [  ] asContext sourceCode.
 	model owner: code.
@@ -17,6 +157,22 @@ StDebuggerContextInteractionModelTest >> testHasUnsavedCodeChanges [
 	
 	code text: 'changed source'.
 	self assert: model hasUnsavedCodeChanges
+]
+
+{ #category : #tests }
+StDebuggerContextInteractionModelTest >> testInteractionModelArePreservedAfterChangingContext [
+
+	self
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 41.
+	self assert: (model hasBindingOf: 'tempVariableForTest').
+
+	model context: [  ] asContext.
+
+	self
+		assert: ((model bindingOf: 'toto') readInContext: model context)
+		equals: 41.
+	self assert: (model hasBindingOf: 'tempVariableForTest') not
 ]
 
 { #category : #tests }

--- a/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
@@ -8,6 +8,15 @@ Class {
 	#category : #'NewTools-Debugger-Tests-Model'
 }
 
+{ #category : #helpers }
+StDebuggerContextInteractionModelTest >> helperMethodForBindings [
+
+	| tempVariableForTest |
+	instanceVariableForTest := 42.
+	tempVariableForTest := 43.
+	^ 44
+]
+
 { #category : #running }
 StDebuggerContextInteractionModelTest >> setUp [
 

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #StDebuggerContextInteractionModel,
 	#superclass : #SpCodeInteractionModel,
 	#instVars : [
-		'context'
+		'context',
+		'bindings'
 	],
 	#category : #'NewTools-Debugger-Model'
 }
@@ -11,6 +12,13 @@ Class {
 StDebuggerContextInteractionModel class >> on: aContext [
 
 	^ self new context: aContext
+]
+
+{ #category : #adding }
+StDebuggerContextInteractionModel >> addBinding: aBinding [
+
+	self flag: 'This is experimental code to add a binding without writing code'.
+	self bindings add: aBinding 
 ]
 
 { #category : #accessing }
@@ -24,9 +32,19 @@ StDebuggerContextInteractionModel >> bindingOf: aString [
 
 	"we can not call #lookupVar: without checking first as it would create the variable"
 
-	^ (self hasBindingOf: aString)
-		  ifTrue: [ (context lookupVar: aString) asDoItVariableFrom: context ]
-		  ifFalse: [ nil ]
+	^ (self hasBindingInContextOf: aString)
+		  ifTrue: [ 
+		  (context lookupVar: aString) asDoItVariableFrom: context ]
+		  ifFalse: [ 
+			  (self hasBindingInInteractionModelOf: aString)
+				  ifTrue: [ self bindings associationAt: aString ]
+				  ifFalse: [ nil ] ]
+]
+
+{ #category : #accessing }
+StDebuggerContextInteractionModel >> bindings [
+
+	^ bindings ifNil: [ bindings := Dictionary new ]
 ]
 
 { #category : #accessing }
@@ -53,9 +71,24 @@ StDebuggerContextInteractionModel >> doItReceiver [
 ]
 
 { #category : #testing }
-StDebuggerContextInteractionModel >> hasBindingOf: aString [
+StDebuggerContextInteractionModel >> hasBindingInContextOf: aString [
 	"we lookup the name without creating a new variable"
 	^ (context lookupVar: aString declare: false) notNil
+]
+
+{ #category : #testing }
+StDebuggerContextInteractionModel >> hasBindingInInteractionModelOf: aString [
+	"we search the name in the interaction model as we would do in a playground"
+	^ self bindings includesKey: aString
+]
+
+{ #category : #testing }
+StDebuggerContextInteractionModel >> hasBindingOf: aString [
+
+	"we lookup the name without creating a new variable then we search in the interaction model"
+
+	^ (self hasBindingInContextOf: aString) or: [ 
+		  self hasBindingInInteractionModelOf: aString ]
 ]
 
 { #category : #testing }

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -35,10 +35,7 @@ StDebuggerContextInteractionModel >> bindingOf: aString [
 	^ (self hasBindingInContextOf: aString)
 		  ifTrue: [ 
 		  (context lookupVar: aString) asDoItVariableFrom: context ]
-		  ifFalse: [ 
-			  (self hasBindingInInteractionModelOf: aString)
-				  ifTrue: [ self bindings associationAt: aString ]
-				  ifFalse: [ nil ] ]
+		  ifFalse: [ self bindings associationAt: aString ifAbsent: [ nil ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This is experimental code that will be used to add bindings in the debugger code presenters. This could be used to instrument code by manipulating objects from anywhere in Pharo, in order to debug something. I think this is quite in adequation with the "playground programming style" that Pharo has.

Notably, I would need this for Chest, which is  a debugger extension that allows to store objects from anywhere in Pharo and to load them into any playground (or debugger if this PR is accepted):  https://github.com/adri09070/Chest
In the end, we will try with @StevenCostiou to load any object from Chest in any method by annotating its AST