### PR TITLE
Added skip command to the expert debugger toolbar command group

### DIFF
--- a/src/NewTools-Sindarin-Commands/SindarinSkipCommand.class.st
+++ b/src/NewTools-Sindarin-Commands/SindarinSkipCommand.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #SindarinSkipCommand,
+	#superclass : #SindarinSkipAllToSelectionCommand,
+	#category : #'NewTools-Sindarin-Commands'
+}
+
+{ #category : #'accessing - defaults' }
+SindarinSkipCommand class >> defaultDescription [
+	^ 'Skips execution of the next step, then returns debugger control.'
+]
+
+{ #category : #'accessing - defaults' }
+SindarinSkipCommand class >> defaultName [
+	<toolbarExtensionDebugCommand: 1>
+	<codeExtensionDebugCommand: 1>
+	^ 'Skip'
+]
+
+{ #category : #hooks }
+SindarinSkipCommand >> execute [
+
+	| targetNode |
+	self flag:
+		'Context should actually be a debugger or a sindarin debugger'.
+	self context sindarinDebugger skip.
+	self context forceSessionUpdate
+]

--- a/src/NewTools-Sindarin-Commands/SindarinSkipCommand.class.st
+++ b/src/NewTools-Sindarin-Commands/SindarinSkipCommand.class.st
@@ -1,3 +1,15 @@
+"
+Instead of executing a normal step, this command skips the next bytecode to be executed.
+It has the same granularity than the step-in command.
+Executing a skip sets the next bytecode in line to be executed, therefore you must be careful when skipping instructions as you could skip a bytecode that sets a required value to execute the rest of your method.
+
+A good example of using skip would be the following:
+You start debugging a method in which you write in to a stream.
+You notice a problem so you fix your method and recompiles it, which triggers a context restart.
+In that case, the execution counter is set back to the beggining of that method but the state is not set back.
+Therefore, if you execute again you will write the same values in your stream.
+You can use skip to avoid all writings in your stream until you get back to the correct point of the execution where you can start writing again in the stream.
+"
 Class {
 	#name : #SindarinSkipCommand,
 	#superclass : #SindarinSkipAllToSelectionCommand,
@@ -19,7 +31,6 @@ SindarinSkipCommand class >> defaultName [
 { #category : #hooks }
 SindarinSkipCommand >> execute [
 
-	| targetNode |
 	self flag:
 		'Context should actually be a debugger or a sindarin debugger'.
 	self context sindarinDebugger skip.


### PR DESCRIPTION
Instead of executing a normal *step*, this command skips the next bytecode to be executed.
It has the same granularity than the step-**in** command.
Executing a skip sets the next bytecode in line to be executed, therefore you must be careful when skipping instructions as you could skip a bytecode that sets a required value to execute the rest of your method.

A good example of using skip would be the following:
You start debugging a method in which you write in to a stream.
You notice a problem so you fix your method and recompiles it, which triggers a context restart.
In that case, the execution counter is set back to the beggining of that method but the state is not set back. 
Therefore, if you execute again you will write the same values in your stream.
You can use skip to avoid all writings in your stream until you get back to the correct point of the execution where you can start writing again in the stream.

Available from the expert toolbar sub-menu:
<img width="668" alt="Capture d’écran 2022-08-09 à 15 50 55" src="https://user-images.githubusercontent.com/26929529/183666425-11f46d5d-57dc-44a9-acc7-90680fb05c32.png">

and from the code pane contextual menu:
<img width="301" alt="Capture d’écran 2022-08-09 à 15 51 09" src="https://user-images.githubusercontent.com/26929529/183666479-978d0d37-a0dc-426f-af2d-e70b281a9a92.png">

