### PR TITLE
Removing the TStDebuggerExtension trait from the dummy debugger presenter

### DIFF
--- a/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
+++ b/src/NewTools-Debugger-Tests/StDummyDebuggerPresenter.class.st
@@ -6,10 +6,9 @@ The debugger interface itself is tested in the debugger test class.
 Class {
 	#name : #StDummyDebuggerPresenter,
 	#superclass : #SpPresenter,
-	#traits : 'TStDebuggerExtension',
-	#classTraits : 'TStDebuggerExtension classTrait',
 	#instVars : [
-		'tag'
+		'tag',
+		'debugger'
 	],
 	#category : #'NewTools-Debugger-Tests-Utils'
 }
@@ -44,9 +43,19 @@ StDummyDebuggerPresenter >> currentContext [
 ]
 
 { #category : #accessing }
+StDummyDebuggerPresenter >> debugger [
+	^debugger
+]
+
+{ #category : #accessing }
 StDummyDebuggerPresenter >> debuggerExtensionToolName [
 	^'Test extendedDebuggingToolTitle'
 	
+]
+
+{ #category : #layout }
+StDummyDebuggerPresenter >> debuggerLayout [
+	^self defaultLayout 
 ]
 
 { #category : #layout }
@@ -96,6 +105,11 @@ tag := thisContext method selector.
 StDummyDebuggerPresenter >> selectNextExecutedExpression [
 tag := thisContext method selector.
 ^true
+]
+
+{ #category : #accessing }
+StDummyDebuggerPresenter >> setModelBeforeInitialization: aDebugger [
+	 debugger := aDebugger
 ]
 
 { #category : #mocks }


### PR DESCRIPTION
Avoids having this dummy debugger presenter intended for tests as a possible system extension.
Added methods to fill the missing behavior due to the trait removal.

Fixes https://github.com/pharo-spec/NewTools/issues/404