### PR TITLE
fix FLDebuggerStackSerializer instance creation

### DIFF
--- a/src/NewTools-Debugger-Fuel/FLDebuggerStackSerializer.class.st
+++ b/src/NewTools-Debugger-Fuel/FLDebuggerStackSerializer.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #serializing }
 FLDebuggerStackSerializer class >> serializeStackFromContext: aContext [
-	self newDefault serializeStackFromContext: aContext
+	self new serializeStackFromContext: aContext
 ]
 
 { #category : #serializing }


### PR DESCRIPTION
was causing DNU when trying "fuel out stack" from the UI