### PR TITLE
377-Uncategorised-method-in-StDebuggerCommandtransform 

### DIFF
--- a/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerCommand.class.st
@@ -108,9 +108,3 @@ StDebuggerCommand >> initialize [
 			<< shortcut asString
 			<< ']' ]])
 ]
-
-{ #category : #'as yet unclassified' }
-StDebuggerCommand >> transform: aBlock [
-
-	^ self
-]

--- a/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
+++ b/src/NewTools-Debugger/StDebuggerStackCommandTreeBuilder.class.st
@@ -55,8 +55,6 @@ StDebuggerStackCommandTreeBuilder >> buildSpecCommand: aCommandClass forContext:
 	| cmd |
 	cmd := super buildSpecCommand: aCommandClass forContext: stDebuggerInstance.
 	cmd name: aCommandClass shortName.
-	cmd innerCommand transform: aBlock.
-	
 	^ cmd
 ]
 

--- a/src/NewTools-ObjectCentricBreakpoints/StObjectBreakpointInspection.extension.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StObjectBreakpointInspection.extension.st
@@ -24,7 +24,5 @@ StObjectBreakpointInspection class >> removeBreakpointCommandFor: presenter [
 	| cmd |
 	cmd := StRemoveBreakpointCommand forSpecContext: presenter.
 	cmd iconName: #smallDelete.
-	cmd innerCommand
-		transform: [ :ctx | ctx methodsWithBreakpoints selection selectedItem ].
 	^ cmd
 ]


### PR DESCRIPTION
The discussion result in the issue was that #transform: can be removed.

This pr removes #transform and the two senders

fixes #377