### PR TITLE
Autocomplete Spotter with current text selection

### DIFF
--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -136,9 +136,7 @@ StSpotter class >> menuCommandOn: aBuilder [
 { #category : #'instance creation' }
 StSpotter class >> open [
 
-	self reset.
-	spotter := self new.
-	^ spotter openModal
+	self openWithText: ''
 ]
 
 { #category : #'instance creation' }
@@ -153,6 +151,17 @@ StSpotter class >> openOn: aModel [
 StSpotter class >> openOnOrigin: anObject [
 
 	^ self openOn: (StSpotterModel newOrigin: anObject)
+]
+
+{ #category : #'instance creation' }
+StSpotter class >> openWithText: aText [
+
+	self reset.
+	spotter := self new.
+	spotter searchText
+		text: aText asString.
+	spotter whenDisplayDo: [ spotter searchText cursorPositionIndex: aText size + 1 ].
+	^ spotter open
 ]
 
 { #category : #settings }

--- a/src/NewTools-Spotter/ToolShortcutsCategory.extension.st
+++ b/src/NewTools-Spotter/ToolShortcutsCategory.extension.st
@@ -7,5 +7,9 @@ ToolShortcutsCategory >> openSpotter [
 
 	^ KMKeymap
 			shortcut: Character cr shift
-			action: [ Smalltalk tools spotter open ]
+			action: [ :target | | selection |
+				selection := target selection.
+				selection ifNotNil: [ Smalltalk tools spotter openWithText: selection ]
+					ifNil: [ Smalltalk tools spotter open ]
+				]
 ]


### PR DESCRIPTION
When opening the Spotter, the search bar's content is pre-filled using the text selection from the tab that is currently focused. If there's no text selected, the search bar starts empty (as it did before).

https://user-images.githubusercontent.com/21206379/176134012-ddcf6b8d-8d3b-4794-9093-e95f69ed4493.mov

Credits to @aboubacardiawara and @DelGaylord, who worked along me on adding this.

⚠️ **Important:** Needs to be integrated alongside https://github.com/pharo-project/pharo/pull/11418