### PR TITLE
Use stateless compiler API

### DIFF
--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -303,10 +303,9 @@ StDebuggerActionModel >> restartContext: aContext [
 StDebuggerActionModel >> returnValueFromExpression: aString fromContext: aContext [
 	| value |
 	value := session class compiler
-		source: aString;
 		context: aContext;
 		receiver: aContext receiver;
-		evaluate.
+		evaluate: aString.
 	self session returnValue: value from: aContext.
 	self updateTopContext
 ]

--- a/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDebugger.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SindarinDebugger }
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger >> debuggerExtensionKey [
-	^self class debuggerExtensionKey
+SindarinDebugger class >> debuggerExtensionKey [
+	^ #sindarin
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }
-SindarinDebugger class >> debuggerExtensionKey [
-	^ #sindarin
+SindarinDebugger >> debuggerExtensionKey [
+	^self class debuggerExtensionKey
 ]
 
 { #category : #'*NewTools-Sindarin-Tools' }

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
@@ -47,19 +47,17 @@ StSindarinDebuggerScriptingPresenter >> debuggerExtensionToolName [
 
 { #category : #actions }
 StSindarinDebuggerScriptingPresenter >> executeScript [
-	| stream result model receiver evaluationContext |
+	| result model receiver evaluationContext |
 	self debugger removeSessionHolderSubscriptions.
-	stream := code text readStream.
 	model := code interactionModel.
 	receiver := model context receiver.
 	evaluationContext := model context.
 	result := receiver class compiler
-		          source: stream;
 		          context: evaluationContext;
 		          receiver: receiver;
 		          requestor: model;
 		          failBlock: [ nil ];
-		          evaluate.
+		          evaluate: code text asString.
 	resultInspection model: result.
 	resultInspection update.
 	self debugger setSessionHolderSubscriptions.


### PR DESCRIPTION
Use stateless compiler API. 
The API was always there (evaluate: source vs source: source; evaluate). So that it's fully compatible any compiler version