### PR TITLE
Adding inspector transmission node

### DIFF
--- a/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #StInspectorTransmissionNode,
+	#superclass : #StInspectorNode,
+	#instVars : [
+		'transmissionBlock'
+	],
+	#category : #'NewTools-Inspector-Model'
+}
+
+{ #category : #'instance initialization' }
+StInspectorTransmissionNode class >> hostObject: anObject transmissionBlock: aFullBlockClosure [
+
+	^ self new
+		  hostObject: anObject;
+		  transmissionBlock: aFullBlockClosure;
+		  yourself
+]
+
+{ #category : #accessing }
+StInspectorTransmissionNode >> key [
+
+	^ self hostObject
+]
+
+{ #category : #accessing }
+StInspectorTransmissionNode >> rawValue [
+
+	^ transmissionBlock value: hostObject
+]
+
+{ #category : #accessing }
+StInspectorTransmissionNode >> transmissionBlock: aBlock [
+
+	transmissionBlock := aBlock
+]

--- a/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
@@ -1,3 +1,6 @@
+"
+I am an inspector node that allows the user to specify a custom transmission. I am made to be used inside the Inspector. The user can specify the `transmissionBlock:`
+"
 Class {
 	#name : #StInspectorTransmissionNode,
 	#superclass : #StInspectorNode,


### PR DESCRIPTION
Currently there is two solutions for having the transmissions on the inspector

- Either you use StInspectorNode to wrap your data, but it very limited with the transmissions
- Either you create a presenter class and customize the transmissions. Bad side is that you need to create a class and for simple presenters is not convenient.

I was thinking on this the other day. So you are right, the blog post and StInspectorNode are not compatible.

One solution that I can think is to create a StInspectorTransmissionNode that manages the transmission. This can be a third option when you have a small presenter that you want to put in the inspector and you don't want to create a class but you want the power of transmissions.

This PR introduces the class `StInspectorTransmissionNode` that allows to the user to specify custom transmissions inside the Inspector in an easy way.


Let's take this code:

```st
<inspectorPresentationOrder: 1 title: 'Demo'>
    | items |
    items := #( 1 2 3 4 5 6 7 8 ).

    ^ SpListPresenter new
        items: (items collect: [ :e |
            StInspectorTransmissionNode hostObject: e transmissionBlock: [ :theObject | theObject + 100 ] ]);
        display: [ :e | e hostObject ];
        yourself
```

This produces the inspector extension that add 100 when you click on a number 

![image](https://user-images.githubusercontent.com/33934979/233337188-54f2ddf9-0660-4e3a-92af-074105882516.png)
