### PR TITLE
Renamed method StInspectorTransmissionNode>>#transmissionBlock:

### DIFF
--- a/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
@@ -32,7 +32,7 @@ StInspectorTransmissionNode >> rawValue [
 ]
 
 { #category : #accessing }
-StInspectorTransmissionNode >> transmissionBlock: aBlock [
+StInspectorTransmissionNode >> transmits: aBlock [
 
 	transmissionBlock := aBlock
 ]

--- a/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
@@ -32,6 +32,15 @@ StInspectorTransmissionNode >> rawValue [
 ]
 
 { #category : #accessing }
+StInspectorTransmissionNode >> transmissionBlock: aBlock [
+
+	self
+		deprecated: 'please use transmits: method insted'
+		transformWith: '`@receiver transmissionBlock: `@arg1' -> '`@receiver transmits: `@arg1'.
+	self transmits: aBlock
+]
+
+{ #category : #accessing }
 StInspectorTransmissionNode >> transmits: aBlock [
 
 	transmissionBlock := aBlock


### PR DESCRIPTION
 Renamed method StInspectorTransmissionNode>>#transmissionBlock: to StInspectorTransmissionNode>>#transmits:

The method `transmits:` is a better name. The deprecated method has a transformation rule.