### PR TITLE
Better-CompiledCode-Inspector: highlight in source

### DIFF
--- a/src/NewTools-Inspector-Extensions/BlockClosure.extension.st
+++ b/src/NewTools-Inspector-Extensions/BlockClosure.extension.st
@@ -1,8 +1,22 @@
 Extension { #name : #BlockClosure }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-BlockClosure >> inspectionSourceCode [
-	<inspectorPresentationOrder: 30 title: 'Source code'>
+BlockClosure >> inpectionIr [
+	<inspectorPresentationOrder: 35 title: 'IR'>
 
-	^ self sourceNode inspectionSourceCode
+	^ self method ir inpectionIr
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+BlockClosure >> inspectionAST [
+	<inspectorPresentationOrder: 35 title: 'AST'>
+
+	^ self sourceNode inspectionAST
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+BlockClosure >> inspectionSource [
+	<inspectorPresentationOrder: 30 title: 'Method Source'>
+
+	^ self sourceNode inspectionSource
 ]

--- a/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
@@ -4,19 +4,8 @@ Extension { #name : #CompiledBlock }
 CompiledBlock >> inspectionSource [
 	<inspectorPresentationOrder: 20 title: 'Method Source'>
 	
-	^ SpCodePresenter new 
-		beForMethod: self method;
-		text: self sourceCode;
+	^ self method inspectionSource
 		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
-			interval: (self sourceNode sourceInterval first to: self sourceNode sourceInterval last + 1);
-			yourself);
-		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
-			addItem: [ :item | item 
-				name: 'Browse method class'; 
-				action: [ self methodClass browse ] ] ]);
-		whenSubmitDo: [ :text | 
-			self isInstalled 
-				ifFalse: [ self inform: 'can not edit methods that are not installed' ]
-				ifTrue: [ self methodClass compile: text ]];
+			interval: (self sourceNode sourceInterval first to: self sourceNode sourceInterval last + 1));
 		yourself
 ]

--- a/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : #CompiledBlock }
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+CompiledBlock >> inspectionSource [
+	<inspectorPresentationOrder: 20 title: 'Method Source'>
+	
+	^ SpCodePresenter new 
+		beForMethod: self method;
+		text: self sourceCode;
+		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
+			interval: (self sourceNode sourceInterval first to: self sourceNode sourceInterval last + 1);
+			yourself);
+		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
+			addItem: [ :item | item 
+				name: 'Browse method class'; 
+				action: [ self methodClass browse ] ] ]);
+		whenSubmitDo: [ :text | 
+			self isInstalled 
+				ifFalse: [ self inform: 'can not edit methods that are not installed' ]
+				ifTrue: [ self methodClass compile: text ]];
+		yourself
+]

--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -63,40 +63,6 @@ CompiledCode >> inspectionItemsContext: aContext [
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }
-CompiledCode >> inspectionPragmas [
-	<inspectorPresentationOrder: 50 title: 'Pragmas'> 
-
-	^ SpListPresenter new
-		items: self pragmas;
-		display: [ :aPragma | aPragma printString ];
-		yourself
-]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
-CompiledCode >> inspectionPragmasContext: aContext [ 
-	
-	aContext active: self hasPragmas
-]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
-CompiledCode >> inspectionSource [
-	<inspectorPresentationOrder: 20 title: 'Source'>
-	
-	^ SpCodePresenter new 
-		beForMethod: self method;
-		text: self sourceCode;
-		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
-			addItem: [ :item | item 
-				name: 'Browse method class'; 
-				action: [ self methodClass browse ] ] ]);
-		whenSubmitDo: [ :text | 
-			self isInstalled 
-				ifFalse: [ self inform: 'can not edit methods that are not installed' ]
-				ifTrue: [ self methodClass compile: text ]];
-		yourself
-]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectorNodes [
 	"Answer a list of attributes as nodes"
 	| nodes |

--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -10,29 +10,14 @@ CompiledCode >> hasPragmas [
 CompiledCode >> inpectionIr [
 	<inspectorPresentationOrder: 35 title: 'IR'>
 
-	^ SpTextPresenter new 
-		text: (self ir longPrintString trimmed);
-		yourself
-
+	^ self ir inpectionIr
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionAST [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 
-	^ SpTreePresenter new 
-		roots: { self ast };
-		children: [ :aNode | aNode children ];
-		display: [ :each | 
-			String
-				streamContents: [ :stream | 
-					stream
-						nextPutAll: each class name;
-						nextPut: $(;
-						nextPutAll: ((each formattedCode truncateTo: 50) copyReplaceAll: String cr with: String space);
-						nextPut: $)
-			 ] ];
-		yourself
+	^ self sourceNode inspectionAST
 ]
 
 { #category : #'*NewTools-Inspector-Extensions' }

--- a/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
@@ -1,0 +1,35 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+CompiledMethod >> inspectionPragmas [
+	<inspectorPresentationOrder: 50 title: 'Pragmas'> 
+
+	^ SpListPresenter new
+		items: self pragmas;
+		display: [ :aPragma | aPragma printString ];
+		yourself
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+CompiledMethod >> inspectionPragmasContext: aContext [ 
+	
+	aContext active: self hasPragmas
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+CompiledMethod >> inspectionSource [
+	<inspectorPresentationOrder: 20 title: 'Source'>
+	
+	^ SpCodePresenter new 
+		beForMethod: self method;
+		text: self sourceCode;
+		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
+			addItem: [ :item | item 
+				name: 'Browse method class'; 
+				action: [ self methodClass browse ] ] ]);
+		whenSubmitDo: [ :text | 
+			self isInstalled 
+				ifFalse: [ self inform: 'can not edit methods that are not installed' ]
+				ifTrue: [ self methodClass compile: text ]];
+		yourself
+]

--- a/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
@@ -18,7 +18,7 @@ CompiledMethod >> inspectionPragmasContext: aContext [
 
 { #category : #'*NewTools-Inspector-Extensions' }
 CompiledMethod >> inspectionSource [
-	<inspectorPresentationOrder: 20 title: 'Source'>
+	<inspectorPresentationOrder: 20 title: 'Method Source'>
 	
 	^ SpCodePresenter new 
 		beForMethod: self method;

--- a/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
@@ -1,31 +1,8 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionASTDump [
-	<inspectorPresentationOrder: 50 title: 'AST Dump'>
-
-	^ SpCodePresenter new 
-		text: (RBParser parseExpression: self dump) formattedCode; 
-		beForScripting; "this is an expression"
-		yourself
-]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionSourceCode [
-	<inspectorPresentationOrder: 30 title: 'Source code'>
-
-	^ SpCodePresenter new 
-		beForMethod: self methodNode;
-		text: (self source ifNil: [ self formattedCode ]);
-		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
-			interval: (self sourceInterval first to: self sourceInterval last + 1);
-			yourself);
-		yourself
-]
-
-{ #category : #'*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionTree [
-	<inspectorPresentationOrder: 35 title: 'Tree'>
+RBProgramNode >> inspectionAST [
+	<inspectorPresentationOrder: 35 title: 'AST'>
 
 	^ SpTreePresenter new 
 		roots: { self };
@@ -39,5 +16,28 @@ RBProgramNode >> inspectionTree [
 						nextPutAll: ((each formattedCode truncateTo: 50) copyReplaceAll: String cr with: String space);
 						nextPut: $)
 			 ] ];
+		yourself
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+RBProgramNode >> inspectionASTDump [
+	<inspectorPresentationOrder: 50 title: 'AST Dump'>
+
+	^ SpCodePresenter new 
+		text: (RBParser parseExpression: self dump) formattedCode; 
+		beForScripting; "this is an expression"
+		yourself
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+RBProgramNode >> inspectionSource [
+	<inspectorPresentationOrder: 30 title: 'Method Source'>
+
+	^ SpCodePresenter new 
+		beForMethod: self methodNode;
+		text: (self source ifNil: [ self formattedCode ]);
+		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
+			interval: (self sourceInterval first to: self sourceInterval last + 1);
+			yourself);
 		yourself
 ]

--- a/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
+++ b/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : #SymbolicBytecode }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-SymbolicBytecode >> inspectionSourceCode [
-	<inspectorPresentationOrder: 30 title: 'Source'>
+SymbolicBytecode >> inspectionSource [
+	<inspectorPresentationOrder: 30 title: 'Method Source'>
 
 	^ SpCodePresenter new 
 		beForBehavior: self method methodClass;


### PR DESCRIPTION
- When inspecting a CompiledBlock, highlight in the source where this…
- move Pragma inspector to CompiledMethod (as Blocks have no Pragmas for now)