### PR TITLE
Adding new rewrite tools

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -30,7 +30,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #('NewTools-Core') ];
 			package: 'NewTools-Inspector-Tests' with: [ spec requires: #('NewTools-Inspector') ];
 			"debugger"
-			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions' 'NewTools-SpTextPresenterDecorators') ];			
+			package: 'NewTools-Debugger' with: [ spec requires: #('NewTools-Inspector' 'NewTools-Debugger-Commands' 'NewTools-Debugger-Extensions' 'NewTools-SpTextPresenterDecorators') ];
 			package: 'NewTools-Debugger-Commands';
 			package: 'NewTools-Debugger-Extensions';
 			package: 'NewTools-Debugger-Tests' with: [ spec requires: #('NewTools-Debugger') ];
@@ -61,7 +61,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-ProjectLoader';
 			package: 'NewTools-ProjectLoader-Microdown';
 			"Object-centric breakpoints"
-			package: 'NewTools-ObjectCentricBreakpoints';			
+			package: 'NewTools-ObjectCentricBreakpoints';
 			"Sindarin"
 			package: 'NewTools-Sindarin-Commands';
 			package: 'NewTools-Sindarin-Commands-Tests' with: [  spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];
@@ -76,18 +76,23 @@ BaselineOfNewTools >> baseline: spec [
 			"Fuel"
 			package: 'NewTools-Debugger-Fuel';
 			package: 'NewTools-Debugger-Fuel-Tests' with: [ spec requires: #('NewTools-Debugger-Fuel') ];
-			package: 'NewTools-Fuel'.
-			
+			package: 'NewTools-Fuel';
+			"Rewriter Tools"
+			package: 'NewTools-RewriterTools-Backend';
+			package: 'NewTools-RewriterTools' with: [ spec requires: #('NewTools-RewriterTools-Backend') ];
+			package: 'NewTools-RewriterTools-Backend-Tests' with: [ spec requires: #('NewTools-RewriterTools-Backend') ];
+			package: 'NewTools-RewriterTools-Tests' with: [ spec requires: #('NewTools-RewriterTools') ].
+
 		spec
 			group: 'Core' with: #('NewTools-Core' 'NewTools-Morphic');
 			group: 'Playground' with: #('Core' 'NewTools-Playground' 'NewTools-Playground-Tests');
 			group: 'Inspector' with: #('Core' 'NewTools-Inspector' 'NewTools-Inspector-Tests');
 			group: 'Debugger' with: #(
-				'Core' 
-				'Inspector' 
+				'Core'
+				'Inspector'
 				'NewTools-Debugger-Commands'
 				'NewTools-Debugger-Extensions'
-				'NewTools-Debugger' 
+				'NewTools-Debugger'
 				'NewTools-ObjectCentricBreakpoints'
 				'NewTools-Sindarin-Tools'
 				'NewTools-Sindarin-Commands'
@@ -98,9 +103,9 @@ BaselineOfNewTools >> baseline: spec [
 				'NewTools-Debugger-Fuel-Tests'
 				'NewTools-Fuel');
 			group: 'Spotter' with: #(
-				'NewTools-Morphic-Spotter' 
-				'NewTools-Spotter-Processors' 
-				'NewTools-Spotter' 
+				'NewTools-Morphic-Spotter'
+				'NewTools-Spotter-Processors'
+				'NewTools-Spotter'
 				'NewTools-Spotter-Extensions'
 				'NewTools-Spotter-Tests'
 				'NewTools-Spotter-Processors-Tests');
@@ -112,25 +117,31 @@ BaselineOfNewTools >> baseline: spec [
 			group: 'CritiqueBrowser' with: #('NewTools-CodeCritiques' 'NewTools-CodeCritiques-Tests');
 			group: 'FontChooser' with: #('Core' 'NewTools-FontChooser' 'NewTools-FontChooser-Tests');
 			group: 'FlagBrowser' with: #(
-				'Core' 
-				'NewTools-FlagBrowser' 
+				'Core'
+				'NewTools-FlagBrowser'
 				'NewTools-FlagBrowser-Tests');
 			group: #development with: #('default'
-				'NewTools-DebuggerSelector' 
+				'NewTools-DebuggerSelector'
 				'NewTools-DebuggerSelector-Tests');
 			group: #FileBrowser with: #(
-				'NewTools-FileBrowser' 
+				'NewTools-FileBrowser'
 				'NewTools-FileBrowser-Tests');
+			group: #RewriterTools with: #(
+				'NewTools-RewriterTools-Backend'
+				'NewTools-RewriterTools'
+				'NewTools-RewriterTools-Backend-Tests'
+				'NewTools-RewriterTools-Tests');
 			group: 'default' with: #(
-				'Playground' 
-				'Inspector' 
+				'Playground'
+				'Inspector'
 				'CritiqueBrowser'
-				'Debugger' 
+				'Debugger'
 				'SystemReporter'
 				'ChangeSorter'
 				'FontChooser'
 				'Methods'
-				'Spotter') ]
+				'Spotter'
+				'RewriterTools') ]
 ]
 
 { #category : #'external projects' }

--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -101,6 +101,15 @@ StPharoApplication >> startUp: resuming [
 ]
 
 { #category : #settings }
+StPharoApplication >> styleSheet [
+
+	^ SpStyle defaultStyleSheet , (SpStyleVariableSTONReader fromString:
+		'.application [
+	.bgOpaque [ Draw { #backgroundColor: EnvironmentColor(#base) } ]
+]')
+]
+
+{ #category : #settings }
 StPharoApplication >> toolbarDisplayMode [
 
 	^ StPharoSettings toolbarDisplayMode

--- a/src/NewTools-RewriterTools-Backend-Tests/RTPatternMatcherTest.class.st
+++ b/src/NewTools-RewriterTools-Backend-Tests/RTPatternMatcherTest.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : #RTPatternMatcherTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'patternMatcher'
+	],
+	#category : #'NewTools-RewriterTools-Backend-Tests'
+}
+
+{ #category : #running }
+RTPatternMatcherTest >> setUp [
+	super setUp.
+
+	patternMatcher := StRewriterPatternMatcher
+]
+
+{ #category : #tests }
+RTPatternMatcherTest >> testParseCodeASTIsForMethod [
+
+	| code methodCode codeAST |
+	code := '| aNumber |
+aNumber ifNil: [ ^ self ].
+aNumber := 5.'.
+	methodCode := 'calculate
+| aNumber |
+aNumber ifNil: [ ^ self ].
+aNumber := 5.'.
+
+	codeAST := patternMatcher parseCodeAST: code isForMethod: false.
+	self
+		assert: codeAST sourceCode
+		equals: code.
+
+	codeAST := patternMatcher parseCodeAST: methodCode isForMethod: true.
+	self
+		assert: codeAST sourceCode
+		equals: methodCode
+]
+
+{ #category : #tests }
+RTPatternMatcherTest >> testParsePatternASTIsForMethod [
+
+	| rule methodRule ast |
+	rule := '| `object |
+`object ifNil: [ ^ self ].
+`.Statement.'.
+	methodRule := '`aMethod
+| `object |
+`object ifNil: [ ^ self ].
+`.Statement.'.
+
+	ast := patternMatcher parsePatternAST: rule isForMethod: false.
+	self
+		assert: ast sourceCode
+		equals: rule.
+
+	ast := patternMatcher parsePatternAST: methodRule isForMethod: true.
+	self
+		assert: ast sourceCode
+		equals: methodRule
+]
+
+{ #category : #tests }
+RTPatternMatcherTest >> testPerformMatchingPatternIsForMethod [
+
+	| pharoCode patternCode matches |
+	pharoCode := 'a = b ifTrue: [ x = y ifTrue: [ aBlock ] ]'.
+	patternCode := '`@expression ifTrue: [ `@codeBlock ]'.
+	matches := patternMatcher
+		performMatching: pharoCode
+		pattern: patternCode
+		isForMethod: false.
+
+	self assert: matches size equals: 2
+]

--- a/src/NewTools-RewriterTools-Backend-Tests/package.st
+++ b/src/NewTools-RewriterTools-Backend-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-RewriterTools-Backend-Tests' }

--- a/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
@@ -1,0 +1,37 @@
+"
+I am the abstract class for applying a code transformation
+"
+Class {
+	#name : #StRewriterAbstractApplier,
+	#superclass : #Object,
+	#category : #'NewTools-RewriterTools-Backend-Core'
+}
+
+{ #category : #api }
+StRewriterAbstractApplier class >> applyTransformationChanges: changes [
+
+	| refactoringJob |
+	refactoringJob := [
+		changes do: [ :change | RBRefactoryChangeManager instance performChange: change ] ] asJob.
+	refactoringJob
+		title: 'Refactoring';
+		run
+]
+
+{ #category : #api }
+StRewriterAbstractApplier class >> calculateAllChangesForRules: ruleHolderCollection [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #api }
+StRewriterAbstractApplier class >> calculateChangesForClasses: classes transformationRules: ruleHolderCollection [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #api }
+StRewriterAbstractApplier class >> defaultEngineApplier [
+
+	^ StRewriterRBApplier
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterDemoRules.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterDemoRules.class.st
@@ -1,0 +1,156 @@
+"
+I am a class that creates some demo rules to be used as rule examples
+"
+Class {
+	#name : #StRewriterDemoRules,
+	#superclass : #Object,
+	#category : #'NewTools-RewriterTools-Backend-DefaultRule'
+}
+
+{ #category : #api }
+StRewriterDemoRules class >> defaultRule [
+
+	| lhs rhs inputCode |
+	lhs := '(`@receiver collect: `@arg) flattened'.
+	rhs := '`@receiver flatCollect: `@arg'.
+	inputCode := '(RBBrowserEnvironment default packages collect: #classes) flattened'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs pharoCode: inputCode
+]
+
+{ #category : #api }
+StRewriterDemoRules class >> demoRules [
+
+	^ {
+		  self simplifyToIfNilIfNotNilRule.
+		  self replaceAssertToAssertEmptyRule.
+		  self simpliflyConditionalToIsEmptyRule.
+		  self removeEqualsInAssertRule.
+		  self replaceDenyDenyEmptyRule.
+		  self replaceCharacterTabAsStringToStringTabRule.
+		  self simpliflyToIfEmptyIfNotEmptyRule.
+		  self removeIfNilRule.
+		  self replaceSelectToRejectRule.
+		  self removeAssignmentWithoutEffectRule.
+		  self replaceCollectFlattenToFlatCollectRule }
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> removeAssignmentWithoutEffectRule [
+
+	| lhs rhs ruleName |
+	lhs := '`var := `var'.
+	rhs := ''.
+	ruleName := 'Remove assignment without effect'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> removeEqualsInAssertRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver assert: `@arg equals: true'.
+	rhs := '`@receiver assert: `@arg'.
+	ruleName := 'Remove equals in assert'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> removeIfNilRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver ifNil: [ nil ] ifNotNil: `@arg'.
+	rhs := '`@receiver ifNotNil: `@arg'.
+	ruleName := 'Remove unnecessary ifNil:'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> replaceAssertToAssertEmptyRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver assert: `@arg isEmpty'.
+	rhs := '`@receiver assertEmpty: `@arg'.
+	ruleName := 'Replace assert to assert empty'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> replaceCharacterTabAsStringToStringTabRule [
+
+	| lhs rhs ruleName |
+	lhs := 'Character tab asString'.
+	rhs := 'String tab'.
+	ruleName := 'Replace Character tab asString to String tab'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> replaceCollectFlattenToFlatCollectRule [
+
+	| lhs rhs ruleName |
+	lhs := '(`@receiver collect: `@arg) flattened'.
+	rhs := '`@receiver flatCollect: `@arg'.
+	ruleName := 'Replace collect: flatten to flatCollect:'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> replaceDenyDenyEmptyRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver select: [ :`each |
+	| `@temps |
+	``@.Statements.
+	``@object not ]'.
+	rhs := '`@receiver denyEmpty: `@arg'.
+	ruleName := 'Replace deny: isEmpty to denyEmpty:'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> replaceSelectToRejectRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver select: [ :`each |
+	| `@temps |
+	``@.Statements.
+	``@object not ]'.
+	rhs := '`@receiver reject: [ :`each |
+	| `@temps |
+	``@.Statements.
+	``@object ]'.
+	ruleName := 'Replace select to reject'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> simpliflyConditionalToIsEmptyRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver ifEmpty: [ true ] ifNotEmpty: [ false ]'.
+	rhs := '`@receiver isEmpty'.
+	ruleName := 'Simplify conditional to isEmpty'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> simpliflyToIfEmptyIfNotEmptyRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver isEmpty ifTrue: `@arg ifFalse: `@arg2'.
+	rhs := '`@receiver ifEmpty: `@arg ifNotEmpty: `@arg2'.
+	ruleName := 'Simplify to ifEmpty: ifNotEmpty:'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]
+
+{ #category : #rules }
+StRewriterDemoRules class >> simplifyToIfNilIfNotNilRule [
+
+	| lhs rhs ruleName |
+	lhs := '`@receiver isNil
+	ifTrue: `@arg
+	ifFalse: `@arg2'.
+	rhs := '`@receiver ifNil: `@arg ifNotNil: `@arg2'.
+	ruleName := 'Simplify to ifNil: ifNotNil:'.
+	^ StRewriterRuleHolder lhs: lhs rhs: rhs name: ruleName
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterEnvironmentCreator.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterEnvironmentCreator.class.st
@@ -1,0 +1,20 @@
+"
+I am a class that creates an environment in which a set of rewrite rules can be applied.
+"
+Class {
+	#name : #StRewriterEnvironmentCreator,
+	#superclass : #Object,
+	#category : #'NewTools-RewriterTools-Backend-Core'
+}
+
+{ #category : #api }
+StRewriterEnvironmentCreator class >> scopeEnvironmentForAllPackages [
+
+	^ RBPackageEnvironment packages: RPackageOrganizer default packages
+]
+
+{ #category : #api }
+StRewriterEnvironmentCreator class >> scopeEnvironmentForClasses: classes [
+
+	^ RBClassEnvironment classes: classes
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterPatternMatcher.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterPatternMatcher.class.st
@@ -1,0 +1,43 @@
+"
+I am a class that is used to perform matches between pharo code and rewrite rules code.
+"
+Class {
+	#name : #StRewriterPatternMatcher,
+	#superclass : #Object,
+	#category : #'NewTools-RewriterTools-Backend-Core'
+}
+
+{ #category : #parsing }
+StRewriterPatternMatcher class >> parseCodeAST: code isForMethod: isForMethod [
+
+	^ isForMethod
+		ifTrue: [ RBParser parseMethod: code ]
+		ifFalse: [ RBParser parseExpression: code ]
+]
+
+{ #category : #parsing }
+StRewriterPatternMatcher class >> parsePatternAST: lhs isForMethod: isForMethod [
+
+	^ isForMethod
+		ifTrue: [ RBPatternParser parseMethod: lhs ]
+		ifFalse: [ RBPatternParser parseExpression: lhs ]
+]
+
+{ #category : #parsing }
+StRewriterPatternMatcher class >> performMatching: pharoCode pattern: lhs isForMethod: isForMethod [
+
+	| matches astCode astPattern |
+	matches := OrderedCollection new.
+
+	astPattern := self parsePatternAST: lhs isForMethod: isForMethod.
+	astCode := self parseCodeAST: pharoCode isForMethod: isForMethod.
+
+	astCode doSemanticAnalysis.
+	astCode nodesDo: [ :node |
+		astPattern
+			match: node
+			onSuccess: [ :bindings | matches add: node -> bindings ]
+			onFailure: [  ] ].
+
+	^ matches
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterRBApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterRBApplier.class.st
@@ -1,0 +1,55 @@
+"
+I use the RB rules to apply transformation rules to a set of methods
+"
+Class {
+	#name : #StRewriterRBApplier,
+	#superclass : #StRewriterAbstractApplier,
+	#category : #'NewTools-RewriterTools-Backend-Core'
+}
+
+{ #category : #api }
+StRewriterRBApplier class >> calculateAllChangesForRules: ruleHolderCollection [
+
+	| env rewriter |
+	env := StRewriterEnvironmentCreator scopeEnvironmentForAllPackages.
+	rewriter := self rewriter: ruleHolderCollection.
+
+	^ self obtainChanges: env rewriter: rewriter
+]
+
+{ #category : #api }
+StRewriterRBApplier class >> calculateChangesForClasses: classes transformationRules: ruleHolderCollection [
+
+	| env rewriter |
+	env := StRewriterEnvironmentCreator scopeEnvironmentForClasses: classes.
+	rewriter := self rewriter: ruleHolderCollection.
+
+	^ self obtainChanges: env rewriter: rewriter
+]
+
+{ #category : #private }
+StRewriterRBApplier class >> obtainChanges: env rewriter: rewriter [
+
+	| checker transformationRule |
+	transformationRule := RBTransformationRule new
+		rewriteRule: rewriter;
+		yourself.
+
+	checker := RBSmalllintChecker new
+		rule: transformationRule;
+		environment: env.
+	checker run.
+	^ transformationRule changes
+]
+
+{ #category : #private }
+StRewriterRBApplier class >> rewriter: ruleHolderCollection [
+
+	| rewriter |
+	rewriter := RBParseTreeRewriter new.
+	ruleHolderCollection do: [ :ruleHolder |
+		ruleHolder isRuleForMethod
+			ifTrue: [ rewriter replaceMethod: ruleHolder lhs with: ruleHolder rhs ]
+			ifFalse: [ rewriter replace: ruleHolder lhs with: ruleHolder rhs ] ].
+	^ rewriter
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterRenrakuApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterRenrakuApplier.class.st
@@ -1,0 +1,71 @@
+"
+I am a class that is in charge to apply a rule, that is represented in an object `RTRuleHolder` to a set of methods.
+
+I use the Renraku engine for applying the transformation rules.
+"
+Class {
+	#name : #StRewriterRenrakuApplier,
+	#superclass : #StRewriterAbstractApplier,
+	#category : #'NewTools-RewriterTools-Backend-Core'
+}
+
+{ #category : #api }
+StRewriterRenrakuApplier class >> calculateAllChangesForRules: aRulesCollection [
+
+	| allSystemMethods |
+	allSystemMethods := (RPackage organizer packages flatCollect: [:each | each classes])
+		flatCollect: [ :each | each methods] as: Set.
+
+	^ self calculateChangesForClasses: allSystemMethods asSet transformationRules: aRulesCollection
+]
+
+{ #category : #api }
+StRewriterRenrakuApplier class >> calculateChangesForClasses: methods transformationRules: rules [
+
+	| critiques changes |
+	critiques := self obtainCritiquesOf: methods forRules: rules.
+	"At this point you have a collection of critiques. Each critique can tell you which rule created it, and which target it criticizes.
+	As the critiques are 'smart', the type you have here (node replace critiques) can give you change compatible with the ChangesBrowser or RewriteChangesBrowser."
+	changes := critiques collect: [: each | each change].
+	^ changes
+]
+
+{ #category : #private }
+StRewriterRenrakuApplier class >> obtainCritiquesOf: methods forRules: ruleHolderCollection [
+
+	"This is a way to obtain the same changes array as obtainChanges:forRule: method. But, here this is done without an RBClassEnvironment and ReSmalllintChecker. Because those two classes inherits from RB rules and will be eventually will be deprecated."
+
+	"Take the methods and apply the rule on each of them (in fact on their nodes).
+Take a look on ReCriticEngine for some automation ideas. Also take a look at CompiledMethod >> #critiques"
+
+	| methodsAsSet critiques rewriteNode |
+	"Extract all the methods from the needed classes.
+	asSet message is needed because sometimes can return duplicated methods of the same classes."
+	methodsAsSet := methods asSet.
+	critiques := OrderedCollection new.
+	rewriteNode := ReNodeRewriteRule new.
+	ruleHolderCollection do: [ :aRuleHolder |
+		aRuleHolder isRuleForMethod
+			ifTrue: [ rewriteNode addMatchingMethod: aRuleHolder lhs rewriteTo: aRuleHolder rhs ]
+			ifFalse: [ rewriteNode addMatchingExpression: aRuleHolder lhs rewriteTo: aRuleHolder rhs ] ].
+	methodsAsSet do: [ :method |
+		| rulesCritiques |
+		"We need to run the rule for each method and combine resulting critiques.
+		In fact rewrite rules check AST nodes. So, we need to run the rule for every AST node of the method and combine the results."
+		rulesCritiques := method ast allChildren flatCollect: [ :node | rewriteNode check: node ].
+
+			"This is a hack. Resulting critiques will tell they reffer to a single AST node.
+			But, as the rewriting functionality requires actual method instances, we go over each critique and reassign the source entity to the method."
+		rulesCritiques do: [ :critique | critique sourceAnchor initializeEnitity: method ].
+		critiques addAll: rulesCritiques ]
+	displayingProgress: [ :method | 'Running critics on: ' , method methodClass name ].
+	^ critiques
+]
+
+{ #category : #private }
+StRewriterRenrakuApplier class >> obtainCritiquesOfAllMethodsForRules: ruleHolderCollection [
+
+	| methods |
+	methods := (RPackage organizer packages flatCollect: #classes) flatCollect: #methods.
+	^ self obtainCritiquesOf: methods forRules: ruleHolderCollection
+]

--- a/src/NewTools-RewriterTools-Backend/StRewriterRuleHolder.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterRuleHolder.class.st
@@ -1,0 +1,133 @@
+"
+I am a class that is used only to store the information of a rule
+"
+Class {
+	#name : #StRewriterRuleHolder,
+	#superclass : #Object,
+	#instVars : [
+		'lhs',
+		'rhs',
+		'isForMethod',
+		'name',
+		'pharoCode'
+	],
+	#category : #'NewTools-RewriterTools-Backend-DataStructure'
+}
+
+{ #category : #'instance creation' }
+StRewriterRuleHolder class >> lhs: lhs rhs: rhs [
+
+	^ self new
+		lhs: lhs;
+		rhs: rhs;
+		yourself
+]
+
+{ #category : #'instance creation' }
+StRewriterRuleHolder class >> lhs: lhs rhs: rhs isForMethod: isForMethod [
+
+	^ self new
+		lhs: lhs;
+		rhs: rhs;
+		isRuleForMethod: isForMethod;
+		yourself
+]
+
+{ #category : #'instance creation' }
+StRewriterRuleHolder class >> lhs: lhs rhs: rhs isForMethod: isForMethod pharoCode: inputCode [
+
+	^ self new
+		lhs: lhs;
+		rhs: rhs;
+		isRuleForMethod: isForMethod;
+		pharoCode: inputCode;
+		yourself
+]
+
+{ #category : #'instance creation' }
+StRewriterRuleHolder class >> lhs: lhs rhs: rhs name: aName [
+
+	^ self new
+		lhs: lhs;
+		rhs: rhs;
+		name: aName;
+		yourself
+]
+
+{ #category : #'instance creation' }
+StRewriterRuleHolder class >> lhs: lhs rhs: rhs pharoCode: aString [
+
+	^ self new
+		lhs: lhs;
+		rhs: rhs;
+		pharoCode: aString;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterRuleHolder >> initialize [
+
+	super initialize.
+	isForMethod := false.
+	pharoCode := ''
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> isRuleForMethod [
+
+	^ isForMethod
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> isRuleForMethod: anObject [
+
+	isForMethod := anObject
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> lhs [
+
+	^ lhs
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> lhs: anObject [
+
+	lhs := anObject
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> name [
+
+	^ name
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> name: aString [
+
+	name := aString
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> pharoCode [
+
+	^ pharoCode
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> pharoCode: anObject [
+
+	pharoCode := anObject
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> rhs [
+
+	^ rhs
+]
+
+{ #category : #accessing }
+StRewriterRuleHolder >> rhs: anObject [
+
+	rhs := anObject
+]

--- a/src/NewTools-RewriterTools-Backend/package.st
+++ b/src/NewTools-RewriterTools-Backend/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-RewriterTools-Backend' }

--- a/src/NewTools-RewriterTools-Tests/StRewriterAbstractToolTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterAbstractToolTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #StRewriterAbstractToolTest,
+	#superclass : #TestCase,
+	#category : #'NewTools-RewriterTools-Tests-AbstractTestClass'
+}
+
+{ #category : #testing }
+StRewriterAbstractToolTest class >> isAbstract [
+
+	^ self = StRewriterAbstractToolTest
+]
+
+{ #category : #tests }
+StRewriterAbstractToolTest >> testDescriptionText [
+
+	self assert: self toolClass descriptionText isString.
+	self assert: self toolClass descriptionText isNotEmpty
+]
+
+{ #category : #tests }
+StRewriterAbstractToolTest >> testIcon [
+
+	self assert: self toolClass icon isForm
+]
+
+{ #category : #tests }
+StRewriterAbstractToolTest >> testIconName [
+
+	self assert: self toolClass iconName isSymbol
+]
+
+{ #category : #tests }
+StRewriterAbstractToolTest >> testTitle [
+
+	self deny: self toolClass title equals: 'Untitled window'
+]
+
+{ #category : #accessing }
+StRewriterAbstractToolTest >> toolClass [
+
+	^ self subclassResponsibility
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterExpressionFinderPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterExpressionFinderPresenterTest.class.st
@@ -1,0 +1,31 @@
+"
+An ExpressionFinderPresenterTest is a test class for testing the behavior of ExpressionFinderPresenter
+"
+Class {
+	#name : #StRewriterExpressionFinderPresenterTest,
+	#superclass : #StRewriterAbstractToolTest,
+	#instVars : [
+		'expressionFinder'
+	],
+	#category : #'NewTools-RewriterTools-Tests-ExpressionFinder'
+}
+
+{ #category : #running }
+StRewriterExpressionFinderPresenterTest >> setUp [
+
+	super setUp.
+	expressionFinder := StRewriterExpressionFinderPresenter new
+]
+
+{ #category : #tests }
+StRewriterExpressionFinderPresenterTest >> testPatternCode [
+
+	expressionFinder patternCode: 'A pattern'.
+	self assert: expressionFinder patternCode equals: 'A pattern'
+]
+
+{ #category : #accessing }
+StRewriterExpressionFinderPresenterTest >> toolClass [
+
+	^ StRewriterExpressionFinderPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterMatchToolPresenter.extension.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterMatchToolPresenter.extension.st
@@ -1,0 +1,57 @@
+Extension { #name : #StRewriterMatchToolPresenter }
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> astCode [
+
+	"This accessor should ONLY be called in the tests."
+
+	^ astCode
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> astPattern [
+
+	"This accessor should ONLY be called in the tests."
+
+	^ astPattern
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> bindingsTable [
+
+	"This accessor should ONLY be called in the tests."
+
+	^ bindingsTable
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> codeEditor [
+
+	"This accessor should ONLY be called in the tests."
+
+	^ codeEditor
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> matchesList [
+
+	"This accessor should ONLY be called in the tests. This is for not break encapsulation."
+
+	^ matchesList
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> methodCheckbox [
+
+	"This accessor should ONLY be called in the tests. This is for not break encapsulation."
+
+	^ methodCheckbox
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterMatchToolPresenter >> ruleEditor [
+
+	"This accessor should ONLY be called in the tests."
+
+	^ ruleEditor
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterMatchToolPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterMatchToolPresenterTest.class.st
@@ -1,0 +1,184 @@
+Class {
+	#name : #StRewriterMatchToolPresenterTest,
+	#superclass : #StRewriterAbstractToolTest,
+	#instVars : [
+		'matchToolPresenter'
+	],
+	#category : #'NewTools-RewriterTools-Tests-MatchTool'
+}
+
+{ #category : #running }
+StRewriterMatchToolPresenterTest >> setUp [
+
+	super setUp.
+	matchToolPresenter := StRewriterMatchToolPresenter new
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testAddIconToTheme [
+
+	| icon |
+	icon := self iconNamed: #jigsawIcon.
+	self deny: icon equals: (self iconNamed: #blackIcon)
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testBindingsTableContainsMatchings [
+
+	"This test tests is the bindings table was populated with the correct matchings.
+	First, we match a pattern with a corresponding Pharo code. This will populate MatchToolPresenter 	tables with the matches."
+
+	matchToolPresenter
+		pharoCode: 'a = b ifTrue: [ x = y ifTrue: [ aBlock ] ]';
+		patternCode: '`@expression ifTrue: [ `@codeBlock ]'.
+	matchToolPresenter performMatching.
+	"Now, we simulate the click on the first item of the match table for populate the bindings table 	because that table is empty until is clicked."
+	matchToolPresenter matchesList clickAtIndex: 1.
+	"Finally, check if the items in the bindigs table are correct. Remember that the bindings table 	have two columns: pattern and match. So, we have to assert four times."
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 1) key formattedCode
+		equals: '`@expression'.
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 1) value formattedCode
+		equals: 'a = b'.
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 2) key formattedCode
+		equals: '`@codeBlock'.
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 2) value formattedCode
+		equals: 'x = y ifTrue: [ aBlock ]'
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testEmptyLists [
+
+	matchToolPresenter emptyLists.
+	self assertEmpty: matchToolPresenter bindingsTable items.
+	self assertEmpty: matchToolPresenter matchesList items
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testGetBindingsItemsForMatch [
+
+	| match |
+	matchToolPresenter
+		patternCode: '`var';
+		pharoCode: 'var'.
+	matchToolPresenter performMatching.
+	match := matchToolPresenter matchesList items first value.
+	self denyEmpty: (matchToolPresenter getBindingsItemsForMatch: match).
+	matchToolPresenter
+		patternCode: '';
+		pharoCode: ''.
+	matchToolPresenter performMatching.
+	match := matchToolPresenter matchesList items first value.
+	self assertEmpty:
+		(matchToolPresenter getBindingsItemsForMatch: match)
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testInitializePresenters [
+
+	self assert: matchToolPresenter methodCheckbox class equals: SpCheckBoxPresenter.
+	self assert: matchToolPresenter ruleEditor class equals: StRewriterSearchForPanel.
+	self assert: matchToolPresenter codeEditor class equals: SpCodePresenter.
+	self assert: matchToolPresenter matchesList class equals: SpListPresenter.
+	self assert: matchToolPresenter bindingsTable class equals: SpTablePresenter.
+	self assert: matchToolPresenter codeEditor text isNotEmpty.
+	self assert: matchToolPresenter ruleEditor lhs isNotEmpty
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testMatchMethod [
+
+	matchToolPresenter
+		patternCode: '`method `var';
+		pharoCode: 'aMethod var'.
+	matchToolPresenter methodCheckbox click.
+	matchToolPresenter performMatching.
+	matchToolPresenter matchesList clickAtIndex: 1.
+	self
+		assert: (matchToolPresenter matchesList items at: 1) key source
+		equals: 'aMethod var'.
+	self
+		assert: (matchToolPresenter bindingsTable items at: 1) value
+		equals: 'aMethod var'.
+	self
+		assert: (matchToolPresenter bindingsTable items at: 2) value
+		equals: 'aMethod'.
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 4) key formattedCode
+		equals: '`var'.
+	self
+		assert:
+		(matchToolPresenter bindingsTable items at: 4) value formattedCode
+		equals: 'var'
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testMatchesChanged [
+
+	matchToolPresenter matchesChanged.
+	self assertEmpty: matchToolPresenter bindingsTable items
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testMatchingTableContainsMatchings [
+
+	"This test tests is the matching table was populated with the correct matchings.
+	First, we match a pattern with a corresponding Pharo code. This will populate MatchToolPresenter 	tables with the matches."
+
+	matchToolPresenter
+		pharoCode: 'a = b ifTrue: [ x = y ifTrue: [ aBlock ] ]';
+		patternCode: '`@expression ifTrue: [ `@codeBlock ]'.
+	matchToolPresenter performMatching.
+	self
+		assert:
+		(matchToolPresenter matchesList items at: 1) key formattedCode
+		equals: 'a = b ifTrue: [ x = y ifTrue: [ aBlock ] ]'.
+	self
+		assert:
+		(matchToolPresenter matchesList items at: 2) key formattedCode
+		equals: 'x = y ifTrue: [ aBlock ]'
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testPatternCode [
+
+	matchToolPresenter patternCode: '`var'.
+	self assert: matchToolPresenter patternCode equals: '`var'
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testPerformMatching [
+
+	"This test tests if the match lists contain the adequate number of matching. The other tests see if the tables are populated correctly."
+
+	matchToolPresenter
+		pharoCode: 'a = b ifTrue: [ x = y ifTrue: [ aBlock ] ]';
+		patternCode: '`@expression ifTrue: [ `@codeBlock ]'.
+	matchToolPresenter performMatching.
+	self assert: matchToolPresenter matchesList items size equals: 2.
+	matchToolPresenter matchesList clickAtIndex: 1.
+	self assert: matchToolPresenter bindingsTable items size equals: 2
+]
+
+{ #category : #tests }
+StRewriterMatchToolPresenterTest >> testPharoCode [
+
+	matchToolPresenter pharoCode: 'OrderedCollection new'.
+	self
+		assert: matchToolPresenter pharoCode
+		equals: 'OrderedCollection new'
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenterTest >> toolClass [
+
+	^ StRewriterMatchToolPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterOccurrencesBrowserPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterOccurrencesBrowserPresenterTest.class.st
@@ -1,0 +1,32 @@
+"
+An OccurrencesBrowserPresenterTest is a test class for testing the behavior of OccurrencesBrowserPresenter
+"
+Class {
+	#name : #StRewriterOccurrencesBrowserPresenterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'occurrencesBrowserPresenter'
+	],
+	#category : #'NewTools-RewriterTools-Tests-OcurrencesBrowser'
+}
+
+{ #category : #running }
+StRewriterOccurrencesBrowserPresenterTest >> setUp [
+
+	super setUp.
+	occurrencesBrowserPresenter := StRewriterOccurrencesBrowserPresenter new
+]
+
+{ #category : #tests }
+StRewriterOccurrencesBrowserPresenterTest >> testCritiques [
+
+	| presenter |
+	presenter := StRewriterOccurrencesBrowserPresenter critiques: #(  ).
+	self assert: (presenter isKindOf: SpPresenter)
+]
+
+{ #category : #tests }
+StRewriterOccurrencesBrowserPresenterTest >> testTitle [
+
+	self deny: StRewriterOccurrencesBrowserPresenter title equals: 'Untitled window'
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterReplaceWithPanelTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterReplaceWithPanelTest.class.st
@@ -1,0 +1,25 @@
+"
+A RTReplaceWithPanelTest is a test class for testing the behavior of RTReplaceWithPanel
+"
+Class {
+	#name : #StRewriterReplaceWithPanelTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'replacePanel'
+	],
+	#category : #'NewTools-RewriterTools-Tests-Panels'
+}
+
+{ #category : #running }
+StRewriterReplaceWithPanelTest >> setUp [
+
+	super setUp.
+	replacePanel := StRewriterReplaceWithPanel new
+]
+
+{ #category : #tests }
+StRewriterReplaceWithPanelTest >> testRhs [
+
+	replacePanel rhs: 'Some code'.
+	self assert: replacePanel rhs equals: 'Some code'
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterRuleEditorPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRuleEditorPresenterTest.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : #StRewriterRuleEditorPresenterTest,
+	#superclass : #StRewriterAbstractToolTest,
+	#instVars : [
+		'rewriteBasicEditor'
+	],
+	#category : #'NewTools-RewriterTools-Tests-BasicEditor'
+}
+
+{ #category : #running }
+StRewriterRuleEditorPresenterTest >> setUp [
+
+	super setUp.
+	rewriteBasicEditor := StRewriterRuleEditorPresenter new
+]
+
+{ #category : #tests }
+StRewriterRuleEditorPresenterTest >> testReplaceWithPatternCode [
+
+	rewriteBasicEditor rhs: 'patternCode'.
+	self
+		assert: rewriteBasicEditor rhs
+		equals: 'patternCode'
+]
+
+{ #category : #tests }
+StRewriterRuleEditorPresenterTest >> testRuleLoadsCorrectly [
+
+	| ruleHolder |
+	ruleHolder := StRewriterRuleHolder lhs: '`aVar foo' rhs: '`aVar otherFoo'.
+
+	rewriteBasicEditor
+		lhs: ruleHolder lhs;
+		rhs: ruleHolder rhs.
+
+	self	assert: rewriteBasicEditor lhs equals: ruleHolder lhs.
+	self	assert: rewriteBasicEditor rhs equals: ruleHolder rhs
+]
+
+{ #category : #tests }
+StRewriterRuleEditorPresenterTest >> testSearchForPatternCode [
+
+	rewriteBasicEditor lhs: 'patternCode'.
+	self
+		assert: rewriteBasicEditor lhs
+		equals: 'patternCode'
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenterTest >> toolClass [
+
+	^ StRewriterRuleEditorPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterRuleLoaderPresenter.extension.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRuleLoaderPresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StRewriterRuleLoaderPresenter }
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterRuleLoaderPresenter >> rulesTableSelector [
+
+	^ rulesTableSelector
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterRuleLoaderPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRuleLoaderPresenterTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #StRewriterRuleLoaderPresenterTest,
+	#superclass : #StRewriterAbstractToolTest,
+	#instVars : [
+		'ruleLoader'
+	],
+	#category : #'NewTools-RewriterTools-Tests-RuleLoader'
+}
+
+{ #category : #running }
+StRewriterRuleLoaderPresenterTest >> setUp [
+
+	super setUp.
+	ruleLoader := StRewriterRuleLoaderPresenter new
+]
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenterTest >> toolClass [
+
+	^ StRewriterRuleLoaderPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterRulesHelpPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRulesHelpPresenterTest.class.st
@@ -1,0 +1,41 @@
+"
+A RewriteRulesHelpPresenterTest is a test class for testing the behavior of RewriteRulesHelpPresenter
+"
+Class {
+	#name : #StRewriterRulesHelpPresenterTest,
+	#superclass : #StRewriterAbstractToolTest,
+	#instVars : [
+		'rulesHelper'
+	],
+	#category : #'NewTools-RewriterTools-Tests-HelpBrowser'
+}
+
+{ #category : #running }
+StRewriterRulesHelpPresenterTest >> setUp [
+
+	super setUp.
+
+	rulesHelper := StRewriterHelpBrowserPresenter new
+]
+
+{ #category : #tests }
+StRewriterRulesHelpPresenterTest >> testCreateTextMorph [
+
+	| morph |
+	morph := rulesHelper createTextMorph.
+	self assert: (morph isMemberOf: RubScrolledTextMorph)
+]
+
+{ #category : #tests }
+StRewriterRulesHelpPresenterTest >> testGetMicrodownParsedText [
+
+	| aText |
+	aText := rulesHelper class getParsedText.
+	self assert: aText isNotEmpty
+]
+
+{ #category : #accessing }
+StRewriterRulesHelpPresenterTest >> toolClass [
+
+	^ StRewriterRuleLoaderPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterRulesTableSelectorPresenter.extension.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRulesTableSelectorPresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StRewriterRulesTableSelectorPresenter }
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterRulesTableSelectorPresenter >> rulesTable [
+
+	^ rulesTable
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenter.extension.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenter.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #StRewriterScopeSelectorPresenter }
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterScopeSelectorPresenter >> classesFilteringListPresenter [
+
+	^ classesListWithFilterPresenter
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterScopeSelectorPresenter >> methodsFilteringListPresenter [
+
+	^ methodsListWithFilterPresenter
+]
+
+{ #category : #'*NewTools-RewriterTools-Tests' }
+StRewriterScopeSelectorPresenter >> packagesFilteringListPresenter [
+
+	^ packagesListWithFilterPresenter
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenterTest.class.st
@@ -1,0 +1,95 @@
+"
+A MethodsSelectorPresenterTest is a test class for testing the behavior of MethodsSelectorPresenter
+"
+Class {
+	#name : #StRewriterScopeSelectorPresenterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'scopeSelectorPresenter'
+	],
+	#category : #'NewTools-RewriterTools-Tests-ScopeSelector'
+}
+
+{ #category : #running }
+StRewriterScopeSelectorPresenterTest >> setUp [
+
+	super setUp.
+	scopeSelectorPresenter := StRewriterScopeSelectorPresenter new
+]
+
+{ #category : #tests }
+StRewriterScopeSelectorPresenterTest >> testInitializePresenters [
+
+	| window |
+	self
+		assertCollection:
+		scopeSelectorPresenter packagesFilteringListPresenter items
+		hasSameElements: RBBrowserEnvironment new packages.
+	window := scopeSelectorPresenter open.
+	self assert: window isBuilt.
+	window close
+]
+
+{ #category : #tests }
+StRewriterScopeSelectorPresenterTest >> testInitializeWithPackages [
+
+	| newPresenter packages |
+	packages := 'Kernel' asPackage asOrderedCollection.
+	newPresenter := StRewriterScopeSelectorPresenter new initializeWithPackages:
+		                packages.
+	self
+		assertCollection: newPresenter packagesFilteringListPresenter items
+		hasSameElements: packages
+]
+
+{ #category : #tests }
+StRewriterScopeSelectorPresenterTest >> testPackagesChanged [
+
+	| selectedPackages |
+	scopeSelectorPresenter packagesFilteringListPresenter listPresenter selectIndexes: (1 to: 16).
+
+	selectedPackages := scopeSelectorPresenter
+		packagesFilteringListPresenter listPresenter selectedItems.
+
+	self assert: selectedPackages size equals: 16.
+
+	self
+		assertCollection: scopeSelectorPresenter classesFilteringListPresenter listPresenter items
+		hasSameElements: (selectedPackages flatCollect: [ :each | each definedClasses]) .
+
+	scopeSelectorPresenter classesFilteringListPresenter listPresenter selectIndexes: (15 to: 30).
+	self
+		assert: scopeSelectorPresenter classesFilteringListPresenter listPresenter selectedItems size
+		equals: 16.
+
+	"self
+		assertCollection: scopeSelectorPresenter methodsFilteringListPresenter listPresenter items
+		hasSameElements: scopeSelectorPresenter selectedMethods.
+
+	scopeSelectorPresenter methodsFilteringListPresenter listPresenter selectIndexes: (1 to: 5).
+	self
+		assert: scopeSelectorPresenter methodsFilteringListPresenter listPresenter selectedItems size
+		equals: 5.
+
+	self assert: scopeSelectorPresenter selectedMethods size equals: 5"
+]
+
+{ #category : #tests }
+StRewriterScopeSelectorPresenterTest >> testSelectedMethods [
+
+	self assertEmpty: scopeSelectorPresenter selectedMethods.
+	scopeSelectorPresenter packagesFilteringListPresenter listPresenter
+		selectIndexes: (20 to: 30).
+	self assert: scopeSelectorPresenter selectedMethods isNotEmpty
+]
+
+{ #category : #tests }
+StRewriterScopeSelectorPresenterTest >> testWithPackages [
+
+	| newPresenter packages |
+	packages := 'Kernel' asPackage asOrderedCollection.
+	newPresenter := StRewriterScopeSelectorPresenter withPackages: packages.
+	self
+		assertCollection: newPresenter packagesFilteringListPresenter items
+		hasSameElements: packages
+]

--- a/src/NewTools-RewriterTools-Tests/StRewriterSearchForPanelTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterSearchForPanelTest.class.st
@@ -1,0 +1,25 @@
+"
+A RTSearchForPanelTest is a test class for testing the behavior of RTSearchForPanel
+"
+Class {
+	#name : #StRewriterSearchForPanelTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'searchPanel'
+	],
+	#category : #'NewTools-RewriterTools-Tests-Panels'
+}
+
+{ #category : #running }
+StRewriterSearchForPanelTest >> setUp [
+
+	super setUp.
+	searchPanel := StRewriterSearchForPanel new
+]
+
+{ #category : #tests }
+StRewriterSearchForPanelTest >> testLhs [
+
+	searchPanel lhs: 'Some code'.
+	self assert: searchPanel lhs equals: 'Some code'
+]

--- a/src/NewTools-RewriterTools-Tests/package.st
+++ b/src/NewTools-RewriterTools-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-RewriterTools-Tests' }

--- a/src/NewTools-RewriterTools/Array.extension.st
+++ b/src/NewTools-RewriterTools/Array.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Array }
+
+{ #category : #'*NewTools-RewriterTools' }
+Array >> formattedCode [
+
+	^ self
+]

--- a/src/NewTools-RewriterTools/StRewriterApplyRuleOnAllClassesCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterApplyRuleOnAllClassesCommand.class.st
@@ -1,0 +1,46 @@
+"
+I am a command that applies the rule that is already present on the presenter to all system classes.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterApplyRuleOnAllClassesCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterApplyRuleOnAllClassesCommand class >> defaultDescription [
+
+	^ 'Apply the current rewrite rule that is on this tool to all classes in the system.'
+]
+
+{ #category : #accessing }
+StRewriterApplyRuleOnAllClassesCommand class >> defaultIconName [
+
+	^ StRewriterScopeSelectorPresenter iconName
+]
+
+{ #category : #default }
+StRewriterApplyRuleOnAllClassesCommand class >> defaultName [
+
+	^ 'Transform all classes'
+]
+
+{ #category : #executing }
+StRewriterApplyRuleOnAllClassesCommand >> execute [
+
+	| changes ruleHolder |
+	(UIManager default
+		confirm: 'This process can take between 1 and 2 minutes.'
+		label: 'Proceed?') ifFalse: [ ^ self ].
+
+	ruleHolder := StRewriterRuleHolder
+		lhs: self context lhs
+		rhs: self context rhs
+		isForMethod: self context isRuleForMethod.
+
+	changes := StRewriterAbstractApplier defaultEngineApplier
+		calculateAllChangesForRules: ruleHolder asOrderedCollection.
+	^ (ChangesBrowser changes: changes) open
+]

--- a/src/NewTools-RewriterTools/StRewriterApplyRuleOnSelectedClassesCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterApplyRuleOnSelectedClassesCommand.class.st
@@ -1,0 +1,46 @@
+"
+I am a command that applies the rule that is already present on the presenter to a seleted set of classes.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterApplyRuleOnSelectedClassesCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterApplyRuleOnSelectedClassesCommand class >> defaultDescription [
+
+	^ 'Apply the current rewrite rule that is on this tool a selected scope.'
+]
+
+{ #category : #accessing }
+StRewriterApplyRuleOnSelectedClassesCommand class >> defaultIconName [
+
+	^ StRewriterScopeSelectorPresenter iconName
+]
+
+{ #category : #default }
+StRewriterApplyRuleOnSelectedClassesCommand class >> defaultName [
+
+	^ 'Transform selected classes'
+]
+
+{ #category : #executing }
+StRewriterApplyRuleOnSelectedClassesCommand >> execute [
+
+	| dialogWindow changes |
+	dialogWindow := self context scopeSelectorPresenter openDialog.
+	dialogWindow okAction: [
+		| ruleHolder |
+		ruleHolder := StRewriterRuleHolder
+			lhs: self context lhs
+			rhs: self context rhs
+			isForMethod: self context isRuleForMethod.
+
+		changes := StRewriterAbstractApplier defaultEngineApplier
+			calculateChangesForClasses: self context scopeSelectorPresenter selectedClasses
+			transformationRules: ruleHolder asOrderedCollection.
+		(ChangesBrowser changes: changes) open ]
+]

--- a/src/NewTools-RewriterTools/StRewriterCheatSheetPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterCheatSheetPresenter.class.st
@@ -1,0 +1,54 @@
+"
+I am a cheat sheet for showing help for the rewriting rules
+"
+Class {
+	#name : #StRewriterCheatSheetPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'textPresenter',
+		'helpButton'
+	],
+	#category : #'NewTools-RewriterTools-Help'
+}
+
+{ #category : #layout }
+StRewriterCheatSheetPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: helpButton expand: false;
+		add: textPresenter;
+		yourself
+]
+
+{ #category : #accessing }
+StRewriterCheatSheetPresenter >> helpText [
+
+	^ '` = meta var
+
+@ = list
+
+` = recurse into
+
+. = statement
+
+# = literal'
+]
+
+{ #category : #initialization }
+StRewriterCheatSheetPresenter >> initializePresenters [
+
+	textPresenter := self newText.
+	textPresenter
+		text: self helpText;
+		beNotEditable.
+
+	helpButton := self instantiate: (StRewriterOpenHelpBrowserCommand forSpecContext: self) asButtonPresenter.
+
+	self initializeStyles
+]
+
+{ #category : #initialization }
+StRewriterCheatSheetPresenter >> initializeStyles [
+
+	textPresenter addStyle: 'bgOpaque'
+]

--- a/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
@@ -1,0 +1,130 @@
+"
+I am a presenter that finds all the ocurrenses of a pattern code in all the methods that are in the Pharo image.
+"
+Class {
+	#name : #StRewriterExpressionFinderPresenter,
+	#superclass : #StPresenter,
+	#instVars : [
+		'patternCodePresenter',
+		'searchButton',
+		'cheatSheet',
+		'searchOnAllClassesButton',
+		'scopeSelectorPresenter'
+	],
+	#category : #'NewTools-RewriterTools-ExpressionFinder'
+}
+
+{ #category : #'world menu' }
+StRewriterExpressionFinderPresenter class >> descriptionText [
+
+	^ 'A tool to search the ocurrences of a rewrite rule within the Pharo image'
+]
+
+{ #category : #accessing }
+StRewriterExpressionFinderPresenter class >> icon [
+
+	^ self iconNamed: self iconName
+]
+
+{ #category : #accessing }
+StRewriterExpressionFinderPresenter class >> iconName [
+
+	^ #smallFind
+]
+
+{ #category : #'world menu' }
+StRewriterExpressionFinderPresenter class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	(aBuilder item: 'Expression Finder')
+		action: [ self new open ];
+		order: 31;
+		parent: #Tools;
+		icon: self icon;
+		help: self descriptionText
+]
+
+{ #category : #specs }
+StRewriterExpressionFinderPresenter class >> title [
+
+	^ 'Expression Finder'
+]
+
+{ #category : #initialization }
+StRewriterExpressionFinderPresenter >> connectPresenters [
+
+	searchButton action: [ self searchExpression ].
+	searchOnAllClassesButton action: [ self searchExpressionOnAllClasses ]
+]
+
+{ #category : #layout }
+StRewriterExpressionFinderPresenter >> defaultLayout [
+
+	^ SpPanedLayout newLeftToRight
+		add: patternCodePresenter;
+		add: (SpBoxLayout newTopToBottom
+			add: cheatSheet expand: true;
+			add: searchButton expand: false;
+			add: searchOnAllClassesButton expand: false;
+			yourself);
+		positionOfSlider: 70 percent;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterExpressionFinderPresenter >> initializePresenters [
+
+	patternCodePresenter := self instantiate: StRewriterSearchForPanel.
+	cheatSheet := self instantiate: StRewriterCheatSheetPresenter.
+	scopeSelectorPresenter := self instantiate: StRewriterScopeSelectorPresenter.
+	searchButton := self newButton
+		iconName: #smallFind;
+		label: 'Find in all classes';
+		yourself.
+	searchOnAllClassesButton := self newButton
+		iconName: #smallFind;
+		label: 'Find in selected classes';
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterExpressionFinderPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 600 @ 330;
+		windowIcon: self class icon;
+		askOkToClose: false
+]
+
+{ #category : #accessing }
+StRewriterExpressionFinderPresenter >> patternCode [
+	^ patternCodePresenter lhs
+]
+
+{ #category : #accessing }
+StRewriterExpressionFinderPresenter >> patternCode: aString [
+
+	patternCodePresenter lhs: aString
+]
+
+{ #category : #action }
+StRewriterExpressionFinderPresenter >> searchExpression [
+
+	| ruleHolder critiques |
+	ruleHolder := StRewriterRuleHolder lhs: patternCodePresenter lhs rhs: ''.
+	critiques := StRewriterRenrakuApplier obtainCritiquesOfAllMethodsForRules: { ruleHolder }.
+	^ (StRewriterOccurrencesBrowserPresenter critiques: critiques) open
+]
+
+{ #category : #action }
+StRewriterExpressionFinderPresenter >> searchExpressionOnAllClasses [
+
+	| dialogWindow methods ruleHolder critiques |
+	dialogWindow := scopeSelectorPresenter openDialog.
+	dialogWindow okAction: [
+		methods := scopeSelectorPresenter selectedClasses flatCollectAsSet: [ :each | each methods ].
+		ruleHolder := StRewriterRuleHolder lhs: patternCodePresenter lhs rhs: ''.
+		critiques := StRewriterRenrakuApplier obtainCritiquesOf: methods forRules: { ruleHolder }.
+		(StRewriterOccurrencesBrowserPresenter critiques: critiques) open ]
+]

--- a/src/NewTools-RewriterTools/StRewriterHelpBrowserPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterHelpBrowserPresenter.class.st
@@ -1,0 +1,270 @@
+"
+I am a helper browser that contains an explanation of what the rewrite rule are and how their syntax works.
+"
+Class {
+	#name : #StRewriterHelpBrowserPresenter,
+	#superclass : #StPresenter,
+	#instVars : [
+		'morphPresenter'
+	],
+	#category : #'NewTools-RewriterTools-Help'
+}
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> basicPatterns [
+
+	^ '(\`) BASIC PATTERN NODES
+
+Code prefixed with a backtick character (\`) defines a pattern node. A pattern node can be a
+variable or a literal:
+
+`node asString
+
+that will match message asString sent to any receiver.
+It can be a message:
+
+Smalltalk globals `message
+
+that will match any unary message sent to `Smalltalk globals`.
+It can also be a method itself:
+
+`method
+	^ nil
+
+that will match any method which returns nil.
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> blockPatterns [
+
+	^ '(`{ }) BLOCK PATTERN NODES
+
+These are the most exotic of all the nodes. They match any AST nodes like a list pattern
+and test it with a block. The syntax is similar to the smalltalk block, but curly braces
+are used instead of square brackets and as always the whole expression begins with a backtick.
+Consider the following example:
+
+`{ :node | node isVariable and: [ node isGlobal ] } become: nil
+
+this pattern will match a message #become: with an attribute nil, where the receiver is a
+variable and it is a global variable.
+
+There is also a special case called wrapped block pattern node which has the same syntax and
+follows a normal pattern node. In this case first the node will be matched based on its
+pattern, and then passed to the block. For example:
+
+`#arr `{ :node | node isLiteralArray } asArray
+
+is a simple way to detect expression like `#(1 2 3) asArray`.
+In this case first `#(1 2 3)` will be matched by the literal node and then tested by the block.
+'
+]
+
+{ #category : #api }
+StRewriterHelpBrowserPresenter class >> getParsedText [
+
+	^ String streamContents: [ :stream |
+		stream << self patternCodeIntro << String cr
+			<< self basicPatterns << String cr
+			<< self literalPatterns << String cr
+			<< self statementPatterns << String cr
+			<< self listPatterns << String cr
+			<< self blockPatterns << String cr
+			<< self namingImportant << String cr
+			<< self whatNext << String cr
+			<< self issues << String cr
+			<< self thanks]
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> issues [
+
+	^ 'ISSUES?
+
+ If you found any issues you can submit them here:
+
+[https://github.com/jordanmontt/RewriteTool-Spec2/issues](https://github.com/jordanmontt/RewriteTool-Spec2/issues)
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> listPatterns [
+
+	^ '(\`@) LIST PATTERN NODES
+
+To have complete flexibility there is the possibility to use an at sign `@` before the name
+of a pattern node which turns the node into a `list pattern node`. These nodes can match more
+than a single entity. For example:
+
+`@expr isPatternVariable
+
+will match both messages
+
+1 isPatternVariable
+
+and
+
+ast statement first isPatternVariable.
+
+but in the second case `\`@expr` will represent `ast statement first`. These pattern nodes
+will also match block definitions.
+
+With message and method list nodes one can match any number of keywords and parameters.
+An expression:
+
+Smalltalk globals `@message: `@args
+
+will match any message (including) unary sent to `Smalltalk globals` and `\`@args` will be
+mapped to the list of arguments.
+
+Disclaimer: you may write an expression with just `args` instead of `\`@args`.
+But, following the list pattern grammar makes it easier to read.
+
+Similarly you can match a list of temporary variables:
+
+`@method: `@args
+	| `temp `@temps |
+
+This will match any method with one or more temporary variables and without any statement.
+The first temporary variable will be mapped to `\`temp` the rest ones — to `\`@temps`.
+
+Finally you can have a list of statements:
+
+[ `.@Statements.
+	`var := `@object ]
+
+this expression will match a block which has an assignment of an expression to a variable as a
+last statement. It can be preceded by any number of other statement (including 0).
+
+The list patterns does not make any sense for literal nodes i.e. `\`#@literal`.
+
+P.S. In the end it does not matter whether you will write `\`.@Statement` or `\`@.Statement`.
+But I like to put `@` closer to the variable name as the character is larger itself and the
+name looks nicer this way.
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> literalPatterns [
+
+	^ '(\`\#) LITERAL PATTERN NODES
+
+For variables backtick can be followed by hash to enforce that matched receiver will be a literal:
+
+`#literal asArray
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> namingImportant [
+
+	^ 'NAMING IS IMPORTANT
+
+The pattern nodes are so that you can match anything in their place. But their naming is also
+important as the code gets mapped to them by name. For example:
+
+`block value: `@expression value: `@expression
+
+will match only those “value:value:” messages that have exactly the same expressions as both
+arguments. It is like that because we used the same pattern variable name.
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> patternCodeIntro [
+
+	^ 'PATTERN CODE INTRODUCTION
+
+Pattern code is very similar to ordinary Smalltalk code, but allows to specify some “wildcards”.
+The purpose is fairly simple. Imagine that you have a piece of code:
+
+car isNil ifTrue: [ ^ self ].
+
+You can of course compare it with the same piece of code for equality, but wouldn''t it be cool
+if you could compare something similar, but ignore the fact that the receiver is named `car`?
+With pattern rules you can do exactly that. Consider the following code and notice the
+backtick before car:
+
+`car isNil ifTrue: [ ^ self ].
+
+Now this expression can match any other expression where `isNil ifTrue: [ ^ self ]` is sent
+to any variable (or literal). With such power you can find all the usages of `isNil ifTrue:`
+and replace them with `ifNil`.
+
+The following sections will go over different kinds of wildcards (pattern nodes).
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> statementPatterns [
+
+	^ '(\`.) STATEMENT PATTERN NODES
+
+Backtick can be followed by a period to match statements. For example:
+
+`var
+	ifTrue:  [ `.statement1 ]
+	ifFalse: [ `.statement2 ]
+
+will match an `ifTrue:ifFalse:` message send to any variable, where both blocks have
+only one statement each.
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> thanks [
+
+	^ '
+
+Thanks to Yuriy Tymchuk for his tool MatchTool that we are using in this set of tools.
+Also thanks to him for writing this help description.
+	'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter class >> whatNext [
+
+	^ 'WHAT IS NEXT?
+
+At the moment you can create quality rules that use pattern expression to detect and even
+automatically fix violations.
+
+Especially read: `Rules > Creating Rules > Special Rules > ReNodeMatchRule`
+'
+]
+
+{ #category : #accessing }
+StRewriterHelpBrowserPresenter >> createTextMorph [
+
+	^ RubScrolledTextMorph new
+		  setText: self class getParsedText;
+		  in: [ :this | this textArea readOnly: true ];
+		  yourself
+]
+
+{ #category : #layout }
+StRewriterHelpBrowserPresenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  add: morphPresenter;
+		  yourself
+]
+
+{ #category : #initialization }
+StRewriterHelpBrowserPresenter >> initializePresenters [
+
+	morphPresenter := self newMorph
+		morph: self createTextMorph;
+		yourself.
+	morphPresenter addStyle: 'bgOpaque'
+]
+
+{ #category : #initialization }
+StRewriterHelpBrowserPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: 'Rewrite rules syntax help';
+		initialExtent: 570 @ 500;
+		askOkToClose: false
+]

--- a/src/NewTools-RewriterTools/StRewriterMatchToolPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterMatchToolPresenter.class.st
@@ -1,0 +1,249 @@
+"
+I am a tool that allows you to match and test a pattern code with Pharo's code. To open me: `MatchToolPresenter open`
+
+Write the pattern's code and the Pharo's code in the code editors and then press the 'Match' button. After that, I will match all ocurrences of the pattern code on the Pharo's code.
+
+- The middle column shows all the occurrences that the pattern code has in the Pharo's code.
+- The right column shows all the bindings of the selected matched of the middle column.
+"
+Class {
+	#name : #StRewriterMatchToolPresenter,
+	#superclass : #StPresenter,
+	#instVars : [
+		'executeButton',
+		'ruleEditor',
+		'codeEditor',
+		'bindingsTable',
+		'matchesList',
+		'codeLabel',
+		'methodCheckbox',
+		'astPattern',
+		'astCode'
+	],
+	#category : #'NewTools-RewriterTools-MatchTool'
+}
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter class >> descriptionText [
+	^ 'MatchTool is a simple UI for experimenting with the matching functionality of a rewrite rule'
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter class >> icon [
+
+	^ self iconNamed: self iconName
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter class >> iconName [
+
+	| iconContent |
+	iconContent := 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABx0lEQVQokWVSTWsTURQ9972ZpkSwpC0RN4GU0oWiqy7cVZD+AD/+gb/Hf+BKXSp04aaCS8WKViKlBARLCTSlIabEJjOZefceF5mJaXvhvdU9555z75H1xpaZJ0kzGLIs3Xz2fOPRk0mamMKMSqjBSDUa6YAYZRH03h/svh0c/3LeAwBk+kQEAgAOV0pcOhx8f/fS8hwiJRFIAiB5DQD4aOG03er8+OyjeAqZfSLiZlAAVDUNcM5FcXLek2k7L9FFhRARDaHWWLu7/bS6vEqJFmt1zbOCeg4TiUhBb3Zv+3HzwcM0TVWZa6Cy1AMRwACgkAQA5Hg40JBbCKYKEiLORyWkKCflKuBcp7WnWVaKdGGSdg+/achE3My7r91szmxc9HurzY2l2w0N6hcqB+/ffH39gqr1O5tmRpKcnwDQdH/n1d+zk7iyeNZu/f60G1eqx18+DE+OnI+mfX55aa2wQYq48Xm/83Ove7jf/riTj0cS+TAZV1fqK+v3LQTO1jpT5XyUDPqj3ql4L94Z6UT+HLWpAQB5ORrTUeKci+O5ZfhRvxsmyTQpV6Mxb0nK2GUXwzwZiYjxGuD/WYr7UkQsZGGSELh1w/4BoVf8Blsi4TsAAAAASUVORK5CYII='.
+	self theme icons icons
+		at: #jigsawIcon
+		ifAbsentPut: [
+		Form fromBinaryStream: iconContent base64Decoded readStream ].
+
+	^ #jigsawIcon
+]
+
+{ #category : #menu }
+StRewriterMatchToolPresenter class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	(aBuilder item: 'Match Tool')
+		action: [ self new open ];
+		order: 32;
+		parent: #Tools;
+		help: self descriptionText;
+		icon: self icon
+]
+
+{ #category : #specs }
+StRewriterMatchToolPresenter class >> title [
+
+	^ 'Match Tool'
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> connectPresenters [
+
+	matchesList
+		whenSelectionChangedDo: [ :selection |
+			self selectedMatchChanged: selection ];
+		whenModelChangedDo: [ :newItems | self matchesChanged ].
+	executeButton action: [ self performMatching ]
+]
+
+{ #category : #layout }
+StRewriterMatchToolPresenter >> defaultLayout [
+
+	| rulePanel codePanel matchesWithLabelPanel |
+	rulePanel := SpBoxLayout newTopToBottom
+		add: (SpBoxLayout newLeftToRight
+			add: methodCheckbox expand: false;
+			addLast: executeButton expand: false;
+			yourself)
+		expand: false;
+		add: ruleEditor;
+		yourself.
+	codePanel := SpBoxLayout newTopToBottom
+		add: codeLabel expand: false;
+		add: codeEditor;
+		yourself.
+	matchesWithLabelPanel := SpBoxLayout newTopToBottom
+		add: 'Matches' expand: false;
+		add: matchesList;
+		yourself.
+
+	^ SpPanedLayout newLeftToRight
+		add: (SpPanedLayout newTopToBottom
+			add: rulePanel;
+			add: codePanel;
+			yourself);
+		add: (SpPanedLayout newLeftToRight
+			add: matchesWithLabelPanel;
+			add: bindingsTable;
+			yourself);
+		yourself
+]
+
+{ #category : #actions }
+StRewriterMatchToolPresenter >> emptyLists [
+
+	bindingsTable items: #(  ).
+	matchesList items: #(  )
+]
+
+{ #category : #defaults }
+StRewriterMatchToolPresenter >> getBindingsItemsForMatch: bindingsAssociation [
+
+	| newItems |
+	newItems := OrderedCollection new.
+	bindingsAssociation keysAndValuesDo: [ :key :value |
+		(value isKindOf: OrderedCollection)
+			ifTrue: [ newItems add: (value collect: [ :each | key -> each ]) ]
+			ifFalse: [ newItems add: key -> value ] ].
+	^ newItems flattened
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> initializeButtons [
+
+	executeButton := self newButton.
+	executeButton
+		icon: (self iconNamed: #smallDoIt);
+		label: 'Match';
+		shortcut: Character cr meta
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> initializeEditors [
+
+	methodCheckbox := self newCheckBox label: 'The rule is for a method?'.
+
+	codeLabel := self newLabel label: 'Pharo code'.
+
+	codeEditor := self newCode.
+	codeEditor
+		withoutLineNumbers;
+		beForScripting;
+		text: StRewriterDemoRules defaultRule pharoCode.
+
+	ruleEditor := self instantiate: StRewriterSearchForPanel
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> initializeMatchesPresenters [
+
+	matchesList := self newList.
+	matchesList display: [ :assoc | assoc key formattedCode ].
+
+	bindingsTable := self newTable.
+	bindingsTable
+		addColumn: (SpStringTableColumn
+			title: 'Pattern'
+			evaluated: [ :assoc | assoc key formattedCode ]);
+		addColumn: (SpStringTableColumn
+			title: 'Bindings'
+			evaluated: [ :assoc | assoc value formattedCode ]);
+		beResizable
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> initializePresenters [
+
+	self initializeEditors.
+	self initializeButtons.
+	self initializeMatchesPresenters
+]
+
+{ #category : #initialization }
+StRewriterMatchToolPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 800 @ 450;
+		windowIcon: self class icon;
+		askOkToClose: false;
+		aboutText: self class descriptionText
+]
+
+{ #category : #'event handling' }
+StRewriterMatchToolPresenter >> matchesChanged [
+
+	bindingsTable items: #(  ).
+	matchesList unselectAll
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter >> patternCode [
+
+	^ ruleEditor lhs
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter >> patternCode: aPatternCode [
+
+	ruleEditor lhs: aPatternCode
+]
+
+{ #category : #actions }
+StRewriterMatchToolPresenter >> performMatching [
+
+	| matches |
+	self emptyLists.
+
+	matches := StRewriterPatternMatcher
+		performMatching: codeEditor text
+		pattern: ruleEditor lhs
+		isForMethod: methodCheckbox state.
+
+	matchesList items: matches
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter >> pharoCode [
+
+	^ codeEditor text
+]
+
+{ #category : #accessing }
+StRewriterMatchToolPresenter >> pharoCode: aPharoCode [
+
+	codeEditor text: aPharoCode
+]
+
+{ #category : #'event handling' }
+StRewriterMatchToolPresenter >> selectedMatchChanged: selection [
+
+	| selectedMatch |
+	selectedMatch := selection selectedItem.
+	selectedMatch
+		ifNil: [
+			bindingsTable items: #(  ).
+			codeEditor clearSelection ]
+		ifNotNil: [
+			bindingsTable items: (self getBindingsItemsForMatch: selectedMatch value).
+			codeEditor selectionInterval: selectedMatch key sourceInterval ]
+]

--- a/src/NewTools-RewriterTools/StRewriterOccurrencesBrowserPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOccurrencesBrowserPresenter.class.st
@@ -1,0 +1,71 @@
+"
+I am a presenter for displaying the ocurrences found by `ExpressionFinderPresenter`
+"
+Class {
+	#name : #StRewriterOccurrencesBrowserPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'codePresenter',
+		'listPresenter'
+	],
+	#category : #'NewTools-RewriterTools-ChangesBrowser'
+}
+
+{ #category : #accessing }
+StRewriterOccurrencesBrowserPresenter class >> critiques: critiques [
+
+	^ self new
+		critiques: critiques;
+		yourself
+]
+
+{ #category : #specs }
+StRewriterOccurrencesBrowserPresenter class >> title [
+
+	^ 'Occurrences matches'
+]
+
+{ #category : #initialization }
+StRewriterOccurrencesBrowserPresenter >> connectPresenters [
+
+	listPresenter whenSelectedDo: [ :selectedItem |
+		codePresenter text: selectedItem sourceAnchor entity sourceCode.
+		codePresenter selectionInterval: selectedItem sourceAnchor interval ]
+]
+
+{ #category : #accessing }
+StRewriterOccurrencesBrowserPresenter >> critiques: critiques [
+
+	listPresenter items: critiques
+]
+
+{ #category : #layout }
+StRewriterOccurrencesBrowserPresenter >> defaultLayout [
+
+	^ SpPanedLayout newLeftToRight
+		add: listPresenter;
+		add: codePresenter;
+		positionOfSlider: 30 percent;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterOccurrencesBrowserPresenter >> initializePresenters [
+
+	codePresenter := self newCode.
+
+	listPresenter := self newList.
+	listPresenter
+		activateOnSingleClick;
+		headerTitle: 'Matches founded';
+		display: [ :item | item sourceAnchor entity printString ]
+]
+
+{ #category : #initialization }
+StRewriterOccurrencesBrowserPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 800 @ 500;
+		askOkToClose: false
+]

--- a/src/NewTools-RewriterTools/StRewriterOpenExpressionFinderCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOpenExpressionFinderCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command that open the expression finder presenter from another presenter keeping the same code.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterOpenExpressionFinderCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterOpenExpressionFinderCommand class >> defaultDescription [
+
+	^ 'Find ocurrences of an expression in all Pharo''s code'
+]
+
+{ #category : #accessing }
+StRewriterOpenExpressionFinderCommand class >> defaultIconName [
+
+	^ StRewriterExpressionFinderPresenter iconName
+]
+
+{ #category : #default }
+StRewriterOpenExpressionFinderCommand class >> defaultName [
+
+	^ 'Find occurrences'
+]
+
+{ #category : #executing }
+StRewriterOpenExpressionFinderCommand >> execute [
+
+	| window |
+	window := StRewriterExpressionFinderPresenter new open.
+	window presenter patternCode: self context lhs.
+	^ window
+]

--- a/src/NewTools-RewriterTools/StRewriterOpenHelpBrowserCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOpenHelpBrowserCommand.class.st
@@ -1,0 +1,36 @@
+"
+I open the RT help browser presenter.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterOpenHelpBrowserCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterOpenHelpBrowserCommand class >> defaultDescription [
+
+	^ 'Help browser'
+]
+
+{ #category : #accessing }
+StRewriterOpenHelpBrowserCommand class >> defaultIconName [
+
+	^ #smallQuestionIcon
+]
+
+{ #category : #default }
+StRewriterOpenHelpBrowserCommand class >> defaultName [
+
+	^ 'More help'
+]
+
+{ #category : #executing }
+StRewriterOpenHelpBrowserCommand >> execute [
+
+	| window |
+	window := StRewriterHelpBrowserPresenter new open.
+	^ window
+]

--- a/src/NewTools-RewriterTools/StRewriterOpenMatchToolCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOpenMatchToolCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command that opens match tool presenter from another presenter keeping the same code.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterOpenMatchToolCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterOpenMatchToolCommand class >> defaultDescription [
+
+	^ 'Open MatchTool'
+]
+
+{ #category : #accessing }
+StRewriterOpenMatchToolCommand class >> defaultIconName [
+
+	^ StRewriterMatchToolPresenter iconName
+]
+
+{ #category : #default }
+StRewriterOpenMatchToolCommand class >> defaultName [
+
+	^ 'Open Match Tool'
+]
+
+{ #category : #executing }
+StRewriterOpenMatchToolCommand >> execute [
+
+	^ StRewriterMatchToolPresenter new
+		  patternCode: self context lhs;
+		  pharoCode: '';
+		  open
+]

--- a/src/NewTools-RewriterTools/StRewriterOpenRuleEditorCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOpenRuleEditorCommand.class.st
@@ -1,0 +1,39 @@
+"
+I am a command that opens the rt basic editor presenter from another presenter keeping the same code.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterOpenRuleEditorCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterOpenRuleEditorCommand class >> defaultDescription [
+
+	^ 'Open Rewrite Rule Editor'
+]
+
+{ #category : #accessing }
+StRewriterOpenRuleEditorCommand class >> defaultIconName [
+
+	^StRewriterRuleEditorPresenter iconName
+]
+
+{ #category : #default }
+StRewriterOpenRuleEditorCommand class >> defaultName [
+
+	^ 'Open Rule Editor'
+]
+
+{ #category : #executing }
+StRewriterOpenRuleEditorCommand >> execute [
+
+	| window |
+	window := StRewriterRuleEditorPresenter new open.
+	window presenter
+		lhs: self context lhs;
+		rhs: self context rhs.
+	^ window
+]

--- a/src/NewTools-RewriterTools/StRewriterOpenRuleLoaderCommand.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOpenRuleLoaderCommand.class.st
@@ -1,0 +1,36 @@
+"
+I am a command that open the rt rule loader presenter from another presenter.
+
+I can be converted into a sepc button to be used in a presenter
+"
+Class {
+	#name : #StRewriterOpenRuleLoaderCommand,
+	#superclass : #StCommand,
+	#category : #'NewTools-RewriterTools-Commands'
+}
+
+{ #category : #default }
+StRewriterOpenRuleLoaderCommand class >> defaultDescription [
+
+	^ 'Load an example Rewrite Rule'
+]
+
+{ #category : #accessing }
+StRewriterOpenRuleLoaderCommand class >> defaultIconName [
+
+	^ StRewriterRuleLoaderPresenter iconName
+]
+
+{ #category : #default }
+StRewriterOpenRuleLoaderCommand class >> defaultName [
+
+	^ 'Load an example rule'
+]
+
+{ #category : #executing }
+StRewriterOpenRuleLoaderCommand >> execute [
+
+	| window |
+	window := StRewriterRuleLoaderPresenter new open.
+	^ window
+]

--- a/src/NewTools-RewriterTools/StRewriterReplaceWithPanel.class.st
+++ b/src/NewTools-RewriterTools/StRewriterReplaceWithPanel.class.st
@@ -1,0 +1,46 @@
+"
+I am the panel for the replace with (rhs) part of the rule
+"
+Class {
+	#name : #StRewriterReplaceWithPanel,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'label',
+		'codePresenter'
+	],
+	#category : #'NewTools-RewriterTools-Widgets'
+}
+
+{ #category : #layout }
+StRewriterReplaceWithPanel >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: label expand: false;
+		  add: codePresenter;
+		  yourself
+]
+
+{ #category : #initialization }
+StRewriterReplaceWithPanel >> initializePresenters [
+
+	label := self newLabel.
+	label label: 'Replace with:'.
+
+	codePresenter := self newCode.
+	codePresenter
+		text: StRewriterDemoRules defaultRule rhs;
+		withoutSyntaxHighlight;
+		withoutLineNumbers
+]
+
+{ #category : #accessing }
+StRewriterReplaceWithPanel >> rhs [
+
+	^ codePresenter text
+]
+
+{ #category : #accessing }
+StRewriterReplaceWithPanel >> rhs: aString [
+
+	codePresenter text: aString
+]

--- a/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
@@ -1,0 +1,179 @@
+"
+I am a tool that allows you to create, apply and save custom rewrite rules. To open me go to my class side method `open`.
+
+You can write the rewrite rule on searchFor's and replaceWith's editors. When the rewrite rule is written, you can click on 'Open Applier' for open a tool that allows you to apply the rewrite rule to specific classes. Or you just can click on 'Apply on all classes' to apply the rewrite rule to all system's classes.
+
+The Applier only works with saved rules, so remember to save your rule before open it. To apply the rule to all system's classes you do not need to save the rule.
+
+The rule is saved as a subclass of `RBTransformationRule` so the name you enter must be a valid class name.
+
+If you want to edit an already saved rewrite rule, just click on 'Open Loader' and select your rule. When you open me with an already saved rule and click the 'Save rule' button, the name of the rule is entered by default. If you save a rewrite rule with the same name it will be updated.
+
+Click on MatchTool to open a tool that allows you to match your rule with a block of Pharo's code.
+"
+Class {
+	#name : #StRewriterRuleEditorPresenter,
+	#superclass : #StPresenter,
+	#instVars : [
+		'cheatSheet',
+		'loadButton',
+		'expressionFinderButton',
+		'searchForEditor',
+		'replaceWithEditor',
+		'scopeSelectorPresenter',
+		'transformSelectedClassesButton',
+		'transformAllClassesButton',
+		'isForMethodCheckbox',
+		'openMatcherButton'
+	],
+	#category : #'NewTools-RewriterTools-RuleEditor'
+}
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter class >> descriptionText [
+
+	^ 'A tool to build and apply custom Rewrite Rules.'
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter class >> icon [
+
+	^ self iconNamed: self iconName
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter class >> iconName [
+	^ #workspaceIcon
+]
+
+{ #category : #'world menu' }
+StRewriterRuleEditorPresenter class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	(aBuilder item: 'Rewrite Rule Editor')
+		action: [ self new open ];
+		order: 30;
+		parent: #Tools;
+		help: self descriptionText;
+		icon: self icon
+]
+
+{ #category : #specs }
+StRewriterRuleEditorPresenter class >> title [
+
+	^ 'Rewrite Basic Editor'
+]
+
+{ #category : #layout }
+StRewriterRuleEditorPresenter >> defaultLayout [
+
+	^ SpPanedLayout newLeftToRight
+		add: (SpPanedLayout newVertical
+			add: searchForEditor;
+			add: replaceWithEditor;
+			yourself);
+		add: (SpBoxLayout newTopToBottom
+			add: isForMethodCheckbox expand: false;
+			add: cheatSheet expand: true;
+			add: transformAllClassesButton expand: false;
+			add: transformSelectedClassesButton expand: false;
+			add: expressionFinderButton expand: false;
+			add: openMatcherButton expand: false;
+			add: loadButton expand: false;
+			yourself);
+		positionOfSlider: 70 percent;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeButtons [
+
+	loadButton := self instantiate:
+		(StRewriterOpenRuleLoaderCommand forSpecContext: self) asButtonPresenter.
+	openMatcherButton := self instantiate:
+		(StRewriterOpenMatchToolCommand forSpecContext: self) asButtonPresenter.
+	transformAllClassesButton := self instantiate:
+		(StRewriterApplyRuleOnAllClassesCommand forSpecContext: self) asButtonPresenter.
+	expressionFinderButton := self instantiate:
+		(StRewriterOpenExpressionFinderCommand forSpecContext: self) asButtonPresenter.
+	transformSelectedClassesButton := self instantiate:
+		(StRewriterApplyRuleOnSelectedClassesCommand forSpecContext: self) asButtonPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeMethodCheckbox [
+
+	isForMethodCheckbox := self newCheckBox.
+	isForMethodCheckbox label: 'The rule is for a method?'
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializePresenters [
+
+	self initializeMethodCheckbox.
+	self initializeTextCheatSheet.
+	self initializeRuleEditors.
+	self initializeButtons.
+	self initializeScopeSelectorPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeRuleEditors [
+
+	searchForEditor := self instantiate: StRewriterSearchForPanel.
+	replaceWithEditor := self instantiate: StRewriterReplaceWithPanel
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeScopeSelectorPresenter [
+
+	scopeSelectorPresenter := self instantiate: StRewriterScopeSelectorPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeTextCheatSheet [
+
+	cheatSheet := self instantiate: StRewriterCheatSheetPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleEditorPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 700 @ 500;
+		windowIcon: self class icon;
+		aboutText: self class descriptionText
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> isRuleForMethod [
+
+	^ isForMethodCheckbox state
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> lhs [
+	^ searchForEditor lhs
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> lhs: aCode [
+	searchForEditor lhs: aCode
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> rhs [
+	^ replaceWithEditor rhs
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> rhs: aCode [
+	replaceWithEditor rhs: aCode
+]
+
+{ #category : #accessing }
+StRewriterRuleEditorPresenter >> scopeSelectorPresenter [
+
+	^ scopeSelectorPresenter
+]

--- a/src/NewTools-RewriterTools/StRewriterRuleLoaderPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRuleLoaderPresenter.class.st
@@ -1,0 +1,101 @@
+"
+I am a simple tool that allows you to load or delete any of the custom rewrite rules that are saved. I open the saved rule on a RewriteBasicEditorPresenter.
+
+To open me: `RewriteRuleLoaderPresenter open`
+"
+Class {
+	#name : #StRewriterRuleLoaderPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'openInBasicEditorButton',
+		'matchToolButton',
+		'rulesTableSelector'
+	],
+	#category : #'NewTools-RewriterTools-Loader'
+}
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenter class >> descriptionText [
+
+	^ 'Loads and deletes custom rewrite rules'
+]
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenter class >> icon [
+
+	^ self iconNamed: self iconName
+]
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenter class >> iconName [
+
+	^ #smallLoadProject
+]
+
+{ #category : #specs }
+StRewriterRuleLoaderPresenter class >> title [
+
+	^ 'Rewrite rule loader'
+]
+
+{ #category : #layout }
+StRewriterRuleLoaderPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: rulesTableSelector;
+		add: (SpBoxLayout newLeftToRight
+			addLast: openInBasicEditorButton;
+			addLast: matchToolButton;
+			yourself)
+		expand: false;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterRuleLoaderPresenter >> initializeButtons [
+
+	openInBasicEditorButton := self instantiate: (StRewriterOpenRuleEditorCommand forSpecContext: self) asButtonPresenter.
+	matchToolButton := self instantiate: (StRewriterOpenMatchToolCommand forSpecContext: self) asButtonPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleLoaderPresenter >> initializePresenters [
+
+	self initializeTableSelector.
+	self initializeButtons
+]
+
+{ #category : #initialization }
+StRewriterRuleLoaderPresenter >> initializeTableSelector [
+
+	rulesTableSelector := self instantiate: StRewriterRulesTableSelectorPresenter
+]
+
+{ #category : #initialization }
+StRewriterRuleLoaderPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 700 @ 450;
+		windowIcon: self class icon;
+		askOkToClose: false;
+		aboutText: self class descriptionText
+]
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenter >> lhs [
+
+	^ rulesTableSelector lhs
+]
+
+{ #category : #accessing }
+StRewriterRuleLoaderPresenter >> rhs [
+
+	^ rulesTableSelector rhs
+]
+
+{ #category : #actions }
+StRewriterRuleLoaderPresenter >> setAllRulesAsTableItems [
+
+	rulesTableSelector refreshRules
+]

--- a/src/NewTools-RewriterTools/StRewriterRulesTableSelectorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRulesTableSelectorPresenter.class.st
@@ -1,0 +1,107 @@
+"
+I am a presenter that provides a table for showing the rules that are stored in the file system. Also, I provide a text input field for filtering the rules according to their name
+"
+Class {
+	#name : #StRewriterRulesTableSelectorPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'rulesTable',
+		'filterTextInput'
+	],
+	#category : #'NewTools-RewriterTools-Widgets'
+}
+
+{ #category : #layout }
+StRewriterRulesTableSelectorPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: rulesTable;
+		  add: filterTextInput expand: false;
+		  yourself
+]
+
+{ #category : #actions }
+StRewriterRulesTableSelectorPresenter >> filterRules: aText [
+
+	| filteredRules |
+	aText ifEmpty: [
+		rulesTable items: self getRules.
+		^ self ].
+	filteredRules := self getRules select: [ :aRuleHolder |
+		(aRuleHolder name includesSubstring: aText caseSensitive: false) or: [
+			(aRuleHolder lhs includesSubstring: aText caseSensitive: false) or: [
+				aRuleHolder rhs includesSubstring: aText caseSensitive: false ] ] ].
+	rulesTable items: filteredRules
+]
+
+{ #category : #accessing }
+StRewriterRulesTableSelectorPresenter >> getRules [
+
+	^ StRewriterDemoRules demoRules
+]
+
+{ #category : #initialization }
+StRewriterRulesTableSelectorPresenter >> initializeFiltering [
+
+	filterTextInput := self newTextInput.
+	filterTextInput
+		placeholder: 'Filter...';
+		whenTextChangedDo: [ :aText | self filterRules: aText ]
+]
+
+{ #category : #initialization }
+StRewriterRulesTableSelectorPresenter >> initializePresenters [
+
+	self initializeTable.
+	self initializeFiltering
+]
+
+{ #category : #initialization }
+StRewriterRulesTableSelectorPresenter >> initializeTable [
+
+	| lhsTableColumn ruleNameTableColumn hashtagTableColumn rhsTableColumn |
+	rulesTable := self newTable.
+	hashtagTableColumn := (SpIndexTableColumn title: '#')
+		                      width: 20;
+		                      yourself.
+	ruleNameTableColumn := SpStringTableColumn
+		                       title: 'Rule name'
+		                       evaluated: [ :rule | rule name ].
+	lhsTableColumn := SpStringTableColumn
+		                  title: 'Search for'
+		                  evaluated: [ :rule | rule lhs ].
+	rhsTableColumn := SpStringTableColumn
+		                  title: 'Replace with'
+		                  evaluated: [ :rule | rule rhs ].
+	rulesTable
+		items: self getRules;
+		sortingBlock: [ :a :b |
+			a name < b name ];
+		addColumn: hashtagTableColumn;
+		addColumn: ruleNameTableColumn;
+		addColumn: lhsTableColumn;
+		addColumn: rhsTableColumn;
+		beMultipleSelection
+]
+
+{ #category : #api }
+StRewriterRulesTableSelectorPresenter >> lhs [
+
+	^ self selectedRules
+		ifEmpty: [ '' ]
+		ifNotEmpty: [ :f |self selectedRules first lhs ]
+]
+
+{ #category : #api }
+StRewriterRulesTableSelectorPresenter >> rhs [
+
+	^ self selectedRules
+		ifEmpty: [ '' ]
+		ifNotEmpty: [ :f |self selectedRules first rhs ]
+]
+
+{ #category : #api }
+StRewriterRulesTableSelectorPresenter >> selectedRules [
+
+	^ rulesTable selectedItems
+]

--- a/src/NewTools-RewriterTools/StRewriterScopeSelectorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterScopeSelectorPresenter.class.st
@@ -1,0 +1,198 @@
+"
+I am a presenter that allows to select a list of methods.
+If you only click on one package, I will return all the methods of all the classes for that package. If you select one class, I will return all the methods of that class. If you select one method, I will only return that method.
+I support multiselection for packages, classes and methods.
+
+I can be initialized with a collection of packages `MethodsSelectorPresenter class>>#withPackages:`. If you do not set a collection of packages and only use `MethodsSelectorPresenter new` I will initialize with all Pharo packages by default.
+
+To obtain the selected methods: `MethodsSelectorPresenter>>#selectedMethods`
+"
+Class {
+	#name : #StRewriterScopeSelectorPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'methodsSelection',
+		'classesListWithFilterPresenter',
+		'packagesListWithFilterPresenter',
+		'methodsListWithFilterPresenter'
+	],
+	#category : #'NewTools-RewriterTools-Transformer'
+}
+
+{ #category : #accessing }
+StRewriterScopeSelectorPresenter class >> descriptionText [
+
+	^ 'Apply your custom rewrite rules to any packages or classes'
+]
+
+{ #category : #accessing }
+StRewriterScopeSelectorPresenter class >> icon [
+	^ self iconNamed: self iconName
+]
+
+{ #category : #accessing }
+StRewriterScopeSelectorPresenter class >> iconName [
+	^ #objects
+]
+
+{ #category : #specs }
+StRewriterScopeSelectorPresenter class >> title [
+
+	^ 'Select the classes'
+]
+
+{ #category : #accessing }
+StRewriterScopeSelectorPresenter class >> windowExtent [
+
+	^ 530 @ 330
+]
+
+{ #category : #'instance creation' }
+StRewriterScopeSelectorPresenter class >> withPackages: aPackagesCollection [
+
+	^ self new initializeWithPackages: aPackagesCollection
+]
+
+{ #category : #api }
+StRewriterScopeSelectorPresenter >> allowMethodSelection [
+
+	methodsSelection := true
+]
+
+{ #category : #actions }
+StRewriterScopeSelectorPresenter >> classesChanged [
+
+	self updateSelectionForMethodsPresenter
+]
+
+{ #category : #layout }
+StRewriterScopeSelectorPresenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  add: packagesListWithFilterPresenter;
+		  add: classesListWithFilterPresenter;
+		  add: methodsListWithFilterPresenter;
+		  spacing: 5;
+		  yourself
+]
+
+{ #category : #api }
+StRewriterScopeSelectorPresenter >> doNotAllowMethodSelection [
+
+	methodsSelection := false
+]
+
+{ #category : #initialization }
+StRewriterScopeSelectorPresenter >> initializeClassesList [
+
+	classesListWithFilterPresenter := self newFilteringList.
+	classesListWithFilterPresenter listPresenter
+		headerTitle: 'Classes';
+		display: [ :item | item name ];
+		displayIcon: [ :elem | elem iconNamed: elem systemIconName ];
+		sortingBlock: [ :a :b | a name < b name ];
+		whenSelectionChangedDo: [ :selection | self classesChanged ];
+		beMultipleSelection
+]
+
+{ #category : #initialization }
+StRewriterScopeSelectorPresenter >> initializeMethodsList [
+
+	methodsListWithFilterPresenter := self newFilteringList.
+	methodsListWithFilterPresenter listPresenter
+		headerTitle: 'Methods';
+		display: [ :item | '    ' , item selector ];
+		sortingBlock: [ :a :b | a selector < b selector ]
+]
+
+{ #category : #initialization }
+StRewriterScopeSelectorPresenter >> initializePackagesList [
+
+	packagesListWithFilterPresenter := self newFilteringList.
+	packagesListWithFilterPresenter items: RBBrowserEnvironment new packages.
+	packagesListWithFilterPresenter listPresenter
+		headerTitle: 'Packages';
+		display: [ :item | item name ];
+		displayIcon: [ self iconNamed: #packageIcon ];
+		sortingBlock: [ :a :b | a name < b name ];
+		whenSelectionChangedDo: [ self packagesChanged ];
+		beMultipleSelection
+]
+
+{ #category : #initialization }
+StRewriterScopeSelectorPresenter >> initializePresenters [
+
+	self initializePackagesList.
+	self initializeClassesList.
+	self initializeMethodsList.
+
+	self doNotAllowMethodSelection
+]
+
+{ #category : #initialization }
+StRewriterScopeSelectorPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		extent: self class windowExtent
+]
+
+{ #category : #api }
+StRewriterScopeSelectorPresenter >> initializeWithPackages: aPackagesCollection [
+
+	packagesListWithFilterPresenter items: aPackagesCollection
+]
+
+{ #category : #showing }
+StRewriterScopeSelectorPresenter >> openDialog [
+
+	| window |
+	window := super openDialog.
+	window resize: self class windowExtent.
+	^ window
+]
+
+{ #category : #actions }
+StRewriterScopeSelectorPresenter >> packagesChanged [
+
+	self updateSelectionForClassesPresenter.
+	self updateSelectionForMethodsPresenter
+]
+
+{ #category : #'api - accessing' }
+StRewriterScopeSelectorPresenter >> selectedClasses [
+
+	^ classesListWithFilterPresenter listPresenter selectedItems
+]
+
+{ #category : #'api - accessing' }
+StRewriterScopeSelectorPresenter >> selectedMethods [
+
+	^ methodsListWithFilterPresenter listPresenter selectedItems
+		  ifEmpty: [ methodsListWithFilterPresenter items ]
+		  ifNotEmpty: [ methodsListWithFilterPresenter listPresenter selectedItems ]
+]
+
+{ #category : #actions }
+StRewriterScopeSelectorPresenter >> updateSelectionForClassesPresenter [
+
+	| selectedClasses |
+	selectedClasses := packagesListWithFilterPresenter listPresenter selectedItems
+		flatCollect: [ :each | each definedClasses ] as: Set.
+
+	classesListWithFilterPresenter items: selectedClasses asOrderedCollection.
+	classesListWithFilterPresenter listPresenter selectItems: selectedClasses asOrderedCollection
+]
+
+{ #category : #actions }
+StRewriterScopeSelectorPresenter >> updateSelectionForMethodsPresenter [
+
+	| methodsInTheSelectedClasses |
+	methodsInTheSelectedClasses := classesListWithFilterPresenter listPresenter
+		selectedItems flatCollect: [ :each | each methods] as: Set.
+	methodsListWithFilterPresenter items: methodsInTheSelectedClasses asOrderedCollection.
+
+	methodsSelection
+		ifTrue: [ methodsListWithFilterPresenter listPresenter selectItems: methodsInTheSelectedClasses asOrderedCollection ]
+		ifFalse: [ methodsListWithFilterPresenter listPresenter resetListSelection ]
+]

--- a/src/NewTools-RewriterTools/StRewriterSearchForPanel.class.st
+++ b/src/NewTools-RewriterTools/StRewriterSearchForPanel.class.st
@@ -1,0 +1,46 @@
+"
+I am the panel for the search for (lhs) part of the rule
+"
+Class {
+	#name : #StRewriterSearchForPanel,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'label',
+		'codePresenter'
+	],
+	#category : #'NewTools-RewriterTools-Widgets'
+}
+
+{ #category : #layout }
+StRewriterSearchForPanel >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: label expand: false;
+		add: codePresenter;
+		yourself
+]
+
+{ #category : #initialization }
+StRewriterSearchForPanel >> initializePresenters [
+
+	label := self newLabel.
+	label label: 'Search for:'.
+
+	codePresenter := self newCode.
+	codePresenter
+		text: StRewriterDemoRules defaultRule lhs;
+		withoutSyntaxHighlight;
+		withoutLineNumbers
+]
+
+{ #category : #accessing }
+StRewriterSearchForPanel >> lhs [
+
+	^ codePresenter text
+]
+
+{ #category : #accessing }
+StRewriterSearchForPanel >> lhs: aString [
+
+	codePresenter text: aString
+]

--- a/src/NewTools-RewriterTools/String.extension.st
+++ b/src/NewTools-RewriterTools/String.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #String }
+
+{ #category : #'*NewTools-RewriterTools' }
+String >> formattedCode [
+
+	^ self
+]

--- a/src/NewTools-RewriterTools/package.st
+++ b/src/NewTools-RewriterTools/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'NewTools-RewriterTools' }


### PR DESCRIPTION
This PR adds the Rewriter Tools. Also has two backends for doing the transformations. One can use either `RB` or `Renraku`

It has the rewriter
![Capture d’écran 2023-02-10 à 17 16 55](https://user-images.githubusercontent.com/33934979/218141546-e3baca67-92b1-452f-bc21-3b866505e547.png)

Scope selector that allows to apply the transformations to custom classes
![Capture d’écran 2023-02-10 à 17 17 18](https://user-images.githubusercontent.com/33934979/218141629-b553b1ff-891e-4a8f-9801-ac83b9cb070f.png)

Match Tool 
![Capture d’écran 2023-02-10 à 17 13 10](https://user-images.githubusercontent.com/33934979/218140681-0fd71a7d-7847-45ab-9694-0e18097cfa68.png)

Expression Browser
![Capture d’écran 2023-02-10 à 17 13 46](https://user-images.githubusercontent.com/33934979/218140830-ef5b006f-915b-463d-9673-ca0c1d7161d6.png)

Ocurrences Browser
![Capture d’écran 2023-02-10 à 17 14 59](https://user-images.githubusercontent.com/33934979/218141105-a703a6be-c2a7-47d9-acdf-93c53912e5cb.png)

Example rules ready to be used
![Capture d’écran 2023-02-10 à 17 15 23](https://user-images.githubusercontent.com/33934979/218141198-34e7e342-3891-456f-8507-e2dcdfb07404.png)



Explanation about Rewrite Rules
![Capture d’écran 2023-02-10 à 17 13 21](https://user-images.githubusercontent.com/33934979/218140740-8395858f-a93d-42ad-a188-bb40bc20e704.png)
