### PR TITLE
More inspector extensions

### DIFF
--- a/src/NewTools-Inspector-Extensions/ByteArray.extension.st
+++ b/src/NewTools-Inspector-Extensions/ByteArray.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #ByteArray }
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+ByteArray >> inspectBytes: specBuilder [
+	<inspectorPresentationOrder: 30 title: 'Bytes'>
+
+	^ self size > 1000 
+		ifTrue: [
+			(StSimpleInspectorBuilder on: specBuilder)
+				key: 'error' value: 'too many bytes, size is ' , self size asString;
+				table ]
+		ifFalse: [
+			(StSimpleInspectorBuilder on: specBuilder)
+				key: 'hex string' value: (String streamContents: [ :out | 
+					self do: [ :each | each printOn: out base: 16 nDigits: 2 ] ]);
+				key: 'hex lines' value: (String streamContents: [ :out |
+					self withIndexDo: [ :each :index |
+						index = 1 ifFalse: [ 
+							index - 1 \\ 8 = 0 ifTrue: [ out cr ] ifFalse: [ out space ] ].
+						each printOn: out base: 16 nDigits: 2 ] ]);
+				key: #UTF8 value: ([ self utf8Decoded ] on: ZnCharacterEncodingError do: [ :exception | exception ]);
+				key: #Latin1 value: ([ self decodeWith: #Latin1 ] on: ZnCharacterEncodingError do: [ :exception | exception ]);
+				key: 'integer' value: self asInteger;
+				key: 'integer reversed' value: self reversed asInteger;
+				table ]
+]

--- a/src/NewTools-Inspector-Extensions/Character.extension.st
+++ b/src/NewTools-Inspector-Extensions/Character.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #Character }
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+Character >> inspectCharacterIn: specBuilder [
+	<inspectorPresentationOrder: 30 title: 'Character'>
+	
+	^ (StSimpleInspectorBuilder on: specBuilder)
+			key: #self value: self;
+			key: #codepoint value: self codePoint;
+			key: #unicode value: (String streamContents: [ :stream | 
+				stream << 'U+'.
+				self codePoint printOn: stream base: 16 nDigits: 4 ]);
+			table
+]

--- a/src/NewTools-Inspector-Extensions/Float.extension.st
+++ b/src/NewTools-Inspector-Extensions/Float.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #Float }
+
+{ #category : #'*NewTools-Inspector-Extensions' }
+Float >> inspectFloatIn: specBuilder [
+	<inspectorPresentationOrder: 30 title: 'Float'>
+	
+	^ (StSimpleInspectorBuilder on: specBuilder)
+			key: #self value: self;
+			key: #binary value: self binaryLiteralString;
+			key: #significand value: self significand;
+			key: #exponent value: self exponent;
+			table
+]

--- a/src/NewTools-Inspector-Extensions/Integer.extension.st
+++ b/src/NewTools-Inspector-Extensions/Integer.extension.st
@@ -1,20 +1,17 @@
 Extension { #name : #Integer }
 
 { #category : #'*NewTools-Inspector-Extensions' }
-Integer >> inspectIntegerIn: aBuilder [
+Integer >> inspectIntegerIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Integer'> 
-	| keysColumn valuesColumn items |
-	items := { 'decimal' -> self printString.
-					'hex' -> self printStringHex.
-					'octal' -> (self printStringBase: 8).
-					'binary' -> (self printStringBase: 2)} asOrderedCollection.
-					
-	keysColumn := SpStringTableColumn title: #key evaluated: [ :anAssociation | anAssociation key ].
-	valuesColumn := SpStringTableColumn title: #value evaluated: [ :anAssociation | anAssociation value ].
 	
-	^ aBuilder newTable
-		addColumn: keysColumn;
-		addColumn: valuesColumn;
-		items: items;
-		yourself
+	| inspectorBuilder |
+	(inspectorBuilder := StSimpleInspectorBuilder on: specBuilder) 
+		key: #self value: self;
+		key: #decimal value: self printString;
+		key: 	#hex value: self printStringHex;
+		key: #octal value: (self printStringBase: 8);
+		key: 	#binary value: (self printStringBase: 2).
+	(self between: 0 and: ZnCharacterEncoder default maximumUTFCode)	
+		ifTrue: [ inspectorBuilder key: #character value: self asCharacter ].
+	^ inspectorBuilder table
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -1,6 +1,18 @@
 Extension { #name : #String }
 
 { #category : #'*NewTools-Inspector-Extensions' }
+String >> inspectionEncoding: specBuilder [
+	<inspectorPresentationOrder: 200 title: 'Encoding'>
+	
+	| shorterString |
+	shorterString := self truncateWithElipsisTo: 1000.
+	^ (StSimpleInspectorBuilder on: specBuilder)
+			key: #UTF8 value: shorterString utf8Encoded printString;
+			key: #Latin1 value: (shorterString encodeWith: #Latin1) printString;
+			table
+]
+
+{ #category : #'*NewTools-Inspector-Extensions' }
 String >> inspectionFullString [
 	<inspectorPresentationOrder: 100 title: 'Full Content'>
 	^ SpCodePresenter new

--- a/src/NewTools-Inspector/StSimpleInspectorBuilder.class.st
+++ b/src/NewTools-Inspector/StSimpleInspectorBuilder.class.st
@@ -1,0 +1,49 @@
+"
+I am StSimpleInspectorBuilder.
+
+I help in creating simple key/value inspector panels.
+
+Check my usage (class references) for examples.
+"
+Class {
+	#name : #StSimpleInspectorBuilder,
+	#superclass : #Object,
+	#instVars : [
+		'specBuilder',
+		'info'
+	],
+	#category : #'NewTools-Inspector-Model'
+}
+
+{ #category : #'instance creation' }
+StSimpleInspectorBuilder class >> on: aSpecBuilder [
+	^ self new on: aSpecBuilder; yourself
+]
+
+{ #category : #initialization }
+StSimpleInspectorBuilder >> initialize [ 
+	super initialize.
+	info := OrderedCollection new
+]
+
+{ #category : #accessing }
+StSimpleInspectorBuilder >> key: key value: value [
+	info add: key -> value
+]
+
+{ #category : #initialization }
+StSimpleInspectorBuilder >> on: aSpecBuilder [
+	specBuilder := aSpecBuilder 
+]
+
+{ #category : #accessing }
+StSimpleInspectorBuilder >> table [
+	| keysColumn valuesColumn |
+	keysColumn := SpStringTableColumn title: #key evaluated: [ :anAssociation | anAssociation key ].
+	valuesColumn := SpStringTableColumn title: #value evaluated: [ :anAssociation | anAssociation value ].
+	^ specBuilder newTable
+		addColumn: keysColumn;
+		addColumn: valuesColumn;
+		items: (info collect: [ :anAssociation | StInspectorAssociationNode hostObject: anAssociation ]);
+		yourself
+]


### PR DESCRIPTION
Introduction of SpSimpleInspectorBuilder to aid in the construction of simple key/value inspector extensions that can be written without knowledge of Spec or the inspector implementation.

Add examples for Integer, Float, Character, String and ByteArray