### PR TITLE
Fix isScripting for block contexts from DoIts

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -96,7 +96,7 @@ StDebuggerContextInteractionModel >> hasUnsavedCodeChanges [
 
 { #category : #testing }
 StDebuggerContextInteractionModel >> isScripting [
-	^context method isDoIt
+	^context belongsToDoIt
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
It requires Pharo PR with #belongsToDoIt method: https://github.com/pharo-project/pharo/pull/11473