### PR TITLE
StTestDebuggerProvider class>>#compileMissingClassContextBuilder use permitUndeclared:

### DIFF
--- a/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
+++ b/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #helpers }
 StTestDebuggerProvider class >> compileMissingClassContextBuilder [
 	
-	self compile: 'buildDebuggerWithMissingClassContext
+	self compiler permitUndeclared: true; install: 'buildDebuggerWithMissingClassContext
 	
 	[ MissingClass new ]
 		on: Error


### PR DESCRIPTION
This makes the intention explicit and lessen the reliance on current heuristic