### PR TITLE
Debugger: can handle new exceptions UndeclaredVariableRead&UndeclaredVariableWrite

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerCommandTest.class.st
@@ -159,11 +159,11 @@ StDebuggerCommandTest >> testCommandsInMissingClassContext [
 	self assert: (StReturnValueCommand forContext: debugger) canBeExecuted. 
 	
 	"Non-executable commands relative to context"
-	self deny: (StStepIntoCommand forContext: debugger) canBeExecuted. 
-	self deny: (StStepOverCommand forContext: debugger) canBeExecuted. 
-	self deny: (StStepThroughCommand forContext: debugger) canBeExecuted. 
-	self deny: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
-	self deny: (StProceedCommand forContext: debugger) canBeExecuted. 
+	self assert: (StStepIntoCommand forContext: debugger) canBeExecuted. 
+	self assert: (StStepOverCommand forContext: debugger) canBeExecuted. 
+	self assert: (StStepThroughCommand forContext: debugger) canBeExecuted. 
+	self assert: (StRunToSelectionCommand forContext: debugger) canBeExecuted.
+	self assert: (StProceedCommand forContext: debugger) canBeExecuted. 
 	self deny: (StDefineSubclassResponsabilityCommand forContext: debugger) canBeExecuted.  
 	
 	

--- a/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
+++ b/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
@@ -15,7 +15,7 @@ StTestDebuggerProvider class >> compileMissingClassContextBuilder [
 	
 	self compiler permitUndeclared: true; install: 'buildDebuggerWithMissingClassContext
 	
-	[ MissingClass new ]
+	[ ^ MissingClass ]
 		on: Error
 		do: [ :err | 			
 			self sessionFor: err signalerContext copy exception: err.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -383,7 +383,7 @@ StDebugger >> createMissingClass [
 	[ 
 	| newClassBinding |
 	self flag: 'This method is actually hard to test because it requires user input to complete. How to test that automatically?'.
-	newClassBinding := OCUndeclaredVariableWarning new
+	newClassBinding := OCCodeReparator new
 		                   node: variableNode;
 		                   defineClass: variableNode name ]
 		on: Abort

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -55,7 +55,7 @@ StDebuggerErrorContextPredicate >> isContextDoesNotUnderstand [
 { #category : #predicates }
 StDebuggerErrorContextPredicate >> isContextMissingClassException [
 
-	^ exception class == VariableNotDeclared
+	^ #(#VariableNotDeclared #UndeclaredVariableRead #UndeclaredVariableWrite) includes: exception class name
 ]
 
 { #category : #predicates }


### PR DESCRIPTION
Pharo12 provides new runtime exceptions UndeclaredVariableRead and UndeclaredVariableWrite that will replace VariableNotDeclared. The latter is a fragile hack based on MessageNotUnderstood.

Also, the code reparation was moved from `OCUndeclaredVariableWarning` to `OCCodeReparator`