### PR TITLE
Optimized-timesRepeat

### DIFF
--- a/src/NewTools-Sindarin-Commands-Tests/SindarinTestObjectToVisit.class.st
+++ b/src/NewTools-Sindarin-Commands-Tests/SindarinTestObjectToVisit.class.st
@@ -33,7 +33,7 @@ SindarinTestObjectToVisit >> acceptVisitorMultipleObjects: aVisitor [
 { #category : #visitors }
 SindarinTestObjectToVisit >> acceptVisitorNeverFinishes: aVisitor [
 
-	10000 timesRepeat: [ self doStuff ]
+	self timesRepeat: [ self doStuff ]
 ]
 
 { #category : #visitors }
@@ -63,4 +63,10 @@ SindarinTestObjectToVisit >> doNotAcceptVisitor: aVisitor [
 SindarinTestObjectToVisit >> doStuff [
 
 	^ self
+]
+
+{ #category : #enumerating }
+SindarinTestObjectToVisit >> timesRepeat: aBlock [
+	"we implement it here to not use the optimized timesRepeat:"
+	10000 timesRepeat: aBlock
 ]


### PR DESCRIPTION
this changes SindarinTestObjectToVisit to not make testStepToNextCallInClassNeverFinishes fail if we compile #timesRepeat: optimized