### PR TITLE
NewTools-Debugger-Breakpoints-Tools leaves the image in a dirty state.

### DIFF
--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltAndBreakpointControlTest.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltAndBreakpointControlTest.class.st
@@ -30,8 +30,8 @@ StHaltAndBreakpointControlTest >> methodWithHaltSources [
 
 { #category : #helpers }
 StHaltAndBreakpointControlTest >> removeMethodsWithHalts [
-	self testClass methods
-		do: [ :method | self testClass removeSelector: method selector]
+
+	(self testClass methods select: [ :m | m selector includesSubstring: 'Halt' ]) do: [ :method | self testClass removeSelector: method selector ]
 ]
 
 { #category : #running }

--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltCacheTest.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltCacheTest.class.st
@@ -58,7 +58,7 @@ StHaltCacheTest >> testInitialCacheBuild [
 	self assert: cache methodsWithHalts size equals: 6.
 	(self testClass methods
 		reject: [ :m | 
-			#('StDummyTestClassWithHalts>>#mNoHalt' 'StDummyTestClassWithHalts>>#mRejectHalt')
+			#('StDummyTestClassWithHalts>>#mNoHalt' 'StDummyTestClassWithHalts>>#mRejectHalt' 'StDummyTestClassWithHalts>>#var')
 				includes: m printString ])
 		do: [ :method | 
 			| haltNode nodeCache |


### PR DESCRIPTION
This fixes it