### PR TITLE
Register-as-basicInspector

### DIFF
--- a/src/NewTools-Inspector/StInspector.class.st
+++ b/src/NewTools-Inspector/StInspector.class.st
@@ -153,7 +153,8 @@ StInspector class >> register [
 { #category : #'tools registry' }
 StInspector class >> registerToolsOn: registry [
 	"self registerToolsOn: Smalltalk tools " 
-	registry register: self as: #inspector
+	registry register: self as: #inspector.
+	registry register: self as: #basicInspector
 ]
 
 { #category : #settings }


### PR DESCRIPTION
We do not have a basic inspector, to not have #basicInspect fail  (and the shortcut), see https://github.com/pharo-project/pharo/issues/10680