### PR TITLE
Inspector-sorting-on-collections

### DIFF
--- a/src/NewTools-Inspector-Extensions/Bag.extension.st
+++ b/src/NewTools-Inspector-Extensions/Bag.extension.st
@@ -9,10 +9,12 @@ Bag >> inspectionItems: aBuilder [
 			title: 'Items';
 			evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each key ];
 			beNotExpandable;
+			beSortable;
 			yourself);
 		addColumn: (SpStringTableColumn new  
 			title: 'Occurences'; 
 			evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: (self occurrencesOf: each key) ];
+			beSortable;
 			yourself);
 		items: contents associations;
 		yourself

--- a/src/NewTools-Inspector-Extensions/Collection.extension.st
+++ b/src/NewTools-Inspector-Extensions/Collection.extension.st
@@ -13,7 +13,7 @@ Collection >> inspectionItems: aBuilder [
 		addColumn: (SpStringTableColumn new  
 			title: 'Value'; 
 			evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each ];
-			sortFunction: #printString ascending;
+			beSortable;
 			yourself);
 		items: self asOrderedCollection;
 		yourself


### PR DESCRIPTION
The collection should have the columns sortable, and not use a sortFunction. When it is sortable, it uses the value shown in the table.

Fix https://github.com/pharo-project/pharo/issues/13430