### PR TITLE
Bugfix: Browse class from Meta inspector pane

### DIFF
--- a/src/NewTools-Inspector/StMetaBrowser.class.st
+++ b/src/NewTools-Inspector/StMetaBrowser.class.st
@@ -128,7 +128,7 @@ StMetaBrowser >> selectedMethod [
 { #category : #accessing }
 StMetaBrowser >> selectedObject [
 
-	^ self selectedMethod
+	^ self selectedMethod ifNil: [ self selectedClass ]
 ]
 
 { #category : #'private - updating' }


### PR DESCRIPTION
Open class browser when clicking on "Browse" class menu in the Meta pane of inspector
Backported bug fix from P11 version
