### PR TITLE
Fix-Menu-Inspector-Meta

### DIFF
--- a/src/NewTools-Inspector/StInspection.class.st
+++ b/src/NewTools-Inspector/StInspection.class.st
@@ -41,6 +41,11 @@ StInspection >> context: aContext [
 ]
 
 { #category : #testing }
+StInspection >> enableSlotMenuEntries [
+	^false
+]
+
+{ #category : #testing }
 StInspection >> hasOutputActivationPort [
 
 	^ false

--- a/src/NewTools-Inspector/StRawInspection.class.st
+++ b/src/NewTools-Inspector/StRawInspection.class.st
@@ -66,6 +66,11 @@ StRawInspection >> defaultOutputPort [
 ]
 
 { #category : #testing }
+StRawInspection >> enableSlotMenuEntries [
+	^ self selectedItem class == StInspectorSlotNode
+]
+
+{ #category : #testing }
 StRawInspection >> hasOutputActivationPort [
 
 	^ true

--- a/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
@@ -24,6 +24,5 @@ StBreakpointCommand >> appliesTo: aTool [
 
 { #category : #testing }
 StBreakpointCommand >> canBeExecuted [
-
-	^ context selectedItem class == StInspectorSlotNode
+	^ context enableSlotMenuEntries
 ]


### PR DESCRIPTION
This PR improves the implementation of not showing slot related menu entries for non-slots

fixes https://github.com/pharo-project/pharo/issues/11213