### PR TITLE
Inspect text and string with code font

### DIFF
--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -3,8 +3,8 @@ Extension { #name : #String }
 { #category : #'*NewTools-Inspector-Extensions' }
 String >> inspectionFullString [
 	<inspectorPresentationOrder: 100 title: 'Full Content'>
-	
-	^ SpTextPresenter new
+	^ SpCodePresenter new
+		syntaxHighlight: false;
 		text: self;
 		yourself
 ]

--- a/src/NewTools-Inspector-Extensions/Text.extension.st
+++ b/src/NewTools-Inspector-Extensions/Text.extension.st
@@ -4,10 +4,12 @@ Extension { #name : #Text }
 Text >> inspectionText [
 	<inspectorPresentationOrder: 0 title: 'Text'>
 
-	^ SpMorphPresenter new 
-		morph: (RubScrolledTextMorph new 
+	^ SpMorphPresenter new
+		morph: (RubScrolledTextMorph new
 			setText: self;
-			in: [ :this | this textArea readOnly: true ];
+			in: [ :this | this textArea
+				readOnly: true;
+				font: StandardFonts codeFont ];
 			yourself);
 		yourself
 ]


### PR DESCRIPTION
Inspecting text usually require a rapid glance on the presence or absence of white spaces and tabulations, the alignment of column. Therefore, this update the full String inspector and the Text inspector to use code font.

Strangely, both inspectors do not use the same toolkit. For Text I just changed the font, for String I used a SpCodePresenter without syntax highlighting (I do not know if it's possible to change the font of a SpAbstractTextPresenter)