### PR TITLE
Fix two deprecated #asOrderedCollection sends

### DIFF
--- a/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterScopeSelectorPresenterTest.class.st
@@ -34,7 +34,7 @@ StRewriterScopeSelectorPresenterTest >> testInitializePresenters [
 StRewriterScopeSelectorPresenterTest >> testInitializeWithPackages [
 
 	| newPresenter packages |
-	packages := 'Kernel' asPackage asOrderedCollection.
+	packages := OrderedCollection with: 'Kernel' asPackage.
 	newPresenter := StRewriterScopeSelectorPresenter new initializeWithPackages:
 		                packages.
 	self
@@ -87,7 +87,7 @@ StRewriterScopeSelectorPresenterTest >> testSelectedMethods [
 StRewriterScopeSelectorPresenterTest >> testWithPackages [
 
 	| newPresenter packages |
-	packages := 'Kernel' asPackage asOrderedCollection.
+	packages := OrderedCollection with:'Kernel' asPackage.
 	newPresenter := StRewriterScopeSelectorPresenter withPackages: packages.
 	self
 		assertCollection: newPresenter packagesFilteringListPresenter items


### PR DESCRIPTION
The logs of the Pharo11 build show:

```
DeprecationPerformedNotification: Automatic deprecation code rewrite: The method Object>>#asOrderedCollection called from StRewriterScopeSelectorPresenterTest>>#testInitializeWithPackages has been deprecated. The usage of this method is not recommended. We want to have a smaller Object api. We will remove this method in the next Pharo version.




DeprecationPerformedNotification: Automatic deprecation code rewrite: The method Object>>#asOrderedCollection called from StRewriterScopeSelectorPresenterTest>>#testWithPackages has been deprecated. The usage of this method is not recommended. We want to have a smaller Object api. We will remove this method in the next Pharo version.

```