### PR TITLE
Show keyboard shortcuts on Debugger commands' tooltips

### DIFF
--- a/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
@@ -99,9 +99,14 @@ StDebuggerCommand >> hash [
 StDebuggerCommand >> initialize [
 
 	super initialize.
-	self description: (String streamContents: [ :stream | 
+	self description: (String streamContents: [ :stream | | shortcut |
 		stream 
 			<< self class defaultName
 			<< ': '
-			<< self class defaultDescription ])
+			<< self class defaultDescription.
+		shortcut := self class defaultShortcut.
+		shortcut ifNotNil: [stream	
+			<< ' ['
+			<< shortcut asString
+			<< ']' ]])
 ]


### PR DESCRIPTION
https://user-images.githubusercontent.com/21206379/175566018-2684e78e-aa3e-47e4-8b0f-6266ca67d1f2.mov

Credits to @aboubacardiawara and @DelGaylord, who worked along me on adding this.