### PR TITLE
Fix the UI of the spotter by outlining the input field. Fix pharo/#10993

### DIFF
--- a/src/NewTools-Morphic-Spotter/StSpotterStyleContributor.class.st
+++ b/src/NewTools-Morphic-Spotter/StSpotterStyleContributor.class.st
@@ -20,7 +20,7 @@ StSpotterStyleContributor >> styleSheetContribution [
 				addPropertyDrawWith: [ :draw | draw color: Color transparent ] ] ];
 		addClass: 'searchInputField' with: [ :class | class 
 			addClass: 'stSpotterSearch' with: [ :spotterClass | spotterClass
-				addPropertyDrawWith: [ :draw | draw color: Color transparent ];
+				addPropertyDrawWith: [ :draw | draw backgroundColor: Smalltalk ui theme lightBackgroundColor ];
 				addPropertyTextWith: [ :text | text drawKeyboardFocus: false ];
 				addPropertyGeometryWith: [ :geometry | geometry minHeight: 35; vResizing: false ];
 				addPropertyFontWith: [ :font | font size: (StandardFonts defaultFont pointSize * 1.2) asInteger ] ] ];


### PR DESCRIPTION
The input field is now light gray (or whatever according to the smalltalk theme), so it is obvious that the x cross belongs to the input field (and clears it) and does not belong to the whole modal window (and mistaken to a close button).

Done with @DanielCamSan