### PR TITLE
 Fixing opening of the Finder on the Spotter

### DIFF
--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -665,7 +665,7 @@ StSpotter >> openFinder [
 
 	self window close.
 	self flag: #TODO. "Move finder to spec (right now is a morph)"
-	Finder open
+	FinderUI open
 ]
 
 { #category : #private }


### PR DESCRIPTION
Calling FinderUI instead of Finder since the method Finder>>open was moved.  Now the correct way is to call FinderUI>>open.

Pair programming with @uNouss for the sprint