### PR TITLE
add StDebuggerContextInteractionModelTest>>#testCompile to test DoIt-evaluations

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextInteractionModelTest.class.st
@@ -122,6 +122,36 @@ StDebuggerContextInteractionModelTest >> testBindingOfPrioritizesContextBindings
 ]
 
 { #category : #tests }
+StDebuggerContextInteractionModelTest >> testCompile [
+
+	| result |
+	model context
+		step;
+		step;
+		step;
+		step. "Perform the two first assigments of the method `helperMethodForBindings`"
+
+	result := model compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 42.
+	instanceVariableForTest := 52.
+	result := model compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 52.
+
+	result := model compiler evaluate: 'instanceVariableForTest := 62'.
+	self assert: result equals: 62.
+	result := model compiler evaluate: 'instanceVariableForTest'.
+	self assert: result equals: 62.
+	self assert: instanceVariableForTest equals: 62.
+
+	result := model compiler evaluate: 'tempVariableForTest'.
+	self assert: result equals: 43.
+	result := model compiler evaluate: 'tempVariableForTest := 53'.
+	self assert: result equals: 53.
+	result := model compiler evaluate: 'tempVariableForTest'.
+	self assert: result equals: 53
+]
+
+{ #category : #tests }
 StDebuggerContextInteractionModelTest >> testHasBindingsInContextOf [
 
 	self


### PR DESCRIPTION
https://github.com/pharo-project/pharo/pull/13498 did solve a regression with dolt evaluation in the debugger.

Related improvements and tests are proposed to https://github.com/pharo-spec/Spec/pull/1379
This is the equivalent test for StDebuggerContextInteractionModel.

Require both PR to be merged in the other repos