### PR TITLE
Add source folder of Sindarin

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -187,6 +187,6 @@ BaselineOfNewTools >> sindarin: spec [
 	spec baseline: 'Sindarin' with: [ 
 		spec
 			repository: (self packageRepositoryURL 
-				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo12' ]);
+				ifEmpty: [ 'github://pharo-spec/ScriptableDebugger:Pharo12/src' ]);
 			loads: 'default' ]
 ]


### PR DESCRIPTION
In order to check if the error we get from the Pharo repository, let's try to add the "src" folder of sindarin to the URI