### PR TITLE
Fix spotter bug while clicking a header

### DIFF
--- a/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSpotterProcessor.class.st
@@ -229,6 +229,12 @@ StSpotterProcessor >> itemIcon [
 ]
 
 { #category : #accessing }
+StSpotterProcessor >> itemIconName [
+
+	^ [ :item | item systemIconName ]
+]
+
+{ #category : #accessing }
 StSpotterProcessor >> itemName [
 
 	^ [ :anItem | anItem asString ]


### PR DESCRIPTION
Here is a reproduction of the bug: 
![Pharo_2023-02-02_13-09-39](https://user-images.githubusercontent.com/9519971/216322477-29624c18-65c9-4827-8c9e-9417ce63ffd2.gif)
