### PR TITLE
Make initial extent of StSpotter and StInspector take the display scale factor into account

### DIFF
--- a/src/NewTools-Inspector/StInspector.class.st
+++ b/src/NewTools-Inspector/StInspector.class.st
@@ -47,7 +47,7 @@ StInspector class >> defaultLayout [
 { #category : #accessing }
 StInspector class >> defaultPreferredExtent [
 
-	^ 700@500
+	^ (700@500) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -454,8 +454,8 @@ StSpotter >> initialExtent [
 
 	self flag: #TODO. "Maybe calculate coordinates?"
 	^ self isShowingPreview 
-		ifTrue: [ 750@450 ]
-		ifFalse: [ 500@450 ]
+		ifTrue: [ (750@450) scaledByDisplayScaleFactor ]
+		ifFalse: [ (500@450) scaledByDisplayScaleFactor ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This pull request makes the initial extent of StSpotter and StInspector take the display scale factor into account.