### PR TITLE
Revert "Migration of events from the debugger UI to the debugger action model to automate its updates"

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -54,7 +54,7 @@ StDebuggerActionModelTest >> benchmarkFilterStack [
 { #category : #helper }
 StDebuggerActionModelTest >> changeSession: aDebugSession [
 
-	debugActionModel clear; clearDebugSession.
+	session clear.
 	session := aDebugSession.
 	debugActionModel := StDebuggerActionModel on: session
 ]
@@ -110,27 +110,24 @@ StDebuggerActionModelTest >> setResult [
 
 { #category : #running }
 StDebuggerActionModelTest >> setUp [
-	| method context process dummyActionModel |
+	| method context process |
 	super setUp.
 	method := self class >> #setResult.
 	process := [ method valueWithReceiver: self arguments: #() ]
 		newProcess.
 	context := process suspendedContext.
 	session ifNotNil: [ session clear ].
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                    context) debuggerActionModel.
-	session := dummyActionModel session.
-	dummyActionModel clear.
-	session stepIntoUntil: [ :currentContext | 
-		currentContext method == method ].
+	session := (StTestDebuggerProvider new debuggerWithContext: context)
+		session.
+	session
+		stepIntoUntil: [ :currentContext | currentContext method == method ].
 	debugActionModel := StDebuggerActionModel on: session.
 	shouldFilterStack := StDebuggerActionModel shouldFilterStack.
 ]
 
 { #category : #running }
 StDebuggerActionModelTest >> tearDown [
-	debugActionModel clear.
-	debugger ifNotNil: [ debugger clear].
+	debugger ifNotNil: [ debugger close].
 	session ifNotNil: [ session clear ].
 	session := nil.
 	StDebuggerUsingSpecSelectorMock removeSelector: #testMethod.
@@ -154,15 +151,11 @@ StDebuggerActionModelTest >> testClearDebugSession [
 
 { #category : #'tests - contexts' }
 StDebuggerActionModelTest >> testComputeInitialTopContext [
-	|newSession dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	|newSession|
+	self changeSession: StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext session.
 	self assert: debugActionModel topContext identicalTo: session exception signalContext.
 	
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext debuggerActionModel.
-	newSession := dummyActionModel session.
-	dummyActionModel clear.
+	newSession := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext session.
 	newSession restart: newSession interruptedContext sender.	
 	self changeSession: newSession.
 	self assert: debugActionModel topContext identicalTo: session interruptedContext
@@ -192,20 +185,16 @@ StDebuggerActionModelTest >> testDefaultShouldFilterStack [
 { #category : #'tests - stack filtering' }
 StDebuggerActionModelTest >> testDynamicShouldFilterStack [
 
-	| mockDebugActionModel |
+	|mockDebugActionModel|
 	mockDebugActionModel := StMockDebuggerActionModel new.
-
+	
 	self assert: mockDebugActionModel filterStack.
-
+	
 	StDebuggerActionModel shouldFilterStack: true.
 	self assert: mockDebugActionModel shouldFilterStack.
-
+	
 	StDebuggerActionModel shouldFilterStack: false.
-	self deny: mockDebugActionModel shouldFilterStack.
-
-	mockDebugActionModel
-		clear;
-		clearDebugSession
+	self deny: mockDebugActionModel shouldFilterStack 
 ]
 
 { #category : #'tests - stack filtering' }
@@ -230,8 +219,6 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 	self deny: mockDebugActionModel filterStack.
 	self deny: mockDebugActionModel shouldFilterStack.
 	
-	mockDebugActionModel clear; clearDebugSession.
-	
 	mockDebugActionModel := StMockDebuggerActionModel new.		
 	self assert: mockDebugActionModel filterStack.
 	self assert: mockDebugActionModel shouldFilterStack.
@@ -249,8 +236,6 @@ StDebuggerActionModelTest >> testDynamicShouldFilterStackUpdate [
 	mockDebugActionModel stepOver: context.
 	self assert: mockDebugActionModel filterStack.
 	self assert: mockDebugActionModel shouldFilterStack.
-	
-	mockDebugActionModel clear; clearDebugSession
 	
 	
 	
@@ -275,10 +260,8 @@ StDebuggerActionModelTest >> testFileOutMethod [
 { #category : #'tests - stack filtering' }
 StDebuggerActionModelTest >> testFilterDNUStack [
 
-	|stack filteredStack dummyActionModel|
-	dummyActionModel := StTestDebuggerProvider new debuggerWithDNUContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	|stack filteredStack|
+	self changeSession: StTestDebuggerProvider new debuggerWithDNUContext session.
 	stack := OrderedCollection new.
 	
 	"First, the stack contains a top context (i.e. from which a signal was sent), then the interrupted context"
@@ -302,12 +285,10 @@ StDebuggerActionModelTest >> testFilterDNUStack [
 { #category : #'tests - stack filtering' }
 StDebuggerActionModelTest >> testFilterMissingSubclassResponsibilityStack [
 
-	|stack filteredStack dummyActionModel|	
+	|stack filteredStack|	
 	
 	"We change the stack with an interrupted context that does not contain the <debuggerCompleteToSender> pragma"
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext session.
 	stack := OrderedCollection new.
 	stack add: debugActionModel topContext.
 	stack add: debugActionModel topContext sender.
@@ -324,10 +305,8 @@ StDebuggerActionModelTest >> testFilterMissingSubclassResponsibilityStack [
 { #category : #'tests - stack filtering' }
 StDebuggerActionModelTest >> testFilterStack [
 
-	|stack filteredStack dummyActionModel|
-	dummyActionModel := StTestDebuggerProvider new debuggerWithDNUContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	|stack filteredStack|
+	self changeSession: StTestDebuggerProvider new debuggerWithDNUContext session.
 	stack := OrderedCollection new.
 	
 	"First, add to the stack a MNU context that has a method with the <debuggerCompleteToSender> pragma"
@@ -432,10 +411,7 @@ StDebuggerActionModelTest >> testInterruptedProcessProvidesSameProcessAsTheSessi
 
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsContextAnAssertionFailure [
-	| dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithFailingAssertionContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithFailingAssertionContext session.
 	self assert: debugActionModel isContextAnAssertionFailure
 ]
 
@@ -446,12 +422,10 @@ StDebuggerActionModelTest >> testIsContextSteppable [
 
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsInterruptedContextAnAssertEqualsFailure [
-	| dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithFailingAssertionContext debuggerActionModel.
+
 	self changeSession:
-		dummyActionModel
+		StTestDebuggerProvider new debuggerWithFailingAssertionContext
 			session.
-	dummyActionModel clear.
 	self assert: debugActionModel isContextAnAssertionFailure
 ]
 
@@ -463,22 +437,16 @@ StDebuggerActionModelTest >> testIsInterruptedContextDead [
 
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsInterruptedContextDoesNotUnderstand [
-	| dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithDNUContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithDNUContext session.
 	self assert: debugActionModel isInterruptedContextDoesNotUnderstand.
 	StTestDebuggerProvider compile: 'foobar ^self'.
 	self deny: debugActionModel isInterruptedContextDoesNotUnderstand
 ]
 
 { #category : #'tests - predicates' }
-StDebuggerActionModelTest >> testIsInterruptedContextMissingClassException [
-	| dummyActionModel |
+StDebuggerActionModelTest >> testIsInterruptedContextMissingClassException [	
 	StTestDebuggerProvider compileMissingClassContextBuilder.
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingClassContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithMissingClassContext session.
 	self assert: debugActionModel isInterruptedContextMissingClassException
 ]
 
@@ -490,21 +458,17 @@ StDebuggerActionModelTest >> testIsInterruptedContextPostMortem [
 
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testIsInterruptedContextSubclassResponsibilityException [
-	| dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext session.
 	self assert: debugActionModel isInterruptedContextSubclassResponsibilityException
 ]
 
 { #category : #'tests - actions' }
 StDebuggerActionModelTest >> testPeelToFirstLike [
 
-	| firstCaller dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithRecursiveContext debuggerActionModel.
+	| firstCaller |
+	
 	self changeSession:
-		dummyActionModel session.
-	dummyActionModel clear.
+		StTestDebuggerProvider new debuggerWithRecursiveContext session.
 		
 	session stepInto.
 	session stepInto.
@@ -673,7 +637,7 @@ StDebuggerActionModelTest >> testStepInto [
 StDebuggerActionModelTest >> testStepIntoQuickMethods [
 	|ctx|
 	ctx := StMockContext new.
-	debugActionModel clearDebugSession; session: (StMockSession new).
+	debugActionModel session: StMockSession new.
 	debugActionModel stepInto: ctx.
 	
 	"When we step into a context, first that context is configured to step into quick method (aContext stepIntoQuickMethod: true),
@@ -720,11 +684,9 @@ StDebuggerActionModelTest >> testStepThrough [
 { #category : #'tests - predicates' }
 StDebuggerActionModelTest >> testUpdateDebugSession [
 
-	| exception dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new
-		                    debuggerWithErrorContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	| exception |
+	self changeSession:
+		StTestDebuggerProvider new debuggerWithErrorContext session.
 	exception := session exception.
 	session exception: nil.
 	debugActionModel updateDebugSession.
@@ -735,10 +697,7 @@ StDebuggerActionModelTest >> testUpdateDebugSession [
 { #category : #'tests - contexts' }
 StDebuggerActionModelTest >> testUpdateTopContext [
 	
-	| dummyActionModel |
-	dummyActionModel := StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext debuggerActionModel.
-	self changeSession: dummyActionModel session.
-	dummyActionModel clear.
+	self changeSession: StTestDebuggerProvider new debuggerWithMissingSubclassResponsibilityContext session.
 	self deny: debugActionModel topContext identicalTo: debugActionModel interruptedContext.
 	debugActionModel updateTopContext.		
 	self assert: debugActionModel topContext identicalTo: debugActionModel interruptedContext
@@ -753,38 +712,31 @@ StDebuggerActionModelTest >> testUpdateTopContextAfterSessionOperation [
 	context := [  ] asContext.
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepInto: context.
-	self assert: mockDebugActionModel tag equals: #updateTopContext.	
-	mockDebugActionModel clear; clearDebugSession.
+	self assert: mockDebugActionModel tag equals: #updateTopContext.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepOver: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepThrough: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel restartContext: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel returnValueFromExpression: 'nil' fromContext: [] asContext.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel runToSelection: nil inContext: nil.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
 	
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel implement: nil classified: nil inClass: nil forContext: nil.
-	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
+	self assert: mockDebugActionModel tag equals: #updateTopContext
 	
 	
 	

--- a/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
@@ -27,120 +27,89 @@ StDebuggerCommandTest >> tearDown [
 { #category : #tests }
 StDebuggerCommandTest >> testCommandsInDNUContext [
 
-	| debugger |
+	|debugger|
 	debugger := debuggerProvider debuggerWithDNUContext.
-
+	
 	"Executable commands relative to context"
-	self assert:
-		(StDefineMethodCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StDefineMissingEntityCommand forContext: debugger) canBeExecuted.
-	self assert: (StRestartCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StReturnValueCommand forContext: debugger) canBeExecuted.
-
+	self assert: (StDefineMethodCommand forContext: debugger) canBeExecuted.
+	self assert: (StDefineMissingEntityCommand forContext: debugger) canBeExecuted.  
+	self assert: (StRestartCommand forContext: debugger) canBeExecuted. 
+	self assert: (StReturnValueCommand forContext: debugger) canBeExecuted. 
+	
 	"Non-executable commands relative to context"
-	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepOverCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
 	self deny: (StProceedCommand forContext: debugger) canBeExecuted.
-	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StDefineSubclassResponsabilityCommand forContext: debugger)
-			canBeExecuted.
-
+	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.  
+	
 	"Executable commands, whatever the context"
-	self assert:
-		(StCopyStackToClipboardCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StFileOutMethodCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StPeelToFirstCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StShowFullStackCommand forContext: debugger) canBeExecuted.
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-
-	debugger debuggerActionModel clear
+	self assert: (StCopyStackToClipboardCommand forContext: debugger) canBeExecuted. 
+	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
+	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
+	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
 StDebuggerCommandTest >> testCommandsInDeadContext [
 
-	| debugger |
+	|debugger|
+
 	debugger := debuggerProvider debuggerWithErrorContext.
 	debugger debuggerActionModel contextPredicate context pc: nil.
-
+		
 	"Non-executable commands relative to context"
-	self deny: (StRestartCommand forContext: debugger) canBeExecuted.
-	self deny: (StReturnValueCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepOverCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self deny: (StRestartCommand forContext: debugger) canBeExecuted. 
+	self deny: (StReturnValueCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
 	self deny: (StProceedCommand forContext: debugger) canBeExecuted.
-	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StDefineSubclassResponsabilityCommand forContext: debugger)
-			canBeExecuted.
+	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.  
 	self deny: (StDefineMethodCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StDefineMissingEntityCommand forContext: debugger) canBeExecuted.
-
+	self deny: (StDefineMissingEntityCommand forContext: debugger) canBeExecuted.  
+	
 	"Executable commands, whatever the context"
-	self assert:
-		(StCopyStackToClipboardCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StFileOutMethodCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StPeelToFirstCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StShowFullStackCommand forContext: debugger) canBeExecuted.
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-
-	debugger debuggerActionModel clear
+	self assert: (StCopyStackToClipboardCommand forContext: debugger) canBeExecuted. 
+	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
+	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
+	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
 StDebuggerCommandTest >> testCommandsInErrorContext [
 
-	| debugger |
+	|debugger|
+
 	debugger := debuggerProvider debuggerWithErrorContext.
-
-	"Executable commands relative to context"
-	self assert: (StRestartCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StReturnValueCommand forContext: debugger) canBeExecuted.
-
+		
+	"Executable commands relative to context"	
+	self assert: (StRestartCommand forContext: debugger) canBeExecuted. 
+	self assert: (StReturnValueCommand forContext: debugger) canBeExecuted. 
+	
 	"Non-executable commands relative to context"
-	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepOverCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
 	self deny: (StProceedCommand forContext: debugger) canBeExecuted.
-	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StDefineSubclassResponsabilityCommand forContext: debugger)
-			canBeExecuted.
+	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.  
 	self deny: (StDefineMethodCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StDefineMissingEntityCommand forContext: debugger) canBeExecuted.
-
+	self deny: (StDefineMissingEntityCommand forContext: debugger) canBeExecuted.  
+	
 	"Executable commands, whatever the context"
-	self assert:
-		(StCopyStackToClipboardCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StFileOutMethodCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StPeelToFirstCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StShowFullStackCommand forContext: debugger) canBeExecuted.
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-
-	debugger debuggerActionModel clear
+	self assert: (StCopyStackToClipboardCommand forContext: debugger) canBeExecuted. 
+	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
+	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
+	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
@@ -170,8 +139,7 @@ StDebuggerCommandTest >> testCommandsInFailingTestContext [
 	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
 	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
 	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-	debugger debuggerActionModel clear
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
@@ -204,49 +172,36 @@ StDebuggerCommandTest >> testCommandsInMissingClassContext [
 	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
 	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
 	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-	debugger debuggerActionModel clear
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
 StDebuggerCommandTest >> testCommandsInMissingSubclassResponsibilityContext [
 
-	| debugger |
-	debugger := debuggerProvider
-		            debuggerWithMissingSubclassResponsibilityContext.
-
+	|debugger|
+	debugger := debuggerProvider debuggerWithMissingSubclassResponsibilityContext.
+	
 	"Executable commands relative to context"
-	self assert:
-		(StDefineSubclassResponsabilityCommand forContext: debugger)
-			canBeExecuted.
-	self assert:
-		(StDefineMissingEntityCommand forContext: debugger) canBeExecuted.
-	self assert: (StRestartCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StReturnValueCommand forContext: debugger) canBeExecuted.
-
+	self assert: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.
+	self assert: (StDefineMissingEntityCommand forContext: debugger) canBeExecuted.  
+	self assert: (StRestartCommand forContext: debugger) canBeExecuted. 
+	self assert: (StReturnValueCommand forContext: debugger) canBeExecuted. 
+	
 	"Non-executable commands relative to context"
-	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepOverCommand forContext: debugger) canBeExecuted.
-	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted.
-	self deny:
-		(StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
 	self deny: (StProceedCommand forContext: debugger) canBeExecuted.
-	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.
-	self deny: (StDefineMethodCommand forContext: debugger) canBeExecuted.
-
+	self deny: (StDefineClassCommand forContext: debugger) canBeExecuted.  
+	self deny: (StDefineMethodCommand forContext: debugger) canBeExecuted.  
+	
 	"Executable commands, whatever the context"
-	self assert:
-		(StCopyStackToClipboardCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StFileOutMethodCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StPeelToFirstCommand forContext: debugger) canBeExecuted.
-	self assert:
-		(StShowFullStackCommand forContext: debugger) canBeExecuted.
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-
-	debugger debuggerActionModel clear
+	self assert: (StCopyStackToClipboardCommand forContext: debugger) canBeExecuted. 
+	self assert: (StFileOutMethodCommand forContext: debugger) canBeExecuted. 
+	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
+	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.	
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #tests }
@@ -276,8 +231,7 @@ StDebuggerCommandTest >> testCommandsInRunnableContext [
 	self assert: (StPeelToFirstCommand forContext: debugger) canBeExecuted. 
 	self assert: (StShowFullStackCommand forContext: debugger) canBeExecuted.
 	self assert: (StProceedCommand forContext: debugger) canBeExecuted.  	 
-	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted.
-	debugger debuggerActionModel clear
+	self assert: (StWhereIsCommand forContext: debugger) canBeExecuted. 
 ]
 
 { #category : #'tests - execution' }
@@ -315,8 +269,8 @@ StDebuggerCommandTest >> testStDefineMethodCommandExecution [
 
 { #category : #'tests - execution' }
 StDebuggerCommandTest >> testStDefineMissingEntityCommandExecution [
-
-	| debugger command oldActionModel |
+	| debugger command |
+	
 	StTestDebuggerProvider compileMissingClassContextBuilder.
 	debugger := debuggerProvider debuggerWithDNUContext.
 	command := StDefineMissingEntityCommand forContext: debugger.
@@ -325,29 +279,20 @@ StDebuggerCommandTest >> testStDefineMissingEntityCommandExecution [
 		equals: StDefineMissingEntityCommand allSubclasses.
 	self
 		assert: command applicableCommand class
-		identicalTo: StDefineMethodCommand.
-
-	oldActionModel := debugger debuggerActionModel.
+		identicalTo: StDefineMethodCommand.	
+	
 	debugger := debuggerProvider debuggerWithMissingClassContext.
 	command := StDefineMissingEntityCommand forContext: debugger.
-	oldActionModel clear.
-	oldActionModel session clear.
 	self
 		assert: command applicableCommand class
 		identicalTo: StDefineClassCommand.
-
-	oldActionModel := debugger debuggerActionModel.
-	debugger := debuggerProvider
-		            debuggerWithMissingSubclassResponsibilityContext.
+		
+	debugger := debuggerProvider debuggerWithMissingSubclassResponsibilityContext.
 	command := StDefineMissingEntityCommand forContext: debugger.
-
 	self
 		assert: command applicableCommand class
 		identicalTo: StDefineSubclassResponsabilityCommand.
-
-	oldActionModel clear.
-	oldActionModel session clear.
-	debugger debuggerActionModel clear
+	
 ]
 
 { #category : #'tests - execution' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -78,7 +78,7 @@ StDebuggerTest >> replaceMethodWithQuickMethodStepping [
 	dbg code type: newSource.
 	dbg code update.
 	dbg acceptCodeChanges: newSource forContext: context.
-	dbg debuggerActionModel updateIfAble 
+	dbg updateStep
 ]
 
 { #category : #running }
@@ -95,15 +95,11 @@ StDebuggerTest >> tearDown [
 	session clear.
 	self debuggerClass fastTDD: oldFastTDD.
 	debugger ifNotNil: [ 
+		debugger unsubscribeFromSystemAnnouncer.
 		debugger close.
-		debugger debuggerActionModel ifNotNil: [ :actionModel | 
-			actionModel session ifNotNil: [ :s | s clear ].
-			actionModel unsubscribeFromSystemAnnouncer ] ].
-	StTestDebuggerProvider removeSelector: #foobar.
-	StDebuggerObjectForTests
-		compile:
-		'haltingMethod <haltOrBreakpointForTesting> self halt. ^self'
-		classified: 'util'.
+		debugger session ifNotNil: [ :s | s clear ] ].
+	StTestDebuggerProvider removeSelector: #foobar. 
+	StDebuggerObjectForTests compile: 'haltingMethod <haltOrBreakpointForTesting> self halt. ^self' classified: 'util'.
 	super tearDown
 ]
 

--- a/src/NewTools-Debugger-Tests/StMockSession.class.st
+++ b/src/NewTools-Debugger-Tests/StMockSession.class.st
@@ -8,12 +8,6 @@ Class {
 	#category : #'NewTools-Debugger-Tests-Utils'
 }
 
-{ #category : #'reflective operations' }
-StMockSession >> doesNotUnderstand: aMessage [
-
-	^ self
-]
-
 { #category : #'debug - session' }
 StMockSession >> implement: aMessage classified: messageCategory inClass: aClass forContext: aContext [
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -75,6 +75,7 @@ Class {
 	#traits : 'TDebugger',
 	#classTraits : 'TDebugger classTrait',
 	#instVars : [
+		'sessionHolder',
 		'code',
 		'toolbar',
 		'stackTable',
@@ -129,14 +130,13 @@ StDebugger class >> closeAllDebuggers [
 
 { #category : #'instance creation' }
 StDebugger class >> debugSession: aDebugSession [
+	| debugger |
 
-	| debugger debugActionModel |
-	debugActionModel := StDebuggerActionModel on: aDebugSession.
 	debugger := self on: aDebugSession.
-	aDebugSession application ifNotNil: [ :app | 
-		debugger application: app ].
+	aDebugSession application 
+		ifNotNil: [ :app | debugger application: app ].
 	debugger openWithFullView.
-
+	
 	^ debugger
 ]
 
@@ -224,12 +224,6 @@ StDebugger class >> taskbarIconName [
 	^#smallDebug
 ]
 
-{ #category : #'updating - widgets' }
-StDebugger class >> updateBlockFor: aDebugger [
-
-	^ [ aDebugger updateStep ]
-]
-
 { #category : #'tools registry' }
 StDebugger class >> usesExtensions [
 
@@ -311,8 +305,8 @@ StDebugger >> clear [
 	extensionToolsNotebook pages do: [ :page | 
 		page activePresenter windowIsClosing ].
 	extensionTools := nil.
-	self debuggerActionModel unsubscribeFromSystemAnnouncer.
-	self unsubscribeFromActionModel.
+	self unsubscribeFromSystemAnnouncer.	
+	self removeActionsForSession: self session.
 	
 	"When we programmatically close the window, we do not need to terminate the session as it was already cleared"
 	programmaticallyClosed ifTrue: [ ^ self ].
@@ -455,6 +449,7 @@ StDebugger >> currentContext [
 { #category : #accessing }
 StDebugger >> debuggerActionModel [
 	^ debuggerActionModel
+		ifNil: [ debuggerActionModel := StDebuggerActionModel on: self session]
 ]
 
 { #category : #accessing }
@@ -611,10 +606,7 @@ StDebugger >> findFirstRelevantStackIndexIn: aStack [
 
 { #category : #'updating - session' }
 StDebugger >> forceSessionUpdate [
-
-	self
-		updateStackFromSession: self session;
-		updateExtensionsFrom: self session
+	self sessionHolder valueChanged
 ]
 
 { #category : #api }
@@ -632,8 +624,9 @@ StDebugger >> initialExtent [
 StDebugger >> initialize [
 	super initialize.
 	self debuggerActionModel updateContextPredicate.			
-	self subscribeToActionModel.
+	self setSessionHolderSubscriptions.
 	self forceSessionUpdate.
+	self subscribeToMethodAddedAnnouncement.
 	
 	programmaticallyClosed := false.
 ]
@@ -896,7 +889,7 @@ StDebugger >> printReceiverClassInContext: aContext [
 { #category : #actions }
 StDebugger >> proceedDebugSession [
 
-	self unsubscribeFromActionModel .
+	self removeActionsForSession: self session.
 	self debuggerActionModel proceedDebugSession.
 	self close
 ]
@@ -918,9 +911,41 @@ StDebugger >> recordUnsavedCodeChanges [
 	self unsavedCodeChanges at: codeInteractionModel context put: codeText
 ]
 
+{ #category : #'updating - session' }
+StDebugger >> registerActionsForSession: aSession [
+	self flag: 'Rewrite it'.
+	aSession
+		ifNotNil: [ aSession
+				when: #restart send: #updateRestart to: self;
+				when: #resume send: #updateResume to: self;
+				when: #stepInto send: #updateStepInto to: self;
+				when: #stepOver send: #updateStepOver to: self;
+				when: #stepThrough send: #updateStepThrough to: self;
+				when: #contextChanged send: #updateContextChanged to: self ]
+]
+
 { #category : #extensions }
 StDebugger >> registerExtensionTool: anExtension [
 	self extensionTools add: anExtension
+]
+
+{ #category : #'updating - session' }
+StDebugger >> removeActionsForSession: aSession [
+	self flag: 'Rewrite it'.
+	aSession
+		ifNotNil: [ aSession
+				removeActionsForEvent: #restart;
+				removeActionsForEvent: #resume;
+				removeActionsForEvent: #stepInto;
+				removeActionsForEvent: #stepOver;
+				removeActionsForEvent: #stepThrough;
+				removeActionsForEvent: #contextChanged ]
+]
+
+{ #category : #'updating - session' }
+StDebugger >> removeSessionHolderSubscriptions [
+	self sessionHolder announcer unsubscribe: self sessionHolder.
+	self removeActionsForSession: self session
 ]
 
 { #category : #'ui requests' }
@@ -1033,23 +1058,33 @@ StDebugger >> selectedContext [
 
 { #category : #accessing }
 StDebugger >> session [
-	^ self debuggerActionModel session
+	^ self sessionHolder value
 ]
 
 { #category : #accessing }
 StDebugger >> session: aSession [
+	self sessionHolder value: aSession
+]
 
-	debuggerActionModel
-		ifNil: [ 
-			debuggerActionModel := StDebuggerActionModel on: aSession.
-			self subscribeToActionModel ]
-		ifNotNil: [ debuggerActionModel session: aSession ]
+{ #category : #accessing }
+StDebugger >> sessionHolder [
+	^ sessionHolder ifNil: [ sessionHolder := nil asValueHolder ]
 ]
 
 { #category : #initialization }
 StDebugger >> setModelBeforeInitialization: aSession [
 
 	self session: aSession
+]
+
+{ #category : #'updating - session' }
+StDebugger >> setSessionHolderSubscriptions [
+	self sessionHolder
+		whenChangedDo: [ :newSession :oldSession | 
+			self removeActionsForSession: oldSession.
+			self registerActionsForSession: newSession.
+			self updateStackFromSession: newSession.
+			self updateExtensionsFrom: newSession ]
 ]
 
 { #category : #initialization }
@@ -1162,10 +1197,13 @@ StDebugger >> stepThrough [
 	self debuggerActionModel stepThrough: self currentContext
 ]
 
-{ #category : #subscription }
-StDebugger >> subscribeToActionModel [
+{ #category : #'system subscriptions' }
+StDebugger >> subscribeToMethodAddedAnnouncement [
 
-	self debuggerActionModel addUpdateEventListener: self whenUpdatedDo: (self class updateBlockFor: self)
+	SystemAnnouncer uniqueInstance weak
+		when: MethodAdded
+		send: #updateAfterMethodAdded
+		to: self
 ]
 
 { #category : #'accessing - widgets' }
@@ -1186,10 +1224,16 @@ StDebugger >> unsavedCodeChangesFor: aContext [
 	^self unsavedCodeChanges at: aContext
 ]
 
-{ #category : #'events - removing' }
-StDebugger >> unsubscribeFromActionModel [
+{ #category : #'system subscriptions' }
+StDebugger >> unsubscribeFromSystemAnnouncer [
 
-	self debuggerActionModel removeUpdateEventListener: self
+	SystemAnnouncer uniqueInstance unsubscribe: self
+]
+
+{ #category : #'updating - widgets' }
+StDebugger >> updateAfterMethodAdded [
+	debuggerActionModel updateContextPredicate.
+	self updateToolbar 
 ]
 
 { #category : #'updating - widgets' }
@@ -1239,6 +1283,11 @@ StDebugger >> updateCodeTextSegmentDecoratorsIn: aContext forInterval: selection
 		title: 'Click me!';"
 ]
 
+{ #category : #'updating - actions' }
+StDebugger >> updateContextChanged [
+	self updateStep
+]
+
 { #category : #'updating - widgets' }
 StDebugger >> updateExtensionsFrom: newSession [
 	self extensionTools do:[:tool| tool updatePresenter]
@@ -1269,6 +1318,17 @@ StDebugger >> updatePresenter [
 	self buildContextMenus
 ]
 
+{ #category : #'updating - actions' }
+StDebugger >> updateRestart [
+	self updateStep
+]
+
+{ #category : #'updating - actions' }
+StDebugger >> updateResume [
+
+	
+]
+
 { #category : #'presenter - code' }
 StDebugger >> updateSourceCodeFor: aContext [
 
@@ -1291,6 +1351,10 @@ StDebugger >> updateStackFromSession: aSession [
 
 { #category : #'updating - actions' }
 StDebugger >> updateStep [
+	self flag: #DBG_UPDATE_OF_MODEL_SHOULD_BE_AUTOMATED.
+	debuggerActionModel updateTopContext.
+	debuggerActionModel updateContextPredicate.	
+	debuggerActionModel updateDebugSession.
 		
 	self updateStackFromSession: self session.
 	self updateWindowTitle.
@@ -1298,6 +1362,24 @@ StDebugger >> updateStep [
 	self updateToolbar.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
+]
+
+{ #category : #'updating - actions' }
+StDebugger >> updateStepInto [
+	self updateStep
+]
+
+{ #category : #'updating - actions' }
+StDebugger >> updateStepOver [
+
+	self updateStep 
+	
+]
+
+{ #category : #'updating - actions' }
+StDebugger >> updateStepThrough [
+
+	self updateStep 
 ]
 
 { #category : #'updating - widgets' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -8,9 +8,7 @@ Class {
 		'session',
 		'contextPredicate',
 		'topContext',
-		'filterStack',
-		'updateEventListeners',
-		'preventUpdate'
+		'filterStack'
 	],
 	#classVars : [
 		'ShouldFilterStack'
@@ -47,12 +45,6 @@ StDebuggerActionModel class >> shouldFilterStackSettingsOn: aBuilder [
 		description: 'Defines if methods with pragma #debuggerCompleteToSender are filtered (hidden) in the debugger stack'
 ]
 
-{ #category : #adding }
-StDebuggerActionModel >> addUpdateEventListener: aDebugger whenUpdatedDo: aBlock [
-
-	updateEventListeners at: aDebugger put: aBlock
-]
-
 { #category : #'debug - session' }
 StDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 
@@ -60,14 +52,6 @@ StDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 	method := aClass lookupSelector: aMessage selector.
 	method protocol = Protocol unclassified ifTrue: [ 
 		MethodClassifier classify: method ]
-]
-
-{ #category : #accessing }
-StDebuggerActionModel >> clear [
-
-	self unsubscribeFromSystemAnnouncer.
-	self removeActionsForSession: self session.
-	updateEventListeners keysDo: [ :key | self removeUpdateEventListener: key ]
 ]
 
 { #category : #'debug - execution' }
@@ -180,11 +164,7 @@ StDebuggerActionModel >> implement: aMessage classified: messageCategory inClass
 StDebuggerActionModel >> initialize [
 	super initialize.
 	self computeInitialTopContext.
-	self subscribeToMethodAddedAnnouncement.
-	filterStack := true.
-	updateEventListeners := Dictionary new.
-	"flag that will prevent any update as long as it is set"
-	preventUpdate := false
+	filterStack := true
 ]
 
 { #category : #accessing }
@@ -286,19 +266,6 @@ StDebuggerActionModel >> predicateFor: aContext postMortem: isContextPostMortem 
 		  yourself
 ]
 
-{ #category : #updating }
-StDebuggerActionModel >> preventUpdatesDuring: aBlock [
-
-	"Sets the prevent update flag during the execution of a block. Restores its value after the block 	finishes"
-
-	| oldEventFlag |
-	oldEventFlag := preventUpdate.
-	preventUpdate := true.
-	[ 
-	aBlock value.
-	self update ] ensure: [ preventUpdate := oldEventFlag ]
-]
-
 { #category : #'debug - execution' }
 StDebuggerActionModel >> proceedDebugSession [
 
@@ -306,12 +273,6 @@ StDebuggerActionModel >> proceedDebugSession [
 	self session
 		resume;
 		clear
-]
-
-{ #category : #'events-triggering' }
-StDebuggerActionModel >> raiseUpdateEvents [
-
-	updateEventListeners valuesDo: [ :each | each value ]
 ]
 
 { #category : #actions }
@@ -330,40 +291,6 @@ StDebuggerActionModel >> referenceContext [
 	or the exception's signaler context in all other cases."
 	self contextPredicate contextSignalsException ifFalse:[^self interruptedContext].
 	^topContext receiver signalerContext 
-]
-
-{ #category : #'events - handling' }
-StDebuggerActionModel >> registerActionsForSession: aSession [
-	self flag: 'Rewrite it'.
-	aSession
-		ifNotNil: [ aSession
-				when: #restart send: #updateIfAble to: self;
-				when: #resume send: #updateIfAble to: self;
-				when: #stepInto send: #updateIfAble to: self;
-				when: #stepOver send: #updateIfAble to: self;
-				when: #stepThrough send: #updateIfAble to: self;
-				when: #contextChanged send: #updateIfAble to: self ]
-]
-
-{ #category : #'events - removing' }
-StDebuggerActionModel >> removeActionsForSession: aSession [
-	self flag: 'Rewrite it'.
-	aSession
-		ifNotNil: [ aSession
-				removeActionsForEvent: #restart;
-				removeActionsForEvent: #resume;
-				removeActionsForEvent: #stepInto;
-				removeActionsForEvent: #stepOver;
-				removeActionsForEvent: #stepThrough;
-				removeActionsForEvent: #contextChanged ]
-]
-
-{ #category : #removing }
-StDebuggerActionModel >> removeUpdateEventListener: anEventListener [
-
-	[ updateEventListeners removeKey: anEventListener ]
-	on: KeyNotFound 
-	do: [ ^ self ]
 ]
 
 { #category : #'debug - execution' }
@@ -402,11 +329,7 @@ StDebuggerActionModel >> session [
 
 { #category : #accessing }
 StDebuggerActionModel >> session: aDebugSession [
-	session ifNotNil: [ self removeActionsForSession: session ].
-	session := aDebugSession.
-	self registerActionsForSession: self session.
-
-	self updateIfAble
+	session := aDebugSession
 ]
 
 { #category : #'debug - stack' }
@@ -457,41 +380,9 @@ StDebuggerActionModel >> stepThrough: aContext [
 	self updateTopContext
 ]
 
-{ #category : #'system subscription' }
-StDebuggerActionModel >> subscribeToMethodAddedAnnouncement [
-
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAdded
-		send: #updateAfterMethodAdded
-		to: self
-]
-
 { #category : #accessing }
 StDebuggerActionModel >> topContext [
 	^ topContext
-]
-
-{ #category : #'system subscription' }
-StDebuggerActionModel >> unsubscribeFromSystemAnnouncer [
-
-	SystemAnnouncer uniqueInstance unsubscribe: self
-]
-
-{ #category : #accessing }
-StDebuggerActionModel >> update [
-
-	self updateTopContext.
-	self updateContextPredicate.
-	self updateDebugSession.
-
-	self raiseUpdateEvents
-]
-
-{ #category : #'updating - widgets' }
-StDebuggerActionModel >> updateAfterMethodAdded [
-
-	self updateContextPredicate.
-	self raiseUpdateEvents 
 ]
 
 { #category : #context }
@@ -515,13 +406,6 @@ StDebuggerActionModel >> updateDebugSession [
 StDebuggerActionModel >> updateDebugSessionException: e [
 
 	self session exception: e
-]
-
-{ #category : #accessing }
-StDebuggerActionModel >> updateIfAble [
-
-	preventUpdate ifNil: [ ^ self ].
-	preventUpdate ifFalse: [ self update ]
 ]
 
 { #category : #context }

--- a/src/NewTools-Sindarin-Commands-Tests/SindarinCommandsTest.class.st
+++ b/src/NewTools-Sindarin-Commands-Tests/SindarinCommandsTest.class.st
@@ -21,7 +21,6 @@ SindarinCommandsTest >> setUp [
 SindarinCommandsTest >> tearDown [
 
 	debugger ifNotNil: [ 
-		debugger debuggerActionModel clear.
 		debugger session ifNotNil: [ :s | s clear ].
 		debugger session: nil.
 		debugger := nil ].
@@ -31,32 +30,29 @@ SindarinCommandsTest >> tearDown [
 { #category : #'tests - step to instance creation' }
 SindarinCommandsTest >> testDebuggerOnNextInstanceCreation [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ Object new ] asContext) debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ Object new ] asContext) session.
 
 	command := SindarinStepToNextInstanceCreation forContext: debugger.
 	command execute.
 	self
 		assert: debugger session context method
 		identicalTo: (Object class lookupSelector: #new).
-	self assert: debugger session context receiver identicalTo: Object
+	self
+		assert: debugger session context receiver
+		identicalTo: Object
 ]
 
 { #category : #'tests - step to instance creation' }
 SindarinCommandsTest >> testNoNextInstanceCreationAfterMaxSearchDepth [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ object acceptVisitor: visitor ] asContext)
-		                    debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
-
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ object acceptVisitor: visitor ] asContext) session.
+			
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (object class >> #acceptVisitor:) ].
 
@@ -70,30 +66,27 @@ SindarinCommandsTest >> testNoNextInstanceCreationAfterMaxSearchDepth [
 { #category : #'tests - step to instance creation' }
 SindarinCommandsTest >> testNoNextInstanceCreationBeforeContextReturn [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ object doNotAcceptVisitor: nil ] asContext)
-		                    debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ object doNotAcceptVisitor: nil ] asContext) session.
 
 	command := SindarinStepToNextInstanceCreation forContext: debugger.
 	command maxDepth: 2.
 	command execute.
-	self assert: command errorString equals: command notFoundErrorString
+	self
+		assert: command errorString
+		equals: command notFoundErrorString
 ]
 
 { #category : #'tests - step to next call' }
 SindarinCommandsTest >> testStepToNextCallInClass [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ visitor visit: object ] asContext)
-		                    debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: 
+	(StTestDebuggerProvider new debuggerWithContext:
+		            [ visitor visit: object ] asContext) session.
 
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (visitor class >> #visit:) ].
@@ -110,13 +103,11 @@ SindarinCommandsTest >> testStepToNextCallInClass [
 { #category : #'tests - step to next call' }
 SindarinCommandsTest >> testStepToNextCallInClassFailure [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ visitor doNotVisit: object ] asContext)
-		                    debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: 
+	(StTestDebuggerProvider new debuggerWithContext:
+		            [ visitor doNotVisit: object ] asContext) session.
 
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (visitor class >> #doNotVisit:) ].
@@ -133,12 +124,10 @@ SindarinCommandsTest >> testStepToNextCallInClassFailure [
 { #category : #'tests - step to next call' }
 SindarinCommandsTest >> testStepToNextCallInClassNeverFinishes [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-			 [ visitor visitNeverFinish: object ] asContext) debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ visitor visitNeverFinish: object ] asContext) session.
 
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (visitor class >> #visitNeverFinish:) ].
@@ -158,12 +147,10 @@ SindarinCommandsTest >> testStepToNextCallInClassNeverFinishes [
 { #category : #'tests - step to next call' }
 SindarinCommandsTest >> testStepToNextCallInClassWithError [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-			 [ visitor visitWithError: object ] asContext) debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ visitor visitWithError: object ] asContext) session.
 
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (visitor class >> #visitWithError:) ].
@@ -180,13 +167,11 @@ SindarinCommandsTest >> testStepToNextCallInClassWithError [
 { #category : #'tests - step to next call' }
 SindarinCommandsTest >> testStepToNextCallInObject [
 
-	| command originalReceiver dummyActionModel |
+	| command originalReceiver |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-		                     [ visitor visitMultipleObjects: object ]
-			                     asContext) debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: 
+	(StTestDebuggerProvider new debuggerWithContext:
+		            [ visitor visitMultipleObjects: object ] asContext) session.
 
 	debugger session stepIntoUntil: [ :currentContext | 
 		currentContext method == (visitor class >> #visitMultipleObjects:) ].
@@ -199,20 +184,16 @@ SindarinCommandsTest >> testStepToNextCallInObject [
 	self
 		assert: debugger session context method
 		identicalTo: visitor class >> #visitTestObject:.
-	self
-		assert: debugger session context receiver
-		identicalTo: originalReceiver
+	self assert: debugger session context receiver identicalTo: originalReceiver
 ]
 
 { #category : #'tests - step to instance creation' }
 SindarinCommandsTest >> testStepToNextInstanceCreation [
 
-	| command dummyActionModel |
+	| command |
 	debugger := SindarinTestCommandDebugger new.
-	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
-			 [ object createInstanceWithNew ] asContext) debuggerActionModel.
-	debugger session: dummyActionModel session.
-	dummyActionModel clear.
+	debugger session: (StTestDebuggerProvider new debuggerWithContext:
+			 [ object createInstanceWithNew ] asContext) session.
 
 	command := SindarinStepToNextInstanceCreation forContext: debugger.
 	command execute.

--- a/src/NewTools-Sindarin-Commands-Tests/SindarinTestCommandDebugger.class.st
+++ b/src/NewTools-Sindarin-Commands-Tests/SindarinTestCommandDebugger.class.st
@@ -6,16 +6,10 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'session',
-		'tag',
-		'debuggerActionModel'
+		'tag'
 	],
 	#category : #'NewTools-Sindarin-Commands-Tests'
 }
-
-{ #category : #accessing }
-SindarinTestCommandDebugger >> debuggerActionModel [
-	^ debuggerActionModel ifNil: [ debuggerActionModel := StDebuggerActionModel on: self session ]
-]
 
 { #category : #removing }
 SindarinTestCommandDebugger >> forceSessionUpdate [ 
@@ -36,8 +30,7 @@ SindarinTestCommandDebugger >> session [
 { #category : #accessing }
 SindarinTestCommandDebugger >> session: anObject [
 
-	session := anObject.
-	session ifNotNil: [ self debuggerActionModel session: anObject ]
+	session := anObject
 ]
 
 { #category : #removing }

--- a/src/NewTools-Sindarin-Commands/SindarinStepToNextCallCommand.class.st
+++ b/src/NewTools-Sindarin-Commands/SindarinStepToNextCallCommand.class.st
@@ -17,20 +17,25 @@ SindarinStepToNextCallCommand class >> defaultIconName [
 SindarinStepToNextCallCommand >> execute [
 
 	| callingMethod maxDepth depth |
-	self debuggerPresenter debuggerActionModel preventUpdatesDuring: [ 
-		debugger := self context sindarinDebugger.
-		self setConditionValue.
-		callingMethod := debugger method.
-		debugger step.
+	self context removeSessionHolderSubscriptions.
+	debugger := self context sindarinDebugger.
+	self setConditionValue.
+	callingMethod := debugger method.
+	debugger step.
 
-		maxDepth := 1000.
-		depth := 0.
-		[ 
-		debugger method ~= callingMethod and: [ 
-			depth < maxDepth and: [ self targetCondition ] ] ] whileTrue: [ 
+	maxDepth := 1000.
+	depth := 0.
+	[ 
+	debugger method ~= callingMethod and: [ 
+		depth < maxDepth and: [ self targetCondition ] ] ] 
+		whileTrue: [ 
 			debugger step.
 			depth := depth + 1.
-			debugger hasSignalledUnhandledException ifTrue: [ depth := 1000 ] ] ].
+			debugger hasSignalledUnhandledException ifTrue: [ depth := 1000 ] ].
+
+	self context
+		setSessionHolderSubscriptions;
+		forceSessionUpdate
 ]
 
 { #category : #hooks }

--- a/src/NewTools-Sindarin-Commands/SindarinStepToNextInstanceCreation.class.st
+++ b/src/NewTools-Sindarin-Commands/SindarinStepToNextInstanceCreation.class.st
@@ -44,22 +44,25 @@ SindarinStepToNextInstanceCreation >> execute [
 
 	| debugger sender depth |
 	debugger := self debuggerPresenter sindarinDebugger.
-	self debuggerPresenter debuggerActionModel preventUpdatesDuring: [ 
-		sender := debugger context sender.
+	self debuggerPresenter removeSessionHolderSubscriptions.
+	sender := debugger context sender.
 
-		depth := 0.
-		errorString := nil.
-		debugger step.
-		[ debugger isAboutToInstantiateClass or: [ errorString notNil ] ] 
-			whileFalse: [ 
-				debugger step.
-				depth := depth + 1.
-				depth = self maxDepth ifTrue: [ 
-					errorString := self notFoundErrorString ].
-				debugger context == sender ifTrue: [ 
-					errorString := self notFoundInCurrentContextString ].
-				debugger hasSignalledUnhandledException ifTrue: [ 
-					errorString := self errorDuringSearchString ] ] ].
+	depth := 0.
+	errorString := nil.
+	debugger step.
+	[ debugger isAboutToInstantiateClass or: [ errorString notNil ] ] 
+		whileFalse: [ 
+			debugger step.
+			depth := depth + 1.
+			depth = self maxDepth ifTrue: [ errorString := self notFoundErrorString ].
+			debugger context == sender ifTrue: [ 
+				errorString := self notFoundInCurrentContextString ].
+			debugger hasSignalledUnhandledException ifTrue: [ 
+				errorString := self errorDuringSearchString ] ].
+
+	self debuggerPresenter
+		setSessionHolderSubscriptions;
+		forceSessionUpdate.
 
 	errorString ifNotNil: [ 
 		self debuggerPresenter

--- a/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SindarinDebugger }
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger class >> debuggerExtensionKey [
-	^ #sindarin
+SindarinDebugger >> debuggerExtensionKey [
+	^self class debuggerExtensionKey
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger >> debuggerExtensionKey [
-	^self class debuggerExtensionKey
+SindarinDebugger class >> debuggerExtensionKey [
+	^ #sindarin
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
@@ -47,22 +47,23 @@ StSindarinDebuggerScriptingPresenter >> debuggerExtensionToolName [
 
 { #category : #actions }
 StSindarinDebuggerScriptingPresenter >> executeScript [
-
 	| stream result model receiver evaluationContext |
-	self debuggerPresenter debuggerActionModel preventUpdatesDuring: [ 
-		stream := code text readStream.
-		model := code interactionModel.
-		receiver := model context receiver.
-		evaluationContext := model context.
-		result := receiver class compiler
-			          source: stream;
-			          context: evaluationContext;
-			          receiver: receiver;
-			          requestor: model;
-			          failBlock: [ nil ];
-			          evaluate.
-		resultInspection model: result.
-		resultInspection update ]
+	self debugger removeSessionHolderSubscriptions.
+	stream := code text readStream.
+	model := code interactionModel.
+	receiver := model context receiver.
+	evaluationContext := model context.
+	result := receiver class compiler
+		          source: stream;
+		          context: evaluationContext;
+		          receiver: receiver;
+		          requestor: model;
+		          failBlock: [ nil ];
+		          evaluate.
+	resultInspection model: result.
+	resultInspection update.
+	self debugger setSessionHolderSubscriptions.
+	self debugger forceSessionUpdate
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Reverts pharo-spec/NewTools#368