### PR TITLE
fixing createSubclassResponsibility not to allow creating a subclass responsibility in a super class of the abstract class

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -427,7 +427,7 @@ StDebugger >> createSubclassResponsibility [
 		       arguments: senderContext arguments.
 	msgCategory := senderContext methodClass organization 
 		               categoryOfElement: msg selector.
-	chosenClass := self requestClassFrom: senderContext receiver class.
+	chosenClass := self requestClassFrom: senderContext receiver class to: senderContext methodClass.
 	chosenClass ifNil: [ ^ self ].
 	self debuggerActionModel
 		implement: msg
@@ -951,8 +951,18 @@ StDebugger >> removeSessionHolderSubscriptions [
 { #category : #'ui requests' }
 StDebugger >> requestClassFrom: aClass [
 
+	^ self requestClassFrom: aClass to: ProtoObject
+
+	
+]
+
+{ #category : #'ui requests' }
+StDebugger >> requestClassFrom: aClass to: aSuperclass [
+
 	self class fastTDD ifTrue: [ ^ aClass ].
-	^ self requestSuperclassOf: aClass to: ProtoObject
+	^ self requestSuperclassOf: aClass to: aSuperclass 
+
+	
 ]
 
 { #category : #'ui requests' }


### PR DESCRIPTION
Fixes #356.

When a user wanted to implement a subclass responsibility, the debugger allowed to define it in a superclass of the abstract method. So, if you executed again the code requiring to implement a subclass responsibility, the debugger would still ask to implement the subclass responsibility.

We have fixed with @RomainDeg and @RemiDufloer  so that the debugger only allows to implement the subclass responsibility in the class hierarchy from the class of the receiver to the class delegating responsibility to its subclasses