### PR TITLE
Revert "Change announcement api"

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -362,7 +362,6 @@ StDebugger >> connectPresenters [
 	self whenDisplayDo: [ 
 		self updateToolbar.
 		self updateCodeFromContext ]
-	for: self
 ]
 
 { #category : #'accessing - context' }

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -174,7 +174,7 @@ StSpotter class >> openWithText: aText [
 	spotter := self new.
 	spotter searchText
 		text: aText asString.
-	spotter whenDisplayDo: [ spotter searchText cursorPositionIndex: aText size + 1 ] for: self.
+	spotter whenDisplayDo: [ spotter searchText cursorPositionIndex: aText size + 1 ].
 	^ spotter openModal
 ]
 


### PR DESCRIPTION
Reverts pharo-spec/NewTools#502

This requires a change in Spec that is not yet integrated. I'll revert it so that Pharo can build