### PR TITLE
remove the unused <return:> pragma in spotter

### DIFF
--- a/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterPragmaBasedProcessor.class.st
@@ -175,8 +175,6 @@ StSpotterPragmaBasedProcessor >> keyBinding [
 { #category : #accessing }
 StSpotterPragmaBasedProcessor >> order [
 	"Return assigned spotter order used to arrange categories in spotter UI"
-	<return: #Number>
-	
 	^ order
 ]
 

--- a/src/NewTools-Spotter/StSpotterCandidatesList.class.st
+++ b/src/NewTools-Spotter/StSpotterCandidatesList.class.st
@@ -139,17 +139,14 @@ StSpotterCandidatesList >> initialize [
 { #category : #testing }
 StSpotterCandidatesList >> isEmpty [
 	"Return true if there are no candidates in the list, false otherwise"
-	<return: #Boolean>
-
 	^ self candidates isEmpty
 ]
 
 { #category : #testing }
 StSpotterCandidatesList >> isNotEmpty [
 	"Return true if there is at least one candidate in the list, false otherwise"
-	<return: #Boolean>
 
-	^ self isEmpty not
+	^ self candidates isNotEmpty
 ]
 
 { #category : #processors }


### PR DESCRIPTION
remove the return pragma