### PR TITLE
Adding debugger extension visitor to display variables from extensions (as Chest)

### DIFF
--- a/src/NewTools-Debugger-Breakpoints-Tools/StDebuggerBreakpointInspection.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StDebuggerBreakpointInspection.class.st
@@ -17,6 +17,12 @@ StDebuggerBreakpointInspection class >> defaultDisplayOrder [
 	^ 3
 ]
 
+{ #category : #visiting }
+StDebuggerBreakpointInspection >> accept: aVisitor [
+
+	^ aVisitor visitBreakpoints: self
+]
+
 { #category : #private }
 StDebuggerBreakpointInspection >> breakPointsForModel [
 	^ Breakpoint all

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1245,14 +1245,19 @@ StDebugger >> updateCodeFromContext [
 { #category : #'presenter - code' }
 StDebugger >> updateCodeFromContext: aContext [
 
-	| selectionInterval |
+	| selectionInterval formerActionModel |
 	aContext ifNil: [ ^ self clearCode ].
 
 	self recordUnsavedCodeChanges.
 	selectionInterval := self selectedCodeRangeForContext: aContext.
 	aContext sourceCode = self code text ifFalse: [ 
 		self updateSourceCodeFor: aContext ].
+	formerActionModel := self code interactionModel.
 	self code beForContext: aContext.
+	"add bindings of the old interaction model in the new one"
+	formerActionModel ifNotNil: [ 
+		formerActionModel bindings associations do: [ :assoc | 
+			self code interactionModel addBinding: assoc ] ].
 	self code selectionInterval:
 		(selectionInterval last to: selectionInterval last - 1).
 	self

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -821,6 +821,7 @@ StDebugger >> newDebuggerContext [
 
 	^ self class debuggerContextClass new
 		  exception: self exception;
+		  debugger: self;
 		  yourself
 ]
 
@@ -829,6 +830,7 @@ StDebugger >> newDebuggerContextFor: aContext [
 
 	^ self newDebuggerContext
 		  context: aContext;
+		  debugger: self;
 		  yourself
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1247,18 +1247,18 @@ StDebugger >> updateCodeFromContext [
 { #category : #'presenter - code' }
 StDebugger >> updateCodeFromContext: aContext [
 
-	| selectionInterval formerActionModel |
+	| selectionInterval formerCodeInteractionModel |
 	aContext ifNil: [ ^ self clearCode ].
 
 	self recordUnsavedCodeChanges.
 	selectionInterval := self selectedCodeRangeForContext: aContext.
 	aContext sourceCode = self code text ifFalse: [ 
 		self updateSourceCodeFor: aContext ].
-	formerActionModel := self code interactionModel.
+	formerCodeInteractionModel := self code interactionModel.
 	self code beForContext: aContext.
 	"add bindings of the old interaction model in the new one"
-	formerActionModel ifNotNil: [ 
-		formerActionModel bindings associations do: [ :assoc | 
+	formerCodeInteractionModel ifNotNil: [ 
+		formerCodeInteractionModel bindings associations do: [ :assoc | 
 			self code interactionModel addBinding: assoc ] ].
 	self code selectionInterval:
 		(selectionInterval last to: selectionInterval last - 1).

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -29,8 +29,9 @@ StDebuggerContext >> buildExtensionNodes [
 
 	^ debugger
 		  ifNotNil: [ 
-			  debugger extensionTools flatCollect: [ :debuggerExtension | 
-				  visitor visit: debuggerExtension ] ]
+			  debugger extensionTools do: [ :debuggerExtension | 
+				  visitor visit: debuggerExtension ].
+			  visitor result ]
 		  ifNil: [ #(  ) asOrderedCollection ]
 ]
 

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'context',
-		'exception'
+		'exception',
+		'debugger'
 	],
 	#category : #'NewTools-Debugger-Model'
 }
@@ -21,13 +22,28 @@ StDebuggerContext class >> context: aContext [
 ]
 
 { #category : #accessing }
+StDebuggerContext >> buildExtensionNodes [
+
+	| visitor |
+	visitor := StDebuggerExtensionInspectorNodeBuilderVisitor new.
+
+	^ debugger
+		  ifNotNil: [ 
+			  debugger extensionTools flatCollect: [ :debuggerExtension | 
+				  visitor visit: debuggerExtension ] ]
+		  ifNil: [ #(  ) asOrderedCollection ]
+]
+
+{ #category : #accessing }
 StDebuggerContext >> buildInspectorNodes [
 
 	| nodes argsNodes tempsNodes tempsAndArgs |
 	nodes := OrderedCollection new.
 	tempsAndArgs := self temporaryVariablesNodes.
-	argsNodes := tempsAndArgs select: [ :tempNode | tempNode tempVariable isArgumentVariable ].
-	tempsNodes := tempsAndArgs select: [ :tempNode | tempNode tempVariable isTempVariable ].
+	argsNodes := tempsAndArgs select: [ :tempNode | 
+		             tempNode tempVariable isArgumentVariable ].
+	tempsNodes := tempsAndArgs select: [ :tempNode | 
+		              tempNode tempVariable isTempVariable ].
 	nodes add: self selfNode.
 	nodes addAll: argsNodes.
 	nodes addAll: tempsNodes.
@@ -35,6 +51,7 @@ StDebuggerContext >> buildInspectorNodes [
 	nodes add: self stackTopNode.
 	nodes add: self thisContextNode.
 	nodes addAll: self exceptionNodes.
+	nodes addAll: self buildExtensionNodes.
 	^ nodes
 ]
 
@@ -47,6 +64,12 @@ StDebuggerContext >> context [
 { #category : #accessing }
 StDebuggerContext >> context: anObject [
 	context := anObject
+]
+
+{ #category : #accessing }
+StDebuggerContext >> debugger: aDebugger [
+
+	debugger := aDebugger
 ]
 
 { #category : #building }

--- a/src/NewTools-Debugger/StDebuggerExtensionInspectorNodeBuilderVisitor.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionInspectorNodeBuilderVisitor.class.st
@@ -1,0 +1,41 @@
+"
+I am a debugger extension visitor that is used to display in the debugger inspector variables that were added via debugger extensions.
+"
+Class {
+	#name : #StDebuggerExtensionInspectorNodeBuilderVisitor,
+	#superclass : #StDebuggerExtensionVisitor,
+	#category : #'NewTools-Debugger-Model'
+}
+
+{ #category : #'instance creation' }
+StDebuggerExtensionInspectorNodeBuilderVisitor >> newCollection [
+
+	^ #(  ) asOrderedCollection
+]
+
+{ #category : #visiting }
+StDebuggerExtensionInspectorNodeBuilderVisitor >> visit: aStDebuggerExtension [
+
+	| extensionNodes |
+	extensionNodes := super visit: aStDebuggerExtension.
+	"If the visit hook that is used does nothing, then we return an empty collection"
+	^ extensionNodes == self ifTrue: [ self newCollection ] ifFalse: [ extensionNodes ]
+]
+
+{ #category : #visiting }
+StDebuggerExtensionInspectorNodeBuilderVisitor >> visitChest: aChestExtension [
+
+	| debuggerInteractionModel  |
+	debuggerInteractionModel := aChestExtension debugger code
+		                            interactionModel.
+	^ debuggerInteractionModel bindings associations
+		  select: [ :aBinding | 
+			  aBinding propertyAt: #comesFromChest ifAbsent: [ false ] ]
+		  thenCollect: [ :chestVariable | 
+			  (StInspectorDynamicNode
+				   hostObject: chestVariable value
+				   label: chestVariable key
+				   value: chestVariable value)
+				  variableTag: 'Chest';
+				  yourself ]
+]

--- a/src/NewTools-Debugger/StDebuggerExtensionInspectorNodeBuilderVisitor.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionInspectorNodeBuilderVisitor.class.st
@@ -7,35 +7,8 @@ Class {
 	#category : #'NewTools-Debugger-Model'
 }
 
-{ #category : #'instance creation' }
-StDebuggerExtensionInspectorNodeBuilderVisitor >> newCollection [
+{ #category : #initialization }
+StDebuggerExtensionInspectorNodeBuilderVisitor >> initializeResult [
 
-	^ #(  ) asOrderedCollection
-]
-
-{ #category : #visiting }
-StDebuggerExtensionInspectorNodeBuilderVisitor >> visit: aStDebuggerExtension [
-
-	| extensionNodes |
-	extensionNodes := super visit: aStDebuggerExtension.
-	"If the visit hook that is used does nothing, then we return an empty collection"
-	^ extensionNodes == self ifTrue: [ self newCollection ] ifFalse: [ extensionNodes ]
-]
-
-{ #category : #visiting }
-StDebuggerExtensionInspectorNodeBuilderVisitor >> visitChest: aChestExtension [
-
-	| debuggerInteractionModel  |
-	debuggerInteractionModel := aChestExtension debugger code
-		                            interactionModel.
-	^ debuggerInteractionModel bindings associations
-		  select: [ :aBinding | 
-			  aBinding propertyAt: #comesFromChest ifAbsent: [ false ] ]
-		  thenCollect: [ :chestVariable | 
-			  (StInspectorDynamicNode
-				   hostObject: chestVariable value
-				   label: chestVariable key
-				   value: chestVariable value)
-				  variableTag: 'Chest';
-				  yourself ]
+	result := OrderedCollection new
 ]

--- a/src/NewTools-Debugger/StDebuggerExtensionVisitor.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionVisitor.class.st
@@ -1,0 +1,39 @@
+"
+This class provides hooks, which do nothing, to visit debugger extensions.
+
+To define a debugger extension visitor, you must create a subclass of this class and override the `visitXXX` hook for the debugger extensions that you want.
+
+If you want to define a new debugger extension that is visited by debugger visitors, you must define an extension method as a hook for you new extension: `visitNewExtension` and define in your debugger extension class:
+
+```language=Pharo
+NewExtension>>#accept: aVisitor
+	^ aVisitor visitNewExtension: self
+```
+"
+Class {
+	#name : #StDebuggerExtensionVisitor,
+	#superclass : #Object,
+	#category : #'NewTools-Debugger-Model'
+}
+
+{ #category : #visiting }
+StDebuggerExtensionVisitor >> visit: aStDebuggerExtension [
+
+	^ aStDebuggerExtension accept: self
+]
+
+{ #category : #visiting }
+StDebuggerExtensionVisitor >> visitBreakpoints: aBreakpointsExtension [
+]
+
+{ #category : #visiting }
+StDebuggerExtensionVisitor >> visitBytecode: aBytecodeExtension [
+]
+
+{ #category : #visiting }
+StDebuggerExtensionVisitor >> visitChest: aChestExtension [
+]
+
+{ #category : #visiting }
+StDebuggerExtensionVisitor >> visitSindarin: aSindarinExtension [
+]

--- a/src/NewTools-Debugger/StDebuggerExtensionVisitor.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionVisitor.class.st
@@ -13,13 +13,35 @@ NewExtension>>#accept: aVisitor
 Class {
 	#name : #StDebuggerExtensionVisitor,
 	#superclass : #Object,
+	#instVars : [
+		'result'
+	],
 	#category : #'NewTools-Debugger-Model'
 }
+
+{ #category : #initialization }
+StDebuggerExtensionVisitor >> initialize [ 
+
+	super initialize.
+	self initializeResult
+]
+
+{ #category : #initialization }
+StDebuggerExtensionVisitor >> initializeResult [
+
+	self subclassResponsibility 
+]
+
+{ #category : #accessing }
+StDebuggerExtensionVisitor >> result [
+
+	^ result
+]
 
 { #category : #visiting }
 StDebuggerExtensionVisitor >> visit: aStDebuggerExtension [
 
-	^ aStDebuggerExtension accept: self
+	aStDebuggerExtension accept: self
 ]
 
 { #category : #visiting }
@@ -28,10 +50,6 @@ StDebuggerExtensionVisitor >> visitBreakpoints: aBreakpointsExtension [
 
 { #category : #visiting }
 StDebuggerExtensionVisitor >> visitBytecode: aBytecodeExtension [
-]
-
-{ #category : #visiting }
-StDebuggerExtensionVisitor >> visitChest: aChestExtension [
 ]
 
 { #category : #visiting }

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -42,6 +42,10 @@ TStDebuggerExtension classSide >> showInDebugger: aBoolean [
 	showDebuggerExtension := aBoolean
 ]
 
+{ #category : #visiting }
+TStDebuggerExtension >> accept: aVisitor [
+]
+
 { #category : #accessing }
 TStDebuggerExtension >> debugger [
 	^debugger

--- a/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SindarinDebugger }
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger >> debuggerExtensionKey [
-	^self class debuggerExtensionKey
+SindarinDebugger class >> debuggerExtensionKey [
+	^ #sindarin
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger class >> debuggerExtensionKey [
-	^ #sindarin
+SindarinDebugger >> debuggerExtensionKey [
+	^self class debuggerExtensionKey
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
@@ -29,6 +29,12 @@ StSindarinBytecodeDebuggerPresenter class >> defaultLayout [
 		yourself
 ]
 
+{ #category : #visiting }
+StSindarinBytecodeDebuggerPresenter >> accept: aVisitor [
+
+	^ aVisitor visitBytecode: self
+]
+
 { #category : #'debugger extension' }
 StSindarinBytecodeDebuggerPresenter >> debuggerExtensionToolName [
 	^ 'Bytecode' 

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
@@ -34,6 +34,12 @@ StSindarinDebuggerScriptingPresenter class >> defaultLayout [
 		yourself
 ]
 
+{ #category : #visiting }
+StSindarinDebuggerScriptingPresenter >> accept: aVisitor [
+
+	^ aVisitor visitSindarin: self
+]
+
 { #category : #actions }
 StSindarinDebuggerScriptingPresenter >> createCommandFromScript [
 	self flag: 'todo'


### PR DESCRIPTION
This follows the PR that modified `StDebuggerContextInteractionModel` to allow to add bindings into the debugger itself: #378. This concept is used for example by Chest, which will be integrated soon into Pharo and allows to load any object from anywhere in Pharo into the debugger: https://github.com/adri09070/Chest

Now that we can add bindings into the debugger itself,  I made this PR to see these bindings in the debugger inspector and to be able to distinguish those that were added from those that come from the context.

To do that, I created an extensible debugger extension visitor system. So, if any other debugger extension add variables into the debugger, we will be able to distinguish those which debugger extension added which variable into the debugger .

Plus, `StDebuggerExtensionVisitor` provides hooks for every debugger extension and can be easily subclassed to perform other operations on debugger extensions.

The only doubt that I have is that I define the `visitChest:` method in `StDebuggerExtensionVisitor` and in `StDebuggerExtensionInspectorNodeBuilderVisitor`. As Chest is not in NewTools, I wonder if it would not be better to put this method as an extension method in Chest (let me know what you think but anyway, it allows you to see how it will work in Chest)