### PR TITLE
Use better protocol API

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -417,13 +417,13 @@ StDebuggerActionModelTest >> testImplementMethodClassification [
 				forContext: dnu signalerContext ].
 
 	method := StDebuggerUsingSpecSelectorMock lookupSelector: #method.
-	self assert: method protocol equals: 'accessing'.
+	self assert: method protocolName equals: 'accessing'.
 
 	method := StDebuggerUsingSpecSelectorMock lookupSelector: #testMethod.
-	self assert: method protocol equals: 'tests'.
+	self assert: method protocolName equals: 'tests'.
 
 	method := StDebuggerUsingSpecSelectorMock lookupSelector: #unclassifiedMethod.
-	self assert: method protocol equals: Protocol unclassified
+	self deny: method isClassified
 ]
 
 { #category : #tests }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -438,14 +438,11 @@ StDebugger >> createMissingMethod [
 
 { #category : #actions }
 StDebugger >> createMissingMethodFor: aMessage in: aClass [
+
 	| method |
 	self flag: #DBG_MISSINGTEST.
-	method := self debuggerActionModel
-		implement: aMessage
-		inClass: aClass
-		forContext: self interruptedContext.
-	method protocol = Protocol unclassified
-		ifTrue: [ method protocol: (self requestProtocolIn: aClass) ].
+	method := self debuggerActionModel implement: aMessage inClass: aClass forContext: self interruptedContext.
+	method isClassified ifFalse: [ method protocol: (self requestProtocolIn: aClass) ].
 
 	self selectTopContext
 ]

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -51,8 +51,7 @@ StDebuggerActionModel >> autoClassifyMessage: aMessage inClass: aClass [
 
 	| method |
 	method := aClass lookupSelector: aMessage selector.
-	method protocol = Protocol unclassified ifTrue: [ 
-		MethodClassifier classify: method ]
+	method isClassified ifFalse: [ MethodClassifier classify: method ]
 ]
 
 { #category : #'debug - execution' }


### PR DESCRIPTION
CompiledMethod>>#protocol behavior will change and a more explicit API has been added in Pharo to replace the current users that cannot deal with a real protocol. This comit updates the API to the new one using #protocolName or #isClassified