### PR TITLE
fix test of Sindarin when timesRepeat: is optimized

### DIFF
--- a/src/NewTools-Sindarin-Commands-Tests/SindarinTestObjectToVisit.class.st
+++ b/src/NewTools-Sindarin-Commands-Tests/SindarinTestObjectToVisit.class.st
@@ -32,8 +32,8 @@ SindarinTestObjectToVisit >> acceptVisitorMultipleObjects: aVisitor [
 
 { #category : #visitors }
 SindarinTestObjectToVisit >> acceptVisitorNeverFinishes: aVisitor [
-
-	self timesRepeat: [ self doStuff ]
+	<compilerOptions: #(- optionInlineTimesRepeat)>
+	10000 timesRepeat: [ self doStuff ]
 ]
 
 { #category : #visitors }
@@ -63,10 +63,4 @@ SindarinTestObjectToVisit >> doNotAcceptVisitor: aVisitor [
 SindarinTestObjectToVisit >> doStuff [
 
 	^ self
-]
-
-{ #category : #enumerating }
-SindarinTestObjectToVisit >> timesRepeat: aBlock [
-	"we implement it here to not use the optimized timesRepeat:"
-	10000 timesRepeat: aBlock
 ]


### PR DESCRIPTION
When enabeling timesRepeat optimization, we have a failing test.

The test was writting with the non-optimized timesRepeat behavior taken into account, but testing something else.

The simplest is to not optimize in this case