### PR TITLE
inspected object name isnt truncated when it have more space

### DIFF
--- a/src/NewTools-Core/StHeaderBar.class.st
+++ b/src/NewTools-Core/StHeaderBar.class.st
@@ -65,7 +65,7 @@ StHeaderBar >> initializePresenters [
 		beNotHomogeneous;
 		borderWidth: 3;
 		spacing: 3;
-		add: (titleLabel := self newLabel) expand: false;
+		add: (titleLabel := self newLabel) expand: true;
 		add: (shortcutLabel := self newLabel) expand: false;
 		addLast: (toolbar := self newToolbar) expand: false;
 		yourself).

--- a/src/NewTools-Inspector/StInspectorModel.class.st
+++ b/src/NewTools-Inspector/StInspectorModel.class.st
@@ -85,7 +85,7 @@ StInspectorModel >> inspectedObject: anObject [
 { #category : #accessing }
 StInspectorModel >> labelString [
 	
-	^ self descriptionString truncateWithElipsisTo: 30
+	^ self descriptionString
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fix #426 