### PR TITLE
StDebuggerTestFailureContextPredicate #printDescription can use #tempNamed:

### DIFF
--- a/src/NewTools-Debugger/StDebuggerTestFailureContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerTestFailureContextPredicate.class.st
@@ -45,9 +45,7 @@ StDebuggerTestFailureContextPredicate >> printDescription [
 		^ str contents ].
 	(failure isClass and: [ failure includesBehavior: TestFailure ]) 
 		ifTrue: [ 
-			| variable |
-			variable := context temporaryVariableNamed: #aStringOrBlock.
-			str << (variable readInContext: context) value.
+			str << (context tempNamed: #aStringOrBlock) value.
 			^ str contents ].
 
 	str << 'Cannot print test failure in: '.


### PR DESCRIPTION
printDescription is looking up the var and then it reads it, we can use #tempNamed: to do that in one step