### PR TITLE
Fixing debugger adding an instance variable not appears in the debugger vars inspector  + fixing args duplication when restarting execution

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -293,6 +293,34 @@ StDebuggerTest >> testContextTempVarList [
 	self assert: contextItems last rawValue identicalTo: dbg currentContext
 ]
 
+{ #category : #tests }
+StDebuggerTest >> testContextTempVarListUpdatesAfterRestartingContext [
+
+	| contextItems inspectorTable newContextItems |
+	dbg := self debuggerOn: session.
+	inspectorTable := dbg inspector getRawInspectorPresenterOrNil
+		                  attributeTable.
+		
+	contextItems := inspectorTable roots copy.
+	self assert: contextItems size equals: 8.
+
+	"We enter the inlined block (node `i + 1`)"
+	4 timesRepeat: [ dbg stepOver ].
+
+	self assert: inspectorTable roots size equals: 9.
+
+	"We restart the context"
+	dbg restartCurrentContext.
+	
+	newContextItems := inspectorTable roots.
+
+	self assert: newContextItems size equals: 8.
+	1 to: 8 do: [ :i |
+		self
+			assert: (newContextItems at: i)
+			identicalTo: (contextItems at: i) ]
+]
+
 { #category : #'tests - context inspector' }
 StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlinedBlocks [
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1334,6 +1334,7 @@ StDebugger >> updatePresenter [
 
 { #category : #'updating - actions' }
 StDebugger >> updateRestart [
+
 	self updateStep
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1296,6 +1296,9 @@ StDebugger >> updateCodeTextSegmentDecoratorsIn: aContext forInterval: selection
 
 { #category : #'updating - actions' }
 StDebugger >> updateContextChanged [
+	"A context has changed when a method has been recompiled. If a method has been recompiled with additional instance variables and/or temporary variables, the inspector needs to be updated"
+
+	inspector shouldUpdate.
 	self updateStep
 ]
 

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -285,11 +285,14 @@ StDebuggerActionModel >> proceedDebugSession [
 
 { #category : #actions }
 StDebuggerActionModel >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
+
 	aContext ifNil: [ ^ self ].
 	self session
 		recompileMethodTo: aString
 		inContext: aContext
-		notifying: aNotifyer
+		notifying: aNotifyer.
+	previousASTScope := (aContext compiledCode sourceNodeForPC:
+		                     aContext pc) scope
 ]
 
 { #category : #context }
@@ -303,7 +306,10 @@ StDebuggerActionModel >> referenceContext [
 
 { #category : #'debug - execution' }
 StDebuggerActionModel >> restartContext: aContext [
+
 	self session restart: aContext.
+	previousASTScope := (aContext compiledCode sourceNodeForPC:
+		                     aContext pc) scope.
 	self updateTopContext
 ]
 

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -307,9 +307,9 @@ StDebuggerActionModel >> referenceContext [
 { #category : #'debug - execution' }
 StDebuggerActionModel >> restartContext: aContext [
 
-	self session restart: aContext.
 	previousASTScope := (aContext compiledCode sourceNodeForPC:
 		                     aContext pc) scope.
+	self session restart: aContext.
 	self updateTopContext
 ]
 

--- a/src/NewTools-Debugger/StDebuggerInspector.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspector.class.st
@@ -15,7 +15,8 @@ Class {
 		'rawInspectionSelectionCache',
 		'assertionFailure',
 		'lateralToolbar',
-		'currentLayoutSelector'
+		'currentLayoutSelector',
+		'shouldBeUpdated'
 	],
 	#classInstVars : [
 		'maximizeAssertionSpec'
@@ -120,6 +121,13 @@ StDebuggerInspector >> getRawInspectorSelectedPath [
 	^ self getRawInspectorPresenterOrNil
 		  ifNil: [ #(  ) ]
 		  ifNotNil: [ :raw | raw selectedPath ]
+]
+
+{ #category : #initialization }
+StDebuggerInspector >> initialize [
+
+	super initialize.
+	shouldBeUpdated := false
 ]
 
 { #category : #initialization }
@@ -236,10 +244,16 @@ StDebuggerInspector >> setModelBeforeInitialization: aModel [
 	model := aModel
 ]
 
+{ #category : #asserting }
+StDebuggerInspector >> shouldUpdate [
+
+	shouldBeUpdated := true
+]
+
 { #category : #updating }
 StDebuggerInspector >> shouldUpdateContext: oldContext with: newContext [
 
-	^ oldContext ~~ newContext
+	^ oldContext ~~ newContext or: [ shouldBeUpdated ]
 ]
 
 { #category : #stepping }
@@ -287,6 +301,7 @@ StDebuggerInspector >> updateWith: inspectedObject [
 	newContext := inspectedObject ifNotNil: [ :dbgCtx | dbgCtx context ].
 	(self shouldUpdateContext: oldContext with: newContext) ifFalse: [ ^ self ].
 
+	shouldBeUpdated := false.
 	self saveRawInspectionSelectionForContext: oldContext.
 	self model: (self debuggerInspectorModelClass on: inspectedObject).
 	self updateEvaluationPaneReceiver.

--- a/src/NewTools-Debugger/StRawInspection.extension.st
+++ b/src/NewTools-Debugger/StRawInspection.extension.st
@@ -47,7 +47,6 @@ StRawInspection >> selectedPageName [
 StRawInspection >> updateNodesFromScope: oldASTScope to: newASTScope [
 
 	| nodes newTemps oldTemps tempsToRemove tempsToAdd |
-	1 haltOnce.
 	oldTemps := oldASTScope allTemps.
 	newTemps := newASTScope allTemps.
 	tempsToRemove := oldTemps difference: newTemps.

--- a/src/NewTools-Debugger/StRawInspection.extension.st
+++ b/src/NewTools-Debugger/StRawInspection.extension.st
@@ -47,6 +47,7 @@ StRawInspection >> selectedPageName [
 StRawInspection >> updateNodesFromScope: oldASTScope to: newASTScope [
 
 	| nodes newTemps oldTemps tempsToRemove tempsToAdd |
+	1 haltOnce.
 	oldTemps := oldASTScope allTemps.
 	newTemps := newASTScope allTemps.
 	tempsToRemove := oldTemps difference: newTemps.


### PR DESCRIPTION
Fixes #475

When the user recompiled a method in the top context in the debugger, if an instance variable was added in the receiver's class, the instance variable didn't use to appear in the debugger after compilation.

This could happen because the debugger inspector `shouldUpdate:` if the new context and the old context are different. However, if the method that is recompiled is recompiled in the top context, the old context and the new context are the same, although the inspector should update.
As a solution, I tell the inspector that it should update itself (with a boolean inst var in `StDebuggerInspector`) and I use this boolean to update the inspector in `StDebuggerInspector>>#shouldUpdate:`.

Concerning arg duplications after restarting a context, it was due to my previous changes in #472 that adds and removes nodes on the fly when entering/leaving inlined blocks, without updating the inspector entirely. Now that the raw inspection compares the previous AST node with the new AST scope to update te inspector, I should also update the `previousASTScope` in `StDebuggerActionModel>>#restartContext:`. That's what I have done