### PR TITLE
Do not register to ClassReorganized

### DIFF
--- a/src/NewTools-ChangeSorter/SpChangeSorterPresenter.class.st
+++ b/src/NewTools-ChangeSorter/SpChangeSorterPresenter.class.st
@@ -388,11 +388,9 @@ SpChangeSorterPresenter >> initialize [
 { #category : #initialization }
 SpChangeSorterPresenter >> initializeAnnouncements [
 
-	SystemAnnouncer uniqueInstance weak 
-		when:
-			ClassAdded , ClassCommented , ClassRecategorized , ClassModifiedClassDefinition , ClassRemoved , ClassRenamed
-				, ClassReorganized , MethodAdded , MethodModified , MethodRecategorized , MethodRemoved , ProtocolAdded
-				, ProtocolRemoved
+	SystemAnnouncer uniqueInstance weak
+		when: ClassAdded , ClassCommented , ClassRecategorized , ClassModifiedClassDefinition , ClassRemoved , ClassRenamed , MethodAdded , MethodModified
+			, MethodRecategorized , MethodRemoved , ProtocolAnnouncement
 		send: #updateClassesList
 		to: self
 ]


### PR DESCRIPTION
ClassReorganized is raised always with ProtocolAdded, ProtocolRemoved and ProtocolRenamed. It will soon be a deprecated alias of ProtocolAnnouncement in Pharo 12 so that we do not duplicate all protocol announcements and here is a PR to clean this in NewTools