### PR TITLE
Add stack coloring to the debugger

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -551,6 +551,46 @@ StDebuggerTest >> testInterruptedProcessProvidesSameProcessAsTheActionModelOne [
 		identicalTo: debugger debuggerActionModel interruptedProcess
 ]
 
+{ #category : #tests }
+StDebuggerTest >> testIsInSelectedContextClass [
+
+	| stackTable context process |
+	context := thisContext.
+	process := Process forContext: context priority: Processor userInterruptPriority.
+	session := DebugSession named: 'test session' on: process startedAt: context.
+	session exception: OupsNullException new.
+
+	debugger := self debuggerOn: session.
+	stackTable := debugger stackTable.
+
+	stackTable selectItem: (stackTable items at: 2).
+	"Let's make sure we select the method we want in case SUnit changes in the future and that our tests will be on the right methods."
+	self assert: stackTable selectedItem method selector equals: #performTest.
+	self assert: (stackTable items at: 7) method selector equals: #runCase.
+
+	self assert: (debugger isInSelectedContextClass: (stackTable items at: 7))
+]
+
+{ #category : #tests }
+StDebuggerTest >> testIsInSelectedContextPackage [
+
+	| stackTable context process |
+	context := thisContext.
+	process := Process forContext: context priority: Processor userInterruptPriority.
+	session := DebugSession named: 'test session' on: process startedAt: context.
+	session exception: OupsNullException new.
+
+	debugger := self debuggerOn: session.
+	stackTable := debugger stackTable.
+
+	stackTable selectItem: (stackTable items at: 2).
+	"Let's make sure we select the method we want in case SUnit changes in the future and that our tests will be on the right methods."
+	self assert: stackTable selectedItem method selector equals: #performTest.
+	self assert: (stackTable items at: 12) method selector equals: #runTestCaseUnderWatchdog:.
+
+	self assert: (debugger isInSelectedContextPackage: (stackTable items at: 12))
+]
+
 { #category : #'tests - context inspector' }
 StDebuggerTest >> testNewDebuggerContext [
 	| debuggerContext |

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -737,39 +737,38 @@ StDebugger >> initializeShortcuts: aWindowPresenter [
 StDebugger >> initializeStack [
 
 	stackTable := self newTable.
-	stackTable 
+	stackTable
 		activateOnDoubleClick;
 		whenActivatedDo: [ :selection | self doBrowseClass ].
 	stackTable
-		addColumn: ((SpImageTableColumn
-				  title: ''
-				  evaluated: [ :context | self stackIconForContext: context ])
+		addColumn: ((SpImageTableColumn title: '' evaluated: [ :context | self stackIconForContext: context ])
 				 width: 8;
 				 sortFunction: nil;
 				 yourself);
-		addColumn: ((SpStringTableColumn
-				  title: 'Class'
-				  evaluated: [ :context | self printReceiverClassInContext: context ])
+		addColumn: ((SpStringTableColumn title: 'Class' evaluated: [ :context | self printReceiverClassInContext: context ])
+				 displayColor: [ :context | self stackColorForContext: context ];
 				 sortFunction: nil;
 				 yourself);
-		addColumn:
-			((SpStringTableColumn title: 'Method' evaluated: [ :context | 
+		addColumn: ((SpStringTableColumn title: 'Method' evaluated: [ :context |
 					  | method |
 					  method := context method.
 					  method isCompiledBlock
 						  ifTrue: [ method sourceNode sourceCode ]
 						  ifFalse: [ method selector ] ])
+				 displayColor: [ :context | self stackColorForContext: context ];
 				 sortFunction: nil;
 				 yourself);
-		addColumn:
-			((SpStringTableColumn title: 'Package' evaluated: [ :context | 
+		addColumn: ((SpStringTableColumn title: 'Package' evaluated: [ :context |
 					  | package |
 					  package := context method package.
-					  package ifNil: [ '-' ] ifNotNil: [ package name asString ] ])
+					  package
+						  ifNil: [ '-' ]
+						  ifNotNil: [ package name asString ] ])
+				 displayColor: [ :context | self stackColorForContext: context ];
 				 sortFunction: nil;
 				 yourself).
-	stackTable transmitDo: [ :context | 
-		stackTable selection isEmpty ifFalse: [ 
+	stackTable transmitDo: [ :context |
+		stackTable selection isEmpty ifFalse: [
 			self updateInspectorFromContext: context.
 			self updateCodeFromContext: context.
 			self updateExtensionsFrom: self session.
@@ -1151,6 +1150,24 @@ StDebugger >> stackAndCodeWithExtensionsLayout [
 			add: self stackAndCodeLayout;
 			add: #extensionToolsNotebook;
 			yourself)
+]
+
+{ #category : #accessing }
+StDebugger >> stackColorForContext: context [
+	"I return the color the text should have in the stack by comparing the context in parameter to the selected context.
+	
+	If they are from the same class, we return a certain 'primary' highlight color.
+	If they are from the same package (but different class), we return a 'secondary' highlight color.
+	Else, we just keep the normal style."
+
+	| selectedContext |
+	selectedContext := stackTable selectedItem.
+	^ selectedContext methodClass = context methodClass
+		  ifTrue: [ self theme highlightTextColor ]
+		  ifFalse: [
+			  selectedContext method package = context method package
+				  ifTrue: [ self theme highlightTextColor alpha: 0.5 ]
+				  ifFalse: [ self theme textColor ] ]
 ]
 
 { #category : #stack }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -749,22 +749,22 @@ StDebugger >> initializeStack [
 				 yourself);
 		addColumn: ((SpStringTableColumn
 				  title: 'Class'
-				  evaluated: [ :item | self printReceiverClassInContext: item ])
+				  evaluated: [ :context | self printReceiverClassInContext: context ])
 				 sortFunction: nil;
 				 yourself);
 		addColumn:
-			((SpStringTableColumn title: 'Method' evaluated: [ :item | 
+			((SpStringTableColumn title: 'Method' evaluated: [ :context | 
 					  | method |
-					  method := item method.
+					  method := context method.
 					  method isCompiledBlock
 						  ifTrue: [ method sourceNode sourceCode ]
 						  ifFalse: [ method selector ] ])
 				 sortFunction: nil;
 				 yourself);
 		addColumn:
-			((SpStringTableColumn title: 'Package' evaluated: [ :item | 
+			((SpStringTableColumn title: 'Package' evaluated: [ :context | 
 					  | package |
-					  package := item method package.
+					  package := context method package.
 					  package ifNil: [ '-' ] ifNotNil: [ package name asString ] ])
 				 sortFunction: nil;
 				 yourself).

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -821,6 +821,20 @@ StDebugger >> interruptedProcess [
 	^ self debuggerActionModel  interruptedProcess
 ]
 
+{ #category : #testing }
+StDebugger >> isInSelectedContextClass: context [
+	"Return true if the given context is in the same class than the currently selected context of the stack."
+
+	^ self selectedContext methodClass = context methodClass
+]
+
+{ #category : #testing }
+StDebugger >> isInSelectedContextPackage: context [
+	"Return true if the given context is in the same package than the currently selected context of the stack."
+
+	^ self selectedContext method package = context method package
+]
+
 { #category : #'commands - support' }
 StDebugger >> keybindsForFromContextMenu: aGroupElement [
 	| keybinds keybindsCommands |
@@ -1160,12 +1174,10 @@ StDebugger >> stackColorForContext: context [
 	If they are from the same package (but different class), we return a 'secondary' highlight color.
 	Else, we just keep the normal style."
 
-	| selectedContext |
-	selectedContext := stackTable selectedItem.
-	^ selectedContext methodClass = context methodClass
+	^ (self isInSelectedContextClass: context)
 		  ifTrue: [ self theme highlightTextColor ]
 		  ifFalse: [
-			  selectedContext method package = context method package
+			  (self isInSelectedContextPackage: context)
 				  ifTrue: [ self theme highlightTextColor alpha: 0.5 ]
 				  ifFalse: [ self theme textColor ] ]
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -91,6 +91,7 @@ Class {
 		'stackAndCodeContainer'
 	],
 	#classVars : [
+		'EnableStackColoring',
 		'ErrorRecursion',
 		'FastTDD'
 	],
@@ -145,9 +146,34 @@ StDebugger class >> debuggerContextClass [
 ]
 
 { #category : #accessing }
+StDebugger class >> debuggerSettingsOn: aBuilder [
+
+	<systemsettings>
+		(aBuilder setting: #enableStackColoring)
+				label: 'Enable stack coloring';
+				target: StDebugger;
+				parent: #debugging;
+				default: true;
+				description:
+					'If enable, the debugger will highlight the elements of the stacks that are from the same class and same package as the selected context.'.
+]
+
+{ #category : #accessing }
 StDebugger class >> defaultDebuggerRank [
 
 	^ 10
+]
+
+{ #category : #accessing }
+StDebugger class >> enableStackColoring [
+
+	^ EnableStackColoring
+]
+
+{ #category : #accessing }
+StDebugger class >> enableStackColoring: anObject [
+
+	EnableStackColoring := anObject
 ]
 
 { #category : #'tools registry' }
@@ -190,7 +216,8 @@ StDebugger class >> hasAnyActivatedExtension: extensionsClasses [
 { #category : #'class initialization' }
 StDebugger class >> initialize [ 
 	self flag: 'Error recursion is used only here?'.
-	ErrorRecursion := false
+	ErrorRecursion := false.
+	EnableStackColoring := true
 ]
 
 { #category : #opening }
@@ -1184,6 +1211,8 @@ StDebugger >> stackColorForContext: context [
 	If they are from the same class, we return a certain 'primary' highlight color.
 	If they are from the same package (but different class), we return a 'secondary' highlight color.
 	Else, we just keep the normal style."
+
+	self class enableStackColoring ifFalse: [ ^ self theme textColor ].
 
 	^ (self isInSelectedContextClass: context)
 		  ifTrue: [ self theme highlightTextColor ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1178,7 +1178,7 @@ StDebugger >> stackColorForContext: context [
 		  ifTrue: [ self theme highlightTextColor ]
 		  ifFalse: [
 			  (self isInSelectedContextPackage: context)
-				  ifTrue: [ self theme highlightTextColor alpha: 0.5 ]
+				  ifTrue: [ self theme highlightTextColor mixed: 0.5 with: self theme textColor ]
 				  ifFalse: [ self theme textColor ] ]
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -146,19 +146,6 @@ StDebugger class >> debuggerContextClass [
 ]
 
 { #category : #accessing }
-StDebugger class >> debuggerSettingsOn: aBuilder [
-
-	<systemsettings>
-		(aBuilder setting: #enableStackColoring)
-				label: 'Enable stack coloring';
-				target: StDebugger;
-				parent: #debugging;
-				default: true;
-				description:
-					'If enable, the debugger will highlight the elements of the stacks that are from the same class and same package as the selected context.'.
-]
-
-{ #category : #accessing }
 StDebugger class >> defaultDebuggerRank [
 
 	^ 10
@@ -244,6 +231,19 @@ StDebugger class >> sessionClass [
 StDebugger class >> spanNewSessionFrom: anotherSession [
 	self flag: 'Where is that used? 2019-06-28'.
 	^ anotherSession spanNewSession
+]
+
+{ #category : #settings }
+StDebugger class >> stackColoringSettingOn: aBuilder [
+
+	<systemsettings>
+		(aBuilder setting: #enableStackColoring)
+				label: 'Enable stack coloring';
+				target: self;
+				parent: #debugging;
+				default: true;
+				description:
+					'If enable, the debugger will highlight the elements of the stacks that are from the same class and same package as the selected context.'.
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR add some stack coloring to the debugger.

Now the stack has 3 different text colors:
- One when the context of a stack element is from the same class than the selected context
- One when the context of the stack element is from the same package than the selected context
- And the default text color otherwise

This is especially useful when debugging some pattern such as visitors or composites...

![image](https://github.com/pharo-spec/NewTools/assets/9519971/bc110500-1b0c-4e20-be2f-c82551974288)

![image](https://github.com/pharo-spec/NewTools/assets/9519971/0b5ee343-4dbe-4441-9e0f-29541b3a5480)

I wanted to add an info popup to describe the feature but I didn't find a way to display text in Spec, just strings.

THIS REQUIRES: https://github.com/pharo-project/pharo/pull/13693