### PR TITLE
fixing StHaltOnCall execution condition

### DIFF
--- a/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StBreakpointCommand.class.st
@@ -24,5 +24,6 @@ StBreakpointCommand >> asSpecCommand [
 
 { #category : #testing }
 StBreakpointCommand >> canBeExecuted [
+
 	^ context enableSlotMenuEntries
 ]

--- a/src/NewTools-ObjectCentricBreakpoints/StHaltOnCallCommand.class.st
+++ b/src/NewTools-ObjectCentricBreakpoints/StHaltOnCallCommand.class.st
@@ -22,6 +22,12 @@ StHaltOnCallCommand class >> defaultName [
 	^ 'Halt on call'
 ]
 
+{ #category : #testing }
+StHaltOnCallCommand >> canBeExecuted [
+
+	^ self appliesTo: context
+]
+
 { #category : #executing }
 StHaltOnCallCommand >> execute [
 


### PR DESCRIPTION
Fixes #480 

In the meta tab of the inspector, when right-clicking on a method, the "halt on call" option was disabled. This is because of `StBreakpointCommand>>#canBeExecuted` returns true only if the contex (i.e: the inspector) enables slot menu entries.

This is relevant for halt on read/write/state access commands but not `StHaltOnCallCommand`. As `StMetaBrowser` does not specify that it enables slot menu entries, the "halt on call" option was disabled.

I fixed it by overriding `#canBeExecuted` in `StHaltOnCallCommand` to ignore this useless check for this command