### PR TITLE
Modified StDebuggerActionModel to use Exception>>defaultDescription…

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
@@ -81,6 +81,14 @@ StDebuggerContextPredicateTest >> testPrintHaltIfDescription [
 ]
 
 { #category : #tests }
+StDebuggerContextPredicateTest >> testPrintHaltNowDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ Halt now ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'Halt'.
+]
+
+{ #category : #tests }
 StDebuggerContextPredicateTest >> testPrintPostMortemDescription [
 	self skip.
 	predicate postMortem: true.

--- a/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
@@ -43,9 +43,25 @@ StDebuggerContextPredicateTest >> testIsSteppable [
 ]
 
 { #category : #tests }
+StDebuggerContextPredicateTest >> testPrintDNUDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ Object perform: #thisMessageIsNotUnderstood ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'Instance of Object class did not understand #thisMessageIsNotUnderstood'.
+]
+
+{ #category : #tests }
 StDebuggerContextPredicateTest >> testPrintDescription [
 	self skip.
 	self assert: predicate printDescription equals: '0'
+]
+
+{ #category : #tests }
+StDebuggerContextPredicateTest >> testPrintExceptionDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ Exception signal ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'Exception'.
 ]
 
 { #category : #tests }
@@ -57,8 +73,32 @@ StDebuggerContextPredicateTest >> testPrintHaltDescription [
 ]
 
 { #category : #tests }
+StDebuggerContextPredicateTest >> testPrintHaltIfDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ Halt if: [ true ] ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'Halt in [ Halt if: [ true ] ] in StDebuggerContextPredicateTest>>testPrintHaltIfDescription'.
+]
+
+{ #category : #tests }
 StDebuggerContextPredicateTest >> testPrintPostMortemDescription [
 	self skip.
 	predicate postMortem: true.
 	self assert: predicate printDescription equals: '[Post-mortem] 0'
+]
+
+{ #category : #tests }
+StDebuggerContextPredicateTest >> testPrintSignalInDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ Exception signalIn: thisContext ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'Exception'.
+]
+
+{ #category : #tests }
+StDebuggerContextPredicateTest >> testPrintTestFailureDescription [
+	self assert: (StDebuggerActionModel on: 
+			([ TestFailure signal ] on: Exception do: 
+				[ :e | StTestDebuggerProvider new sessionFor: nil exception: e ]) session) statusStringForContext
+		equals: 'TestFailure'.
 ]

--- a/src/NewTools-Debugger/Halt.extension.st
+++ b/src/NewTools-Debugger/Halt.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Halt }
+
+{ #category : #'*NewTools-Debugger' }
+Halt >> description [
+	(self signalContext receiver isKindOf: Exception) 
+		& (self signalContext selector = #signal) ifTrue: [ ^ 'Halt' ].
+	^ 'Halt in ', self signalContext asString.
+]

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -351,7 +351,7 @@ StDebuggerActionModel >> stackOfSize: anInteger [
 { #category : #context }
 StDebuggerActionModel >> statusStringForContext [
 
-	^ self contextPredicate printDescription
+	^ self exception description
 ]
 
 { #category : #'debug - stepping' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -351,7 +351,7 @@ StDebuggerActionModel >> stackOfSize: anInteger [
 { #category : #context }
 StDebuggerActionModel >> statusStringForContext [
 
-	^ self contextPredicate printDescription
+	^ self exception defaultDescription
 ]
 
 { #category : #'debug - stepping' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -351,7 +351,7 @@ StDebuggerActionModel >> stackOfSize: anInteger [
 { #category : #context }
 StDebuggerActionModel >> statusStringForContext [
 
-	^ self exception defaultDescription
+	^ self exception description
 ]
 
 { #category : #'debug - stepping' }


### PR DESCRIPTION
… as the debugger's window title rather than the context predicate. This brings the behavior of `Exception signalIn: thisContext` in line with `Exception signal`with respect to having the same window title.