### PR TITLE
Make #inspectionColors in UITheme take the display scale factor into account

### DIFF
--- a/src/NewTools-Inspector-Extensions/UITheme.extension.st
+++ b/src/NewTools-Inspector-Extensions/UITheme.extension.st
@@ -12,6 +12,6 @@ UITheme >> inspectionColors [
 		displayIcon: [ :each | 
 			Morph new 
 				color: (self perform: each);
-				asFormOfSize: 20@20 ];
+				asFormOfSize: (20@20) scaledByDisplayScaleFactor ];
 		yourself
 ]


### PR DESCRIPTION
This pull request makes #inspectionColors in UITheme take the display scale factor into account.