### PR TITLE
Fix-CleanBlocks-StInspectorSelfNode

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -132,7 +132,7 @@ StDebuggerContext >> receiverNodes [
 { #category : #nodes }
 StDebuggerContext >> selfNode [
 
-	^ StInspectorSelfNode hostObject: self context receiver
+	^ StInspectorSelfNode hostObject: (self context home ifNotNil: [:home | home receiver])
 ]
 
 { #category : #nodes }


### PR DESCRIPTION
make sure that the StInspectorSelfNode is created on the receiver of the home context, so it shows a nice self when inspecting a clean block.

(I guess another step could be to make StInspectorSelfNode wraper of a SelfVariable, similar to what it does for temps, but not sure if that is needed, the behavior with this fix is the same)