### PR TITLE
297-Inspector-Meta-tab-Browse-on-class-opens-UndefinedObject 

### DIFF
--- a/src/NewTools-Inspector/StMetaBrowser.class.st
+++ b/src/NewTools-Inspector/StMetaBrowser.class.st
@@ -128,7 +128,7 @@ StMetaBrowser >> selectedMethod [
 { #category : #accessing }
 StMetaBrowser >> selectedObject [
 
-	^ self selectedMethod
+	^ self selectedMethod ifNil: [ self selectedClass  ]
 ]
 
 { #category : #'private - updating' }


### PR DESCRIPTION
If selectedMethods is nil, return the selected class

fixes #297 
fixes https://github.com/pharo-project/pharo/issues/10241