### PR TITLE
Fix glitch on method creation

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -403,14 +403,14 @@ StDebugger >> createMissingMethod [
 	| msg chosenClass |
 	self flag: #DBG_MISSINGTEST.
 	msg := self interruptedContext tempAt: 1.
-	[ 
-	chosenClass := self requestClassFrom:
-		               self interruptedContext receiver class.
+	[
+	chosenClass := self requestClassFrom: self interruptedContext receiver class.
 	self createMissingMethodFor: msg in: chosenClass ]
 		on: Abort
 		do: [ ^ self ].
-		
-	code takeKeyboardFocus 
+
+	code triggerResetAction.
+	code takeKeyboardFocus
 ]
 
 { #category : #actions }


### PR DESCRIPTION
When creating a new method through the debugger, the code presenter is not reset, leading to the debugger showing a doesNotUndestard: instead of the new method. 

Fixes #489