### PR TITLE
[improvement] Debugger Commands shortcuts are now displayed in tooltip

### DIFF
--- a/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
@@ -103,7 +103,13 @@ StDebuggerCommand >> initialize [
 		stream 
 			<< self class defaultName
 			<< ': '
-			<< self class defaultDescription ])
+			<< self class defaultDescription.
+			self class defaultShortcut ifNotNil: [ :shortCut |
+				stream << '('	
+				<< shortCut printString
+				<< ')'  
+				]
+			])
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
When passing the mouse on a button for a debugger action, it wasn't displaying the shortcut.
Many people do not know it (Myself included for reasons).
This PR adds the shortcut inside the description of the debug action in the tooltip