### PR TITLE
Fix code highlighting for no-header doIts

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -64,6 +64,11 @@ StDebuggerContextInteractionModel >> hasUnsavedCodeChanges [
 	^ context notNil and: [ context sourceCode ~= owner text asString ]
 ]
 
+{ #category : #testing }
+StDebuggerContextInteractionModel >> isScripting [
+	^context method isDoIt
+]
+
 { #category : #accessing }
 StDebuggerContextInteractionModel >> object [
 

--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -73,7 +73,7 @@ CompiledCode >> inspectionSource [
 	<inspectorPresentationOrder: 20 title: 'Source'>
 	
 	^ SpCodePresenter new 
-		beForBehavior: self methodClass;
+		beForMethod: self method;
 		text: self sourceCode;
 		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
 			addItem: [ :item | item 

--- a/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
@@ -15,7 +15,7 @@ RBProgramNode >> inspectionSourceCode [
 	<inspectorPresentationOrder: 30 title: 'Source code'>
 
 	^ SpCodePresenter new 
-		beForBehavior: self methodNode methodClass;
+		beForMethod: self methodNode;
 		text: (self source ifNil: [ self formattedCode ]);
 		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
 			interval: (self sourceInterval first to: self sourceInterval last + 1);


### PR DESCRIPTION
Fix code highlighting for no-header doIts in debugger and method and AST inspections.

Integration into Pharo should be done after https://github.com/pharo-project/pharo/pull/11463