### PR TITLE
Fix: "Copy stack to clipboard" doesnt copy the whole stack

### DIFF
--- a/src/NewTools-Debugger-Commands/StCopyStackToClipboardCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StCopyStackToClipboardCommand.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #initialization }
 StCopyStackToClipboardCommand class >> defaultDescription [
-	^ 'Copy a short debugging stack to the clipboard.'
+	^ 'Copy the debugging stack to the clipboard.'
 ]
 
 { #category : #initialization }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -108,7 +108,7 @@ StDebuggerActionModel >> copyStackToClipboard [
 	Clipboard
 		clipboardText:
 			(String
-				streamContents: [ :s | self interruptedContext shortDebugStackOn: s ])
+				streamContents: [ :s | self interruptedContext printDebugStackOn: s ])
 ]
 
 { #category : #'stack - helpers' }


### PR DESCRIPTION
See: https://github.com/pharo-project/pharo/pull/11983