### PR TITLE
Spotter has an empty line at the end, resulting in "#spotterPreview s…

### DIFF
--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -756,15 +756,14 @@ StSpotter >> setModelBeforeInitialization: aSpotterModel [
 { #category : #'private - actions' }
 StSpotter >> showPreview: aPresenter [
 
-	previewContainer removeAll.	
-	(aPresenter isNil or: [ aPresenter isHeader ]) 
-		ifTrue: [ ^ self ].
+	previewContainer removeAll.
+	(aPresenter isNil or: [ aPresenter isHeader ]) ifTrue: [ ^ self ].
 
-	aPresenter model value spotterPreview 
-		ifNotNil: [ :previewPresenter | 
-			previewContainer add: (previewPresenter 
-				owner: self; 
-				yourself) ]
+	aPresenter model value ifNotNil: [ :value |
+		value spotterPreview ifNotNil: [ :previewPresenter |
+			previewContainer add: (previewPresenter
+					 owner: self;
+					 yourself) ] ]
 ]
 
 { #category : #'private - actions' }


### PR DESCRIPTION
…ent to nil"

It might be better to remove that empty line, but this at least prevents the error.