### PR TITLE
Updating Sindarin to Pharo-11 branch

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -167,5 +167,5 @@ BaselineOfNewTools >> sindarin: spec [
 		spec
 			repository: (self packageRepositoryURL 
 				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo-11' ]);
-			loads: 'Core' ]
+			loads: 'default' ]
 ]

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -166,6 +166,6 @@ BaselineOfNewTools >> sindarin: spec [
 	spec baseline: 'Sindarin' with: [ 
 		spec
 			repository: (self packageRepositoryURL 
-				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo-10' ]);
+				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo-11' ]);
 			loads: 'Core' ]
 ]


### PR DESCRIPTION
BaselineOfNewTools was importing the Pharo-10 branch of the https://github.com/pharo-spec/ScriptableDebugger repository.

I have reworked this repository on a Pharo-11 branch so the changes made on this branch are not synched with what's imported by NewTools.

Plus, the CI used to be red because of Sindarin tests but I have fixed them on the Pharo-11 branch so it looks like it's a good time to change the version of Sindarin that must be imported :)