### PR TITLE
StDebugger-stackSelectionMethodContext-homeMethod

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1158,7 +1158,7 @@ StDebugger >> stackOfSize: anInteger [
 { #category : #'commands - support' }
 StDebugger >> stackSelectionMethodContext [
 
-	^ [ :dbg | stackTable selection selectedItem home method ]
+	^ [ :dbg | stackTable selection selectedItem homeMethod ]
 ]
 
 { #category : #'commands - support' }


### PR DESCRIPTION
use #homeMethod (it is odd that the method named -Context returns a method, but that is to be checked later)