### PR TITLE
Fix debugger to update debugger extensions when a context is selected in the stack + fixing bytecode extension

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -743,6 +743,7 @@ StDebugger >> initializeStack [
 		stackTable selection isEmpty ifFalse: [ 
 			self updateInspectorFromContext: context.
 			self updateCodeFromContext: context.
+			self updateExtensionsFrom: self session.
 			self expandStackIfLastItemIsSelected.
 			self updateWindowTitle ] ].
 	stackHeader := self instantiate: StHeaderBar.

--- a/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SindarinDebugger }
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger >> debuggerExtensionKey [
-	^self class debuggerExtensionKey
+SindarinDebugger class >> debuggerExtensionKey [
+	^ #sindarin
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger class >> debuggerExtensionKey [
-	^ #sindarin
+SindarinDebugger >> debuggerExtensionKey [
+	^self class debuggerExtensionKey
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }

--- a/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinBytecodeDebuggerPresenter.class.st
@@ -85,8 +85,8 @@ StSindarinBytecodeDebuggerPresenter >> toolbarActions [
 StSindarinBytecodeDebuggerPresenter >> updateBytecode [
 
 	| selectionIndex |
-	bytecodeList := self sindarin currentBytecode.
-	currentPC := self sindarin pc.
+	bytecodeList := debugger currentContext method symbolicBytecodes.
+	currentPC := debugger currentContext pc .
 	bytecode
 		items: bytecodeList;
 		displayIcon: [ :elem | 
@@ -94,7 +94,7 @@ StSindarinBytecodeDebuggerPresenter >> updateBytecode [
 				ifTrue: [ Smalltalk iconNamed: #glamorousRight ]
 				ifFalse: [ Smalltalk iconNamed: #blank ] ].
 	bcContextInspection model:
-		(StSindarinBytecodeContextInspectorModel on: self sindarin context).
+		(StSindarinBytecodeContextInspectorModel on: debugger currentContext).
 	selectionIndex := currentPC - bytecodeList first offset + 1.
 	selectionIndex <= bytecodeList size ifTrue: [ 
 		bytecode selectIndex: selectionIndex ]


### PR DESCRIPTION
Fixes #403.

In the debugger, when we would select a context in the stack, debugger extensions weren't updated.
In the case of the bytecode debugger extension, this would cause that the displayed bytecodes didn't necessarily match the code of the selected context.

There were 2 reasons to that:

1) Debugger extensions were not updated when a context was selected in the stack. I fixed it so that debugger extensions are updated when a context is selected

```Smalltalk
StDebugger>>#initializeStack
...
stackTable transmitDo: [ :context | 
		stackTable selection isEmpty ifFalse: [ 
			self updateInspectorFromContext: context.
			self updateCodeFromContext: context.
			self updateExtensionsFrom: self session.
			self expandStackIfLastItemIsSelected.
			self updateWindowTitle ] ]
...
```

2) To provide the list of bytecodes, the bytecode extension uses a `SindarinDebugger` that only manipulates the interrupted context (= topContext). So, no matter what, the bytecode list that was displayed stood for the top context instead of the selected context in the debugger. I fixed it so that the bytecode extension uses the debugger itself instead of a sindarin debugger to build the list of symbolic bytecodes that must be displayed.