### PR TITLE
Make #defaultExtent and #preferredExtent in playground presenters take the display scale factor into account

### DIFF
--- a/src/NewTools-Playground/StPlaygroundBindingsPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundBindingsPresenter.class.st
@@ -19,7 +19,7 @@ Class {
 { #category : #accessing }
 StPlaygroundBindingsPresenter class >> defaultExtent [
 
-	^ 600@400
+	^ (600@400) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }

--- a/src/NewTools-Playground/StPlaygroundPageVersionsPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPageVersionsPresenter.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #accessing }
 StPlaygroundPageVersionsPresenter class >> preferredExtent [
 
-	^ 700@400
+	^ (700@400) scaledByDisplayScaleFactor
 ]
 
 { #category : #actions }

--- a/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
@@ -20,7 +20,7 @@ Class {
 { #category : #accessing }
 StPlaygroundPagesPresenter class >> defaultExtent [
 
-	^ 700@400
+	^ (700@400) scaledByDisplayScaleFactor
 ]
 
 { #category : #layout }

--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -74,7 +74,7 @@ StPlaygroundPresenter class >> defaultCacheDirectory [
 { #category : #accessing }
 StPlaygroundPresenter class >> defaultExtent [
 
-	^ 600@400
+	^ (600@400) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request make `#defaultExtent` and `#preferredExtent` in the playground presenters take the display scale factor into account.