### PR TITLE
[cleanup] remove debug action, necessary to cleanup an old package

### DIFF
--- a/src/NewTools-Debugger-Extensions/DebugAction.extension.st
+++ b/src/NewTools-Debugger-Extensions/DebugAction.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #DebugAction }
-
-{ #category : #'*NewTools-Debugger-Extensions' }
-DebugAction >> value [
-	self execute
-]


### PR DESCRIPTION
To remove the old debugger action package (https://github.com/pharo-project/pharo/pull/11485) we need to remove this extension method .