### PR TITLE
fixing the code update bug after compiling a missing method with the unfiltered stack

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerErrorContextPredicate.extension.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerErrorContextPredicate.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #StDebuggerErrorContextPredicate }
+
+{ #category : #'*NewTools-Debugger-Tests' }
+StDebuggerErrorContextPredicate >> exception [
+
+	^ exception
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -96,6 +96,8 @@ StDebuggerTest >> tearDown [
 
 	session clear.
 	self debuggerClass fastTDD: oldFastTDD.
+	
+	"In tests, should we use `debugger` when we need a fully initialized debugger and `dbg` when we just need a debugger created with #basicNew? Still, isn't it weird to clear the session only for a fully initialized debugger but not for a debugger created with #basicNew? Both have a session. Maybe this implies that `dbg`  should only use the instance variable `session` and nothing else. These specifications should be written somewhere, in the doc of the class maybe."
 	debugger ifNotNil: [
 		debugger unsubscribeFromSystemAnnouncer.
 		debugger close.
@@ -395,39 +397,44 @@ StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
 
 	| dnuMessage method pcRangeForContext segments highlightSegment adapter |
 	StDebuggerActionModel shouldFilterStack: false.
-	dbg := StTestDebuggerProvider new debuggerWithDNUContext.
-	dbg
-		application: dbg class currentApplication;
+	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
+	debugger
+		application: debugger class currentApplication;
 		initialize.
 	adapter := SpMorphicCodeAdapter new.
-	adapter adapt: dbg code.
-	dbg code adapter: adapter.
-	dbg code adapter buildWidget.
+	adapter adapt: debugger code.
+	debugger code adapter: adapter.
+	debugger code adapter buildWidget.
 	self assert:
-		dbg debuggerActionModel isInterruptedContextDoesNotUnderstand.
+		debugger debuggerActionModel isInterruptedContextDoesNotUnderstand.
 	self
-		assert: dbg interruptedContext receiver class
+		assert: debugger interruptedContext receiver class
 		identicalTo: StTestDebuggerProvider.
-	dnuMessage := dbg debuggerActionModel contextPredicate exception
+	dnuMessage := debugger debuggerActionModel contextPredicate exception
 		              message.
 
 	self assert: dnuMessage selector identicalTo: #foobar.
 
 	"stack is unfiltered. So the text shown should be the code from the DNU"
-	self assert: (dbg code text beginsWith: 'doesNotUnderstand:').
+	self assert: (debugger code text beginsWith: 'doesNotUnderstand:').
 
 	"we create the missing method #foobar"
-	dbg createMissingMethodFor: dnuMessage in: StTestDebuggerProvider.
+	debugger
+		createMissingMethodFor: dnuMessage
+		in: StTestDebuggerProvider.
 
 	method := StTestDebuggerProvider methodDictionary at: #foobar.
 
 	"code must have been updated with the new method"
-	self assert: dbg interruptedContext compiledCode identicalTo: method.
-	self assert: dbg code text equals: method sourceCode.
+	self
+		assert: debugger interruptedContext compiledCode
+		identicalTo: method.
+	self assert: debugger code text equals: method sourceCode.
 
-	session := dbg session.
-	pcRangeForContext := session pcRangeForContext: dbg currentContext.
-	segments := dbg code adapter widget segments.
+	session := debugger session.
+	pcRangeForContext := session pcRangeForContext:
+		                     debugger currentContext.
+	segments := debugger code adapter widget segments.
 	self assert: segments size equals: 1.
 	highlightSegment := segments first.
 

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -393,12 +393,16 @@ StDebuggerTest >> testCopyStackToClipboard [
 { #category : #tests }
 StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
 
-	| dnuMessage |
+	| dnuMessage method pcRangeForContext segments highlightSegment adapter |
 	StDebuggerActionModel shouldFilterStack: false.
 	dbg := StTestDebuggerProvider new debuggerWithDNUContext.
 	dbg
 		application: dbg class currentApplication;
 		initialize.
+	adapter := SpMorphicCodeAdapter new.
+	adapter adapt: dbg code.
+	dbg code adapter: adapter.
+	dbg code adapter buildWidget.
 	self assert:
 		dbg debuggerActionModel isInterruptedContextDoesNotUnderstand.
 	self
@@ -415,11 +419,21 @@ StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
 	"we create the missing method #foobar"
 	dbg createMissingMethodFor: dnuMessage in: StTestDebuggerProvider.
 
+	method := StTestDebuggerProvider methodDictionary at: #foobar.
+
 	"code must have been updated with the new method"
+	self assert: dbg interruptedContext compiledCode identicalTo: method.
+	self assert: dbg code text equals: method sourceCode.
+
+	session := dbg session.
+	pcRangeForContext := session pcRangeForContext: dbg currentContext.
+	segments := dbg code adapter widget segments.
+	self assert: segments size equals: 1.
+	highlightSegment := segments first.
+
 	self
-		assert: dbg interruptedContext compiledCode selector
-		identicalTo: #foobar.
-	self assert: (dbg code text beginsWith: 'foobar')
+		assert: (highlightSegment firstIndex to: highlightSegment lastIndex)
+		equals: (pcRangeForContext first to: pcRangeForContext last + 1)
 ]
 
 { #category : #'tests - initialization' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -6,7 +6,8 @@ Class {
 		'debugger',
 		'oldFastTDD',
 		'dbg',
-		'stackSizeBefore'
+		'stackSizeBefore',
+		'shouldFilterStack'
 	],
 	#category : #'NewTools-Debugger-Tests-Presenters'
 }
@@ -86,6 +87,7 @@ StDebuggerTest >> setUp [
 	super setUp.	
 	session := StTestDebuggerProvider new sessionForDebuggerTests.
 	oldFastTDD := self debuggerClass fastTDD.
+	shouldFilterStack := StDebuggerActionModel shouldFilterStack.
 	self debuggerClass fastTDD: true
 ]
 
@@ -94,12 +96,17 @@ StDebuggerTest >> tearDown [
 
 	session clear.
 	self debuggerClass fastTDD: oldFastTDD.
-	debugger ifNotNil: [ 
+	debugger ifNotNil: [
 		debugger unsubscribeFromSystemAnnouncer.
 		debugger close.
 		debugger session ifNotNil: [ :s | s clear ] ].
-	StTestDebuggerProvider removeSelector: #foobar. 
-	StDebuggerObjectForTests compile: 'haltingMethod <haltOrBreakpointForTesting> self halt. ^self' classified: 'util'.
+	StTestDebuggerProvider removeSelector: #foobar.
+	StDebuggerObjectForTests
+		compile:
+		'haltingMethod <haltOrBreakpointForTesting> self halt. ^self'
+		classified: 'util'.
+	StDebuggerActionModel shouldFilterStack: shouldFilterStack.
+	StTestDebuggerProvider removeSelector: #foobar.
 	super tearDown
 ]
 
@@ -381,6 +388,38 @@ StDebuggerTest >> testCopyStackToClipboard [
 		assert: Clipboard clipboardText string
 		equals: (String streamContents: [ :s | 
 				 session interruptedContext shortDebugStackOn: s ])
+]
+
+{ #category : #tests }
+StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
+
+	| dnuMessage |
+	StDebuggerActionModel shouldFilterStack: false.
+	dbg := StTestDebuggerProvider new debuggerWithDNUContext.
+	dbg
+		application: dbg class currentApplication;
+		initialize.
+	self assert:
+		dbg debuggerActionModel isInterruptedContextDoesNotUnderstand.
+	self
+		assert: dbg interruptedContext receiver class
+		identicalTo: StTestDebuggerProvider.
+	dnuMessage := dbg debuggerActionModel contextPredicate exception
+		              message.
+
+	self assert: dnuMessage selector identicalTo: #foobar.
+
+	"stack is unfiltered. So the text shown should be the code from the DNU"
+	self assert: (dbg code text beginsWith: 'doesNotUnderstand:').
+
+	"we create the missing method #foobar"
+	dbg createMissingMethodFor: dnuMessage in: StTestDebuggerProvider.
+
+	"code must have been updated with the new method"
+	self
+		assert: dbg interruptedContext compiledCode selector
+		identicalTo: #foobar.
+	self assert: (dbg code text beginsWith: 'foobar')
 ]
 
 { #category : #'tests - initialization' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1299,6 +1299,8 @@ StDebugger >> updateContextChanged [
 	"A context has changed when a method has been recompiled. If a method has been recompiled with additional instance variables and/or temporary variables, the inspector needs to be updated"
 
 	inspector shouldUpdate.
+	"The top context has been changed so we force the code presenter to change its text. Otherwise, the debugger would consider that there are unsaved code changes, as the source code from the context would not be the same as the source code displayed"
+	self code text: self interruptedContext sourceCode.
 	self updateStep
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1300,7 +1300,7 @@ StDebugger >> updateContextChanged [
 
 	inspector shouldUpdate.
 	"The top context has been changed so we force the code presenter to change its text. Otherwise, the debugger would consider that there are unsaved code changes, as the source code from the context would not be the same as the source code displayed"
-	self code text: self interruptedContext sourceCode.
+	self updateSourceCodeFor: self interruptedContext.
 	self updateStep
 ]
 


### PR DESCRIPTION
Fixes #489 

When you encounter a DNU with the unfiltered stack in the debugger, the DNU context is at the top of your stack.

If you clicked the create "button" to create the missing method, the DebugSession will update the top context (here the DNU) with the new implemented method.

Then the event `#contextChanged` is triggered so that the debugger updates the stack, the code, the inspector, etc.

However, to update the code in `StDebugger>>#updateCodeFromContext:`, the debugger executes first its method `#recordUnsavedCodeChanges` that checks if there are unsaved code changes. To do that, the debugger checks if the displayed code is different from the code of the selected context. Here this is the case, because the code of the DNU is different from the code of the newly implemented method.

As the debugger considers there are unsaved code changes, it prevents from updating the code, which is wrong.

I fixed it so that the code is forced to update in the case of the top context has changed.

I set this PR as a draft because I would like to write a test