### PR TITLE
change spotter selection paste default

### DIFF
--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -114,7 +114,7 @@ StSpotter class >> initialize [
 { #category : #settings }
 StSpotter class >> insertsSelection [
 		
-	^ InsertsSelection ifNil: [ InsertsSelection := true ]
+	^ InsertsSelection ifNil: [ InsertsSelection := false ]
 ]
 
 { #category : #settings }


### PR DESCRIPTION
default of this has to be false, otherwise is very annoying