### PR TITLE
Revert "Fixing Chest's group that should be loaded in the baseline"

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -101,8 +101,7 @@ BaselineOfNewTools >> baseline: spec [
 				    		'NewTools-Debugger-Tests' 
 					 	'NewTools-Debugger-Fuel'
 				    		'NewTools-Debugger-Fuel-Tests' 
-					 	'NewTools-Fuel'
-						'Chest' );
+					 	'NewTools-Fuel' );
 			group: 'Spotter' with: #( 
 						'NewTools-Morphic-Spotter' 
 						'NewTools-Spotter-Processors'
@@ -148,10 +147,10 @@ BaselineOfNewTools >> baseline: spec [
 { #category : #'external projects' }
 BaselineOfNewTools >> chest: spec [
 
-	spec baseline: 'Chest' with: [
+	spec baseline: 'Chest' with: [ 
 		spec
-			repository: (self packageRepositoryURL ifEmpty: [
-						 'github://pharo-spec/Chest:v0.4.2' ]);
+			repository: (self packageRepositoryURL ifEmpty: [ 
+						 'github://pharo-spec/Chest:v0.4.1' ]);
 			loads: 'default' ]
 ]
 


### PR DESCRIPTION
Reverts pharo-spec/NewTools#473

This breaks the Pharo build because Chest depend on NewTools in the code.

Either it should be Chest that depends on NewTools and we load Chest in Pharo, or Chest need to be integrated in NewTools. 

But we cannot have NewTools depending on Chest in order for it to work:

```
MetacelloNotification: Loading -> Chest-tonel.1 --- github://pharo-spec/Chest:v0.4.2 --- cache
Error: Package Chest depends on the following classes:
  StPlaygroundInteractionModel
  StDebugger
  StDebuggerExtensionVisitor
  StDebuggerExtensionInspectorNodeBuilderVisitor
You must resolve these dependencies before you will be able to load these definitions: 
  ChestCodeScriptingInteractionModel
  ChestCodeScriptingInteractionModel>>#debugger:
  ChestCodeScriptingInteractionModel>>#addBinding:
  ChestCodeScriptingInteractionModel>>#addSelfAndThisContextBindings
  ChestCodeScriptingInteractionModel>>#bindingOf:
  ChestCodeScriptingInteractionModel>>#bindings
  ChestCodeScriptingInteractionModel>>#debugger:
  ChestCodeScriptingInteractionModel>>#hasBindingOf:
  ChestCodeScriptingInteractionModel>>#removeBinding:
  StDebugger>>#bindings
  StDebugger>>#interactionModel
  StDebuggerExtensionInspectorNodeBuilderVisitor>>#visitChest:
  StDebuggerExtensionVisitor>>#visitChest:

```