### PR TITLE
Do not use `RPackage organizer`

### DIFF
--- a/src/NewTools-RewriterTools-Backend/StRewriterRenrakuApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterRenrakuApplier.class.st
@@ -13,7 +13,7 @@ Class {
 StRewriterRenrakuApplier class >> calculateAllChangesForRules: aRulesCollection [
 
 	| allSystemMethods |
-	allSystemMethods := (RPackage organizer packages flatCollect: [:each | each classes])
+	allSystemMethods := (self packageOrganizer packages flatCollect: [:each | each classes])
 		flatCollect: [ :each | each methods] as: Set.
 
 	^ self calculateChangesForClasses: allSystemMethods asSet transformationRules: aRulesCollection
@@ -66,6 +66,6 @@ Take a look on ReCriticEngine for some automation ideas. Also take a look at Com
 StRewriterRenrakuApplier class >> obtainCritiquesOfAllMethodsForRules: ruleHolderCollection [
 
 	| methods |
-	methods := (RPackage organizer packages flatCollect: #classes) flatCollect: #methods.
+	methods := (self packageOrganizer packages flatCollect: #classes) flatCollect: #methods.
 	^ self obtainCritiquesOf: methods forRules: ruleHolderCollection
 ]


### PR DESCRIPTION
This method emulates a dynamic global variable and is plan for deprecation. This PR provides an alternative way to access the organizer that does not contains the hacks of `RPackage organizer`.