### PR TITLE
fixing previousASTScope after recompiling a method from the debugger,  from inside a block

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebugContextForTests.class.st
+++ b/src/NewTools-Debugger-Tests/StDebugContextForTests.class.st
@@ -1,0 +1,17 @@
+"
+I am a subclass of debug context where I override all methods requesting an UI action.
+By default, I act as if a user validated the requested popup.
+This is for tests.
+"
+Class {
+	#name : #StDebugContextForTests,
+	#superclass : #DebugContext,
+	#category : #'NewTools-Debugger-Tests-Utils'
+}
+
+{ #category : #'ui requests' }
+StDebugContextForTests >> confirm: aString [
+	"Voluntarily returns true to simulate popup validation"
+
+	^ true
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -94,8 +94,39 @@ StDebuggerActionModelTest >> methodClass [
 ]
 
 { #category : #helper }
+StDebuggerActionModelTest >> methodWithBlockContext [
+
+	| block |
+	block := [ (1+1 ) printString ].
+	block value
+]
+
+{ #category : #helper }
 StDebuggerActionModelTest >> methodWithPragma [
 	<debuggerCompleteToSender>
+]
+
+{ #category : #helper }
+StDebuggerActionModelTest >> newSessionWithBlockContext [
+
+	| process method |
+	method := self class >> #methodWithBlockContext.
+	methodWithBlockContextOriginalSource := method sourceCode.
+	process := [ method valueWithReceiver: self arguments: #(  ) ]
+		           newProcess.
+	self
+		setSessionAndDebuggerModelForMethod: method
+		inContext: process suspendedContext.
+
+	4 timesRepeat: [
+		debugActionModel stepInto: debugActionModel topContext ]
+]
+
+{ #category : #helper }
+StDebuggerActionModelTest >> resetModifiedSourceCode [
+
+	methodWithBlockContextOriginalSource ifNotNil: [
+		self class compile: methodWithBlockContextOriginalSource ]
 ]
 
 { #category : #helper }
@@ -146,6 +177,8 @@ StDebuggerActionModelTest >> tearDown [
 	StTestDebuggerProvider removeSelector: #buildDebuggerWithMissingClassContext.
 	StTestDebuggerProvider removeSelector: #foobar.
 	StDebuggerActionModel shouldFilterStack: shouldFilterStack.
+	DebugSession contextModelClass: DebugContext.
+	self resetModifiedSourceCode.
 	super tearDown
 ]
 
@@ -504,6 +537,37 @@ StDebuggerActionModelTest >> testProceedDebugSession [
 	debugActionModel proceedDebugSession.
 	self assert: session interruptedContext isNil.
 	self assert: result equals: 4
+]
+
+{ #category : #'tests - actions' }
+StDebuggerActionModelTest >> testRecompileMethodToInBlockContext [
+
+	| contextChanged previousASTScope |
+	self newSessionWithBlockContext.
+
+	DebugSession contextModelClass: StDebugContextForTests.
+	contextChanged := debugActionModel topContext.
+	
+	"We stepped into a block for which the debugActionModel holds an ast scope:"
+	previousASTScope := debugActionModel previousASTScope.
+	self
+		assert: previousASTScope
+		identicalTo: contextChanged astScope.
+
+	debugActionModel
+		recompileMethodTo: contextChanged method sourceCode , '. ^self'
+		inContext: contextChanged
+		notifying: nil.
+	debugActionModel updateTopContext.
+
+	"After recompiling the method, the model holds an updated ast scope that is not the one of the block:"
+	self deny: previousASTScope identicalTo: debugActionModel previousASTScope.
+	
+	"The new ast scope is the one of the AST of the first interesting bytecode of the method,
+	that is the block declaration:"
+	self
+		assert: debugActionModel previousASTScope
+		identicalTo: (self class >> #methodWithBlockContext) ast statements first value scope
 ]
 
 { #category : #'tests - actions' }

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -6,7 +6,8 @@ Class {
 		'debugActionModel',
 		'debugger',
 		'result',
-		'shouldFilterStack'
+		'shouldFilterStack',
+		'methodWithBlockContextOriginalSource'
 	],
 	#category : #'NewTools-Debugger-Tests-Model'
 }
@@ -496,7 +497,7 @@ StDebuggerActionModelTest >> testProceedDebugSession [
 	self assert: result equals: 4
 ]
 
-{ #category : #tests }
+{ #category : #'tests - actions' }
 StDebuggerActionModelTest >> testRecompileMethodToInContextNotifyingUpdatesSourceCodeAndContext [
 
 	| oldStack contextChanged expectedNewStack rejectedFromOldStack |

--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -110,20 +110,29 @@ StDebuggerActionModelTest >> setResult [
 ]
 
 { #category : #running }
+StDebuggerActionModelTest >> setSessionAndDebuggerModelForMethod: aMethod inContext: aContext [
+
+	session ifNotNil: [ session clear ].
+	session := (StTestDebuggerProvider new debuggerWithContext: aContext)
+		           session.
+	session stepIntoUntil: [ :currentContext |
+		currentContext method == aMethod ].
+	debugActionModel := StDebuggerActionModel on: session.
+	shouldFilterStack := StDebuggerActionModel shouldFilterStack
+]
+
+{ #category : #running }
 StDebuggerActionModelTest >> setUp [
-	| method context process |
+
+	| method process |
 	super setUp.
 	method := self class >> #setResult.
-	process := [ method valueWithReceiver: self arguments: #() ]
-		newProcess.
-	context := process suspendedContext.
-	session ifNotNil: [ session clear ].
-	session := (StTestDebuggerProvider new debuggerWithContext: context)
-		session.
-	session
-		stepIntoUntil: [ :currentContext | currentContext method == method ].
-	debugActionModel := StDebuggerActionModel on: session.
-	shouldFilterStack := StDebuggerActionModel shouldFilterStack.
+	process := [ method valueWithReceiver: self arguments: #(  ) ]
+		           newProcess.
+
+	self
+		setSessionAndDebuggerModelForMethod: method
+		inContext: process suspendedContext
 ]
 
 { #category : #running }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -285,11 +285,19 @@ StDebuggerActionModel >> proceedDebugSession [
 
 { #category : #actions }
 StDebuggerActionModel >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
+
+	| methodContext |
 	aContext ifNil: [ ^ self ].
 	self session
 		recompileMethodTo: aString
 		inContext: aContext
-		notifying: aNotifyer
+		notifying: aNotifyer.
+		
+	methodContext := aContext.
+	[ methodContext outerContext ] whileNotNil: [
+		methodContext := methodContext outerContext ].
+	previousASTScope := (methodContext compiledCode sourceNodeForPC:
+		                     methodContext pc) scope
 ]
 
 { #category : #context }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -285,17 +285,15 @@ StDebuggerActionModel >> proceedDebugSession [
 
 { #category : #actions }
 StDebuggerActionModel >> recompileMethodTo: aString inContext: aContext notifying: aNotifyer [
-	| methodContext |
 
+	| methodContext |
 	aContext ifNil: [ ^ self ].
 	self session
 		recompileMethodTo: aString
 		inContext: aContext
 		notifying: aNotifyer.
-		
-	methodContext := aContext.
-	[ methodContext outerContext ] whileNotNil: [
-		methodContext := methodContext outerContext ].
+
+	methodContext := aContext home.
 	previousASTScope := (methodContext compiledCode sourceNodeForPC:
 		                     methodContext pc) scope
 ]


### PR DESCRIPTION
Fixes #486 

When we recompile a method in the debugger while being inside a block, contexts are popped to restart the method context.

The debugger action model tries to get an AST scope from the context we're trying to rewind (i.e: the block context) that is thus terminated. That's why the block context's pc was nil.

To fix that, I get the previousASTScope from the method context because that's the one that I need in order to avoid a faulty inspector update