### PR TITLE
Small compiler API useage fix in StDebuggerActionModel

### DIFF
--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -322,7 +322,6 @@ StDebuggerActionModel >> returnValueFromExpression: aString fromContext: aContex
 	value := session class compiler
 		source: aString;
 		context: aContext;
-		receiver: aContext receiver;
 		evaluate.
 	self session returnValue: value from: aContext.
 	self updateTopContext


### PR DESCRIPTION
in StDebuggerActionModel>>#returnValueFromExpression:fromContext: wedo not need to set the context and the receiver