### PR TITLE
Fixing debugger inspector that wasn't updating when the debugger entered a new optimized scope

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -294,6 +294,45 @@ StDebuggerTest >> testContextTempVarList [
 ]
 
 { #category : #'tests - context inspector' }
+StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlinedBlocks [
+
+	| contextItems inspectorTable newContextItems |
+	dbg := self debuggerOn: session.
+	inspectorTable := dbg inspector getRawInspectorPresenterOrNil
+		                  attributeTable.
+
+	"We stop on the node `i = 1` node"
+	3 timesRepeat: [ dbg stepOver ].
+
+	contextItems := inspectorTable roots copy.
+	self assert: contextItems size equals: 8.
+
+	"We enter inlined block"
+	dbg stepOver.
+
+	newContextItems := inspectorTable roots.
+
+	self assert: newContextItems size equals: 9.
+
+	1 to: 8 do: [ :i |
+		self
+			assert: (newContextItems at: i)
+			identicalTo: (contextItems at: i) ].
+
+	self assert: (newContextItems at: 9) tempVariable isTempVariable.
+	self assert: (newContextItems at: 9) tempVariable name equals: 'j'.
+
+	"We leave inlined block"
+	2 timesRepeat: [ dbg stepOver ].
+
+	self assert: newContextItems size equals: 8.
+	1 to: 8 do: [ :i |
+		self
+			assert: (newContextItems at: i)
+			identicalTo: (contextItems at: i) ]
+]
+
+{ #category : #'tests - context inspector' }
 StDebuggerTest >> testContextUnchangedAfterStepOver [
 	| currentContext |
 	

--- a/src/NewTools-Debugger-Tests/StMockContext.class.st
+++ b/src/NewTools-Debugger-Tests/StMockContext.class.st
@@ -11,6 +11,14 @@ Class {
 	#category : #'NewTools-Debugger-Tests-Utils'
 }
 
+{ #category : #accessing }
+StMockContext >> scope [
+]
+
+{ #category : #accessing }
+StMockContext >> sourceNodeExecuted [
+]
+
 { #category : #'debugger access' }
 StMockContext >> stepIntoQuickMethod: aBoolean [
 	self stepIntoQuickMethodBooleans add: aBoolean

--- a/src/NewTools-Debugger-Tests/StMockSession.class.st
+++ b/src/NewTools-Debugger-Tests/StMockSession.class.st
@@ -31,6 +31,14 @@ StMockSession >> returnValue: value from: aContext [
 StMockSession >> runToSelection: aSelectionInterval inContext: aContext [
 ]
 
+{ #category : #accessing }
+StMockSession >> scope [
+]
+
+{ #category : #accessing }
+StMockSession >> sourceNodeExecuted [
+]
+
 { #category : #'debugging actions' }
 StMockSession >> stepInto: aContext [ 
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1362,17 +1362,29 @@ StDebugger >> updateStackFromSession: aSession [
 
 { #category : #'updating - actions' }
 StDebugger >> updateStep [
+
+	| previousASTScope previousContext currentASTScope currentContext |
+	previousContext := self currentContext.
+	previousASTScope := debuggerActionModel previousASTScope. 
+
 	self flag: #DBG_UPDATE_OF_MODEL_SHOULD_BE_AUTOMATED.
 	debuggerActionModel updateTopContext.
-	debuggerActionModel updateContextPredicate.	
+	debuggerActionModel updateContextPredicate.
 	debuggerActionModel updateDebugSession.
-		
+
 	self updateStackFromSession: self session.
 	self updateWindowTitle.
-	self updateExtensionsFrom: self session.	
+	self updateExtensionsFrom: self session.
 	self updateToolbar.
+
+	currentContext := self currentContext.
+	currentASTScope := (currentContext compiledCode sourceNodeForPC:
+		                    currentContext pc) scope.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
-	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
+	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
+		previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes." "Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."
+			p updateNodesFromScope: previousASTScope to: currentASTScope ].
+		p update ]
 ]
 
 { #category : #'updating - actions' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -8,7 +8,8 @@ Class {
 		'session',
 		'contextPredicate',
 		'topContext',
-		'filterStack'
+		'filterStack',
+		'previousASTScope'
 	],
 	#classVars : [
 		'ShouldFilterStack'
@@ -266,6 +267,12 @@ StDebuggerActionModel >> predicateFor: aContext postMortem: isContextPostMortem 
 		  yourself
 ]
 
+{ #category : #accessing }
+StDebuggerActionModel >> previousASTScope [
+
+	^ previousASTScope
+]
+
 { #category : #'debug - execution' }
 StDebuggerActionModel >> proceedDebugSession [
 
@@ -329,7 +336,10 @@ StDebuggerActionModel >> session [
 
 { #category : #accessing }
 StDebuggerActionModel >> session: aDebugSession [
-	session := aDebugSession
+
+	session := aDebugSession.
+	previousASTScope := aDebugSession interruptedContext
+		                    sourceNodeExecuted scope
 ]
 
 { #category : #'debug - stack' }
@@ -355,17 +365,20 @@ StDebuggerActionModel >> statusStringForContext [
 ]
 
 { #category : #'debug - stepping' }
-StDebuggerActionModel >> stepInto: aContext [ 
+StDebuggerActionModel >> stepInto: aContext [
+
+	previousASTScope := aContext sourceNodeExecuted scope.
 	filterStack := false.
 	aContext stepIntoQuickMethod: true.
 	self session stepInto: aContext.
 	aContext stepIntoQuickMethod: false.
-	self updateTopContext.
-
+	self updateTopContext
 ]
 
 { #category : #'debug - stepping' }
 StDebuggerActionModel >> stepOver: aContext [
+
+	previousASTScope := aContext sourceNodeExecuted scope.
 	filterStack := (self topContext method hasPragmaNamed:
 		                #debuggerCompleteToSender)
 		               ifTrue: [ false ]
@@ -376,6 +389,8 @@ StDebuggerActionModel >> stepOver: aContext [
 
 { #category : #'debug - stepping' }
 StDebuggerActionModel >> stepThrough: aContext [
+
+	previousASTScope := aContext sourceNodeExecuted scope.
 	self session stepThrough: aContext.
 	self updateTopContext
 ]

--- a/src/NewTools-Debugger/StRawInspection.extension.st
+++ b/src/NewTools-Debugger/StRawInspection.extension.st
@@ -44,6 +44,29 @@ StRawInspection >> selectedPageName [
 ]
 
 { #category : #'*NewTools-Debugger' }
+StRawInspection >> updateNodesFromScope: oldASTScope to: newASTScope [
+
+	| nodes newTemps oldTemps tempsToRemove tempsToAdd |
+	oldTemps := oldASTScope allTemps.
+	newTemps := newASTScope allTemps.
+	tempsToRemove := oldTemps difference: newTemps.
+	tempsToAdd := newTemps difference: oldTemps.
+	nodes := self attributeTable roots.
+
+	nodes removeAllSuchThat: [ :node |
+		node class = StInspectorTempNode and: [
+			tempsToRemove includes: node tempVariable ] ].
+	tempsToAdd do: [ :temp |
+		nodes add:
+			((StInspectorTempNode hostObject:
+					  self model inspectedObject context)
+				 tempVariable: temp;
+				 yourself) ].
+
+	self attributeTable roots: nodes
+]
+
+{ #category : #'*NewTools-Debugger' }
 StRawInspection >> variableTagColumn [
 
 	^  SpLinkTableColumn new 


### PR DESCRIPTION
Fixes #450 .

When the debugger entered/left an inlined block with a step, the debugger inspector wouldn't update. As a consequence, if new temporaries were declared in this optimized scope, their values wouldn't be displayed in the inspector (unless this context was deselected and then selected again in the stack).

To fix that, in the debugger action model, before performing a step I store the AST scope of the context we step into/over/through.
Then, after updating the stack of the `StDebugger`, I compare if the interrupted context after stepping is still the context that was selected before stepping. If this is the case, I ask the raw inspection presenter to update its nodes from the old AST scope with the nodes from the current AST scope.
To do that, I use methods on collections to remove all temp nodes that were in the old scope and that aren't anymore in the new scope (in case we leave an inlined block) and I also add all temp nodes that are in the new scope and that were not in the old scope (in case we enter an inlined block).
Using methods on collections allows to do nothing in case both scopes are the same or in case both scopes aren't the same but have the same temps.