### PR TITLE
[Debugger] Improving skipUpTo stability + reintegration in the advanced debugging tools

### DIFF
--- a/src/NewTools-Sindarin-Commands/SindarinSkipUpToSelectionCommand.class.st
+++ b/src/NewTools-Sindarin-Commands/SindarinSkipUpToSelectionCommand.class.st
@@ -11,8 +11,8 @@ SindarinSkipUpToSelectionCommand class >> defaultDescription [
 
 { #category : #'accessing - defaults' }
 SindarinSkipUpToSelectionCommand class >> defaultName [
-	"<toolbarExtensionDebugCommand: 50>
-	<codeExtensionDebugCommand: 50>"
+	<toolbarExtensionDebugCommand: 50>
+	<codeExtensionDebugCommand: 50>
 	^ '[Exp.] Skip up to (stop before)'
 ]
 
@@ -23,7 +23,7 @@ SindarinSkipUpToSelectionCommand >> execute [
 	self flag: 'Context should actually be a debugger or a sindarin debugger'.
 	self flag: 'Suspicious call to internal debugger UI state'.
 	targetNode := self context sindarinDebugger
-		bestNodeFor: self context code nonEmptySelectionInterval.
+		bestNodeFor: self context code selectionInterval.
 	self context sindarinDebugger skipUpToNode: targetNode.
 	self context forceSessionUpdate
 ]


### PR DESCRIPTION
skipUpTo command was very unstable and could easily make an image freeze. However, it has been improved a lot via a bunch of PRs in https://github.com/pharo-spec/ScriptableDebugger.

The only PR that needs to be integrated to make it completely stable is this one: https://github.com/pharo-spec/ScriptableDebugger/pull/48. Then, I believe that this could be integrated again in the debugger and that's why I make this PR as some people like @labordep and @astares are interested in this feature.

I also improved the command to make it more intuitive as, until now, the user had to select a message send or an assignment to skip up to this instruction, otherwise it would skip everything. I improved it so that putting a caret before a message send or assignment (or anything else) allows the user to skip up to this instruction.

This PR could be merged after https://github.com/pharo-spec/ScriptableDebugger/pull/48 is merged.