### PR TITLE
Displaying '#' for symbols in the debugger inspector

### DIFF
--- a/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #AbstractFileReference }
+Extension { #name : 'AbstractFileReference' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionCompressedItems [
 	<inspectorPresentationOrder: 0 title: 'Compressed Items'>
 	| items children root |
@@ -38,13 +38,13 @@ AbstractFileReference >> inspectionCompressedItems [
 					each creationTime printHMSOn: stream ] ])
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionCompressedItemsContext: aContext [ 
 	
 	aContext active: self isCompressedFile
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionContents [
 	<inspectorPresentationOrder: 0 title: 'Contents'> 
 	| maxBytes buffer atEnd stringContents displayStream displayString |
@@ -74,19 +74,19 @@ AbstractFileReference >> inspectionContents [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionContentsContext: aContext [ 
 	
 	aContext active: self isFile
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionFuelContext: aContext [ 
 	
 	aContext active: self isFuel
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionGif [
 	<inspectorPresentationOrder: 0 title: 'Picture'>
 	
@@ -95,13 +95,13 @@ AbstractFileReference >> inspectionGif [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionGifContext: aContext [ 
 	
 	aContext active: self isImageGif
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionItems [
 	<inspectorPresentationOrder: 0 title: 'Items'>
 	| items |
@@ -145,13 +145,13 @@ AbstractFileReference >> inspectionItems [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionItemsContext: aContext [ 
 	
 	aContext active: self isDirectory
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionJpeg [
 	<inspectorPresentationOrder: 0 title: 'Picture'>
 	
@@ -160,13 +160,13 @@ AbstractFileReference >> inspectionJpeg [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionJpegContext: aContext [
 	
 	aContext active: self isImageJpeg
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionPng [
 	<inspectorPresentationOrder: 0 title: 'Picture'>
 	
@@ -175,13 +175,13 @@ AbstractFileReference >> inspectionPng [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionPngContext: aContext [ 
 	
 	aContext active: self isImagePng
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionStScript [
 	<inspectorPresentationOrder: 0 title: 'Script'>
 	
@@ -192,25 +192,25 @@ AbstractFileReference >> inspectionStScript [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionStScriptContext: aContext [ 
 	
 	aContext active: self isScript
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isCompressedFile [
 
 	^ #('zip' 'jar' 'ear' 'war' 'mcz') includes: self extension
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isFuel [
 
 	^ self isFile and: [ self extension = 'fuel' ]
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isImageGif [
 
 	^ self isFile 
@@ -218,7 +218,7 @@ AbstractFileReference >> isImageGif [
 		and: [ self mimeTypes first matches: ZnMimeType imageGif ] ]
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isImageJpeg [
 
 	^ self isFile 
@@ -226,7 +226,7 @@ AbstractFileReference >> isImageJpeg [
 		and: [ self mimeTypes first matches: ZnMimeType imageJpeg ] ]
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isImagePng [
 
 	^ self isFile 
@@ -234,7 +234,7 @@ AbstractFileReference >> isImagePng [
 		and: [ self mimeTypes first matches: ZnMimeType imagePng ] ]
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> isScript [
 	
 	^ self isFile and: [ self extension = 'st' ]

--- a/src/NewTools-Inspector-Extensions/Announcer.extension.st
+++ b/src/NewTools-Inspector-Extensions/Announcer.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #Announcer }
+Extension { #name : 'Announcer' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Announcer >> hasSubscriptions [
 	
 	^ self numberOfSubscriptions isZero not
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Announcer >> inspectionSubscriptions [
 	<inspectorPresentationOrder: 0 title: 'Subscriptions'>
 	| table |
@@ -38,7 +38,7 @@ Announcer >> inspectionSubscriptions [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Announcer >> inspectionSubscriptionsContext: aContext [ 
 	
 	aContext active: self hasSubscriptions

--- a/src/NewTools-Inspector-Extensions/Array.extension.st
+++ b/src/NewTools-Inspector-Extensions/Array.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Array }
+Extension { #name : 'Array' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Array >> displayString [
 
 	^ super displayString contractTo: 200

--- a/src/NewTools-Inspector-Extensions/Array2D.extension.st
+++ b/src/NewTools-Inspector-Extensions/Array2D.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Array2D }
+Extension { #name : 'Array2D' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Array2D >> inspectorExtension [
 
 	<inspectorPresentationOrder: 0 title: 'Matrix'>

--- a/src/NewTools-Inspector-Extensions/Bag.extension.st
+++ b/src/NewTools-Inspector-Extensions/Bag.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Bag }
+Extension { #name : 'Bag' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Bag >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 

--- a/src/NewTools-Inspector-Extensions/BaselineOf.extension.st
+++ b/src/NewTools-Inspector-Extensions/BaselineOf.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BaselineOf }
+Extension { #name : 'BaselineOf' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 BaselineOf >> inspectionProject [
 	<inspectorPresentationOrder: 10 title: 'Project'>
 	| specs |
@@ -18,7 +18,7 @@ BaselineOf >> inspectionProject [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 BaselineOf >> inspectionRecord [
 	<inspectorPresentationOrder: 20 title: 'Record'>
 	| specs |

--- a/src/NewTools-Inspector-Extensions/BlockClosure.extension.st
+++ b/src/NewTools-Inspector-Extensions/BlockClosure.extension.st
@@ -1,20 +1,20 @@
-Extension { #name : #BlockClosure }
+Extension { #name : 'BlockClosure' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 BlockClosure >> inpectionIr [
 	<inspectorPresentationOrder: 35 title: 'IR'>
 
 	^ self method ir inpectionIr
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 BlockClosure >> inspectionAST [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 
 	^ self sourceNode inspectionAST
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 BlockClosure >> inspectionSource [
 	<inspectorPresentationOrder: 30 title: 'Method Source'>
 

--- a/src/NewTools-Inspector-Extensions/ByteArray.extension.st
+++ b/src/NewTools-Inspector-Extensions/ByteArray.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ByteArray }
+Extension { #name : 'ByteArray' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ByteArray >> inspectBytes: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Bytes'>
 

--- a/src/NewTools-Inspector-Extensions/Character.extension.st
+++ b/src/NewTools-Inspector-Extensions/Character.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Character }
+Extension { #name : 'Character' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Character >> inspectCharacterIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Character'>
 	

--- a/src/NewTools-Inspector-Extensions/Class.extension.st
+++ b/src/NewTools-Inspector-Extensions/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Class >> inspectionAllReferences [
 	<inspectorPresentationOrder: 920 title: 'All References'>
 	| allReferences allClassesReferencing sortBlock treeTable childrenBlock |
@@ -26,7 +26,7 @@ Class >> inspectionAllReferences [
 	^ treeTable
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Class >> inspectionClassComment [
 	"This provides an editable comment of the current class"
 	<inspectorPresentationOrder: 920 title: 'Comment'>
@@ -39,7 +39,7 @@ Class >> inspectionClassComment [
 				stamp: Author changeStamp ]
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Class >> inspectionClassDefinition [
 
 	"This provides an editable comment of the current class"

--- a/src/NewTools-Inspector-Extensions/Collection.extension.st
+++ b/src/NewTools-Inspector-Extensions/Collection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Collection }
+Extension { #name : 'Collection' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Collection >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	

--- a/src/NewTools-Inspector-Extensions/Color.extension.st
+++ b/src/NewTools-Inspector-Extensions/Color.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Color }
+Extension { #name : 'Color' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Color >> inspectionColor [
 	<inspectorPresentationOrder: 10 title: 'Color'>
 	
@@ -11,7 +11,7 @@ Color >> inspectionColor [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Color class >> inspectionColors [
 	<inspectorPresentationOrder: 10 title: 'Registered'>
 	

--- a/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledBlock.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledBlock }
+Extension { #name : 'CompiledBlock' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledBlock >> inspectionSource [
 	<inspectorPresentationOrder: 20 title: 'Method Source'>
 	

--- a/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledCode.extension.st
@@ -1,26 +1,26 @@
-Extension { #name : #CompiledCode }
+Extension { #name : 'CompiledCode' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> hasPragmas [
 
 	^ self pragmas notEmpty
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inpectionIr [
 	<inspectorPresentationOrder: 35 title: 'IR'>
 
 	^ self ir inpectionIr
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionAST [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 
 	^ self sourceNode inspectionAST
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionBytecode [
 	<inspectorPresentationOrder: 30 title: 'Bytecode'>
 
@@ -31,7 +31,7 @@ CompiledCode >> inspectionBytecode [
 
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionHeader [
 	<inspectorPresentationOrder: 40 title: 'Header'> 
 	
@@ -40,14 +40,14 @@ CompiledCode >> inspectionHeader [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectionItemsContext: aContext [
 
 	"Disable items view on compiled code"
 	aContext active: false
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledCode >> inspectorNodes [
 	"Answer a list of attributes as nodes"
 	| nodes |

--- a/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledMethod >> inspectionPragmas [
 	<inspectorPresentationOrder: 50 title: 'Pragmas'> 
 
@@ -10,13 +10,13 @@ CompiledMethod >> inspectionPragmas [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledMethod >> inspectionPragmasContext: aContext [ 
 	
 	aContext active: self hasPragmas
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 CompiledMethod >> inspectionSource [
 	<inspectorPresentationOrder: 20 title: 'Method Source'>
 	

--- a/src/NewTools-Inspector-Extensions/Context.extension.st
+++ b/src/NewTools-Inspector-Extensions/Context.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Context }
+Extension { #name : 'Context' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Context >> inspectionSource [
 	<inspectorPresentationOrder: 910 title: 'Method Source'>
 

--- a/src/NewTools-Inspector-Extensions/Date.extension.st
+++ b/src/NewTools-Inspector-Extensions/Date.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Date }
+Extension { #name : 'Date' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Date >> inspectDateIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Details'>
 	

--- a/src/NewTools-Inspector-Extensions/DateAndTime.extension.st
+++ b/src/NewTools-Inspector-Extensions/DateAndTime.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DateAndTime }
+Extension { #name : 'DateAndTime' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 DateAndTime >> inspectDateAndTimeIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Details'>
 	

--- a/src/NewTools-Inspector-Extensions/Dictionary.extension.st
+++ b/src/NewTools-Inspector-Extensions/Dictionary.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Dictionary }
+Extension { #name : 'Dictionary' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Dictionary >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	

--- a/src/NewTools-Inspector-Extensions/Duration.extension.st
+++ b/src/NewTools-Inspector-Extensions/Duration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Duration }
+Extension { #name : 'Duration' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Duration >> inspectDurationIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Details'>
 	

--- a/src/NewTools-Inspector-Extensions/Float.extension.st
+++ b/src/NewTools-Inspector-Extensions/Float.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Float }
+Extension { #name : 'Float' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Float >> inspectFloatIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Float'>
 	

--- a/src/NewTools-Inspector-Extensions/Form.extension.st
+++ b/src/NewTools-Inspector-Extensions/Form.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Form }
+Extension { #name : 'Form' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Form >> inspectionForm [
 	<inspectorPresentationOrder: 0 title: 'Form'>
 	

--- a/src/NewTools-Inspector-Extensions/IRMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/IRMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #IRMethod }
+Extension { #name : 'IRMethod' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 IRMethod >> inpectionIr [
 	<inspectorPresentationOrder: 40 title: 'Symbolic'>
 

--- a/src/NewTools-Inspector-Extensions/Integer.extension.st
+++ b/src/NewTools-Inspector-Extensions/Integer.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Integer }
+Extension { #name : 'Integer' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Integer >> inspectIntegerIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Integer'> 
 	

--- a/src/NewTools-Inspector-Extensions/ManifestNewToolsInspectorExtensions.class.st
+++ b/src/NewTools-Inspector-Extensions/ManifestNewToolsInspectorExtensions.class.st
@@ -2,7 +2,9 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestNewToolsInspectorExtensions,
-	#superclass : #PackageManifest,
-	#category : #'NewTools-Inspector-Extensions-Manifest'
+	#name : 'ManifestNewToolsInspectorExtensions',
+	#superclass : 'PackageManifest',
+	#category : 'NewTools-Inspector-Extensions-Manifest',
+	#package : 'NewTools-Inspector-Extensions',
+	#tag : 'Manifest'
 }

--- a/src/NewTools-Inspector-Extensions/MetaLink.extension.st
+++ b/src/NewTools-Inspector-Extensions/MetaLink.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MetaLink }
+Extension { #name : 'MetaLink' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetaLink >> inpectionDefiniton [
 	<inspectorPresentationOrder: 920 title: 'Definition'>
 	^ SpTextPresenter new 

--- a/src/NewTools-Inspector-Extensions/MetacelloGroupSpec.extension.st
+++ b/src/NewTools-Inspector-Extensions/MetacelloGroupSpec.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MetacelloGroupSpec }
+Extension { #name : 'MetacelloGroupSpec' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloGroupSpec >> inspectionIncludes [
 	<inspectorPresentationOrder: 10 title: 'Include'>
 	| specs |
@@ -21,7 +21,7 @@ MetacelloGroupSpec >> inspectionIncludes [
 
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloGroupSpec >> type [
 
 	^ 'group'

--- a/src/NewTools-Inspector-Extensions/MetacelloPackageSpec.extension.st
+++ b/src/NewTools-Inspector-Extensions/MetacelloPackageSpec.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MetacelloPackageSpec }
+Extension { #name : 'MetacelloPackageSpec' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloPackageSpec >> inspectionRequires [
 	<inspectorPresentationOrder: 10 title: 'Require'>
 	| specs |
@@ -12,13 +12,13 @@ MetacelloPackageSpec >> inspectionRequires [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloPackageSpec >> inspectionRequiresContext: aContext [
 		
 	aContext active: self requires isNotEmpty
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloPackageSpec >> type [
 
 	^ 'package'

--- a/src/NewTools-Inspector-Extensions/MetacelloProjectReferenceSpec.extension.st
+++ b/src/NewTools-Inspector-Extensions/MetacelloProjectReferenceSpec.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MetacelloProjectReferenceSpec }
+Extension { #name : 'MetacelloProjectReferenceSpec' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloProjectReferenceSpec >> inspectionProject [
 	<inspectorPresentationOrder: 10 title: 'Project'>
 	| specs loadedSpecs |
@@ -23,7 +23,7 @@ MetacelloProjectReferenceSpec >> inspectionProject [
 	
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloProjectReferenceSpec >> inspectionRecord [
 	<inspectorPresentationOrder: 20 title: 'Record'>
 	| specs |
@@ -42,7 +42,7 @@ MetacelloProjectReferenceSpec >> inspectionRecord [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 MetacelloProjectReferenceSpec >> type [
 
 	^ 'project'

--- a/src/NewTools-Inspector-Extensions/Object.extension.st
+++ b/src/NewTools-Inspector-Extensions/Object.extension.st
@@ -1,44 +1,44 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> asInspectorModel [
 
 	^ StInspectorModel on: self
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> defaultObjectInspectorClass [
 
 	^ StObjectInspectorPresenter
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> inspectionMeta [
 	<inspectorPresentationOrder: 999 title: 'Meta'>
 
 	^ StMetaBrowserPresenter on: self
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> inspectionMetaContext: aContext [
 
 	aContext withoutEvaluator
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> inspectorNodes [
 	"Answer a list of attributes as nodes"
 	
 	^ (StNodeCollector for: self) collectNodes
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> stDisplayString [
 
 	^ StObjectPrinter asTruncatedTextFrom: self
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Object >> stDisplayStringFull [
 
 	^ StObjectPrinter asNonTruncatedTextFrom: self

--- a/src/NewTools-Inspector-Extensions/OrderedDictionary.extension.st
+++ b/src/NewTools-Inspector-Extensions/OrderedDictionary.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #OrderedDictionary }
+Extension { #name : 'OrderedDictionary' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 OrderedDictionary >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	

--- a/src/NewTools-Inspector-Extensions/Pragma.extension.st
+++ b/src/NewTools-Inspector-Extensions/Pragma.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Pragma }
+Extension { #name : 'Pragma' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Pragma >> inspectionSourceCodeMethod [
 	<inspectorPresentationOrder: 30 title: 'Method'>
 

--- a/src/NewTools-Inspector-Extensions/ProtoObject.extension.st
+++ b/src/NewTools-Inspector-Extensions/ProtoObject.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ProtoObject }
+Extension { #name : 'ProtoObject' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> allInspectorNodes [
 	"Answer a list of attributes as nodes"
 
@@ -8,7 +8,7 @@ ProtoObject >> allInspectorNodes [
 		self inspectorNodes
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectionContexts [
 	"This is a utility method that collects all presentations for the current object.
 	By default, it simply looks for the #inspectorPresentationOrder:title: pragma.
@@ -18,7 +18,7 @@ ProtoObject >> inspectionContexts [
 	^ (StInspectionCollector on: self) collectInspectionContexts
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectionRaw [
 	"This is the most basic presentation showing the state of the object"
 	<inspectorPresentationOrder: 900 title: 'Raw'>
@@ -26,20 +26,20 @@ ProtoObject >> inspectionRaw [
 	^ StRawInspectionPresenter on: self
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectorIconName [
 
 	^ nil
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectorNodes [ 
 	"Answer a list of attributes as nodes"
 
 	^ (StNodeCollector for: self) slotNodes
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectorPerform: aSymbol [
 	"This method is required by the inspector infrastructure (in order to inspect properly 
 	 ProtoObject and its direct decendants). 
@@ -49,7 +49,7 @@ ProtoObject >> inspectorPerform: aSymbol [
 	^ self primitiveFailed
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ProtoObject >> inspectorPerform: aSymbol with: anObject [
 	"This method is required by the inspector infrastructure (in order to inspect properly 
 	 ProtoObject and its direct decendants). 

--- a/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/RBProgramNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RBProgramNode }
+Extension { #name : 'RBProgramNode' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 RBProgramNode >> inspectionAST [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 
@@ -19,7 +19,7 @@ RBProgramNode >> inspectionAST [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 RBProgramNode >> inspectionASTDump [
 	<inspectorPresentationOrder: 50 title: 'AST Dump'>
 
@@ -29,7 +29,7 @@ RBProgramNode >> inspectionASTDump [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 RBProgramNode >> inspectionSource [
 	<inspectorPresentationOrder: 30 title: 'Method Source'>
 

--- a/src/NewTools-Inspector-Extensions/RPackage.extension.st
+++ b/src/NewTools-Inspector-Extensions/RPackage.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RPackage }
+Extension { #name : 'RPackage' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 RPackage >> baselineInspector [
 
 	<inspectorPresentationOrder: 2 title: 'Belongs to Baselines'>
@@ -11,7 +11,7 @@ RPackage >> baselineInspector [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 RPackage >> overwiew [
 
 	<inspectorPresentationOrder: 1 title: 'Overwiew'>

--- a/src/NewTools-Inspector-Extensions/SmallDictionary.extension.st
+++ b/src/NewTools-Inspector-Extensions/SmallDictionary.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SmallDictionary }
+Extension { #name : 'SmallDictionary' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 SmallDictionary >> inspectionItems: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 	

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 String >> inspectionEncoding: specBuilder [
 	<inspectorPresentationOrder: 200 title: 'Encoding'>
 	
@@ -12,7 +12,7 @@ String >> inspectionEncoding: specBuilder [
 			table
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 String >> inspectionFullString [
 	<inspectorPresentationOrder: 100 title: 'Full Content'>
 	^ SpCodePresenter new
@@ -21,7 +21,7 @@ String >> inspectionFullString [
 		yourself
 ]
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 String >> inspectionString [
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	

--- a/src/NewTools-Inspector-Extensions/SubscriptionRegistry.extension.st
+++ b/src/NewTools-Inspector-Extensions/SubscriptionRegistry.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SubscriptionRegistry }
+Extension { #name : 'SubscriptionRegistry' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 SubscriptionRegistry >> inspectionSubscriptions [
 	<inspectorPresentationOrder: 0 title: 'Subscriptions'>
 

--- a/src/NewTools-Inspector-Extensions/Symbol.extension.st
+++ b/src/NewTools-Inspector-Extensions/Symbol.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'Symbol' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+Symbol >> stDisplayString [
+
+	^ '#{1}' format: { super stDisplayString }
+]

--- a/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
+++ b/src/NewTools-Inspector-Extensions/SymbolicBytecode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SymbolicBytecode }
+Extension { #name : 'SymbolicBytecode' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 SymbolicBytecode >> inspectionSource [
 	<inspectorPresentationOrder: 30 title: 'Method Source'>
 

--- a/src/NewTools-Inspector-Extensions/Text.extension.st
+++ b/src/NewTools-Inspector-Extensions/Text.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Text }
+Extension { #name : 'Text' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Text >> inspectionText [
 	<inspectorPresentationOrder: 0 title: 'Text'>
 

--- a/src/NewTools-Inspector-Extensions/ThemeIcons.extension.st
+++ b/src/NewTools-Inspector-Extensions/ThemeIcons.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ThemeIcons }
+Extension { #name : 'ThemeIcons' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 ThemeIcons >> inspectionIcons [
 	<inspectorPresentationOrder: 0 title: 'Icons'>
 	

--- a/src/NewTools-Inspector-Extensions/Time.extension.st
+++ b/src/NewTools-Inspector-Extensions/Time.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Time }
+Extension { #name : 'Time' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Time >> inspectTimeIn: specBuilder [
 	<inspectorPresentationOrder: 30 title: 'Details'>
 	

--- a/src/NewTools-Inspector-Extensions/UITheme.extension.st
+++ b/src/NewTools-Inspector-Extensions/UITheme.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #UITheme }
+Extension { #name : 'UITheme' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 UITheme >> inspectionColors [
 	<inspectorPresentationOrder: 10 title: 'Colors'>
 	

--- a/src/NewTools-Inspector-Extensions/Variable.extension.st
+++ b/src/NewTools-Inspector-Extensions/Variable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Variable }
+Extension { #name : 'Variable' }
 
-{ #category : #'*NewTools-Inspector-Extensions' }
+{ #category : '*NewTools-Inspector-Extensions' }
 Variable >> inspectionUsingMethods [
 	<inspectorPresentationOrder: 920 title: 'Using Methods'>
 	

--- a/src/NewTools-Inspector-Extensions/package.st
+++ b/src/NewTools-Inspector-Extensions/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'NewTools-Inspector-Extensions' }
+Package { #name : 'NewTools-Inspector-Extensions' }


### PR DESCRIPTION
The debugger inspector uses the method `Object>>#stDisplayString` to display objects in the tree view of the debugger.

```Smalltalk
Object>>#stDisplayString

	^ StObjectPrinter asTruncatedTextFrom: self
```

which truncates the string description to 100 characters. This is done by calling the method:

```Smalltalk
Object>>#displayStringLimitedTo: limit
	"Answer a String whose characters are a description of the receiver.
	If you want to print without a character limit, use fullDisplayString."

	^ self printStringLimitedTo: limit using: [:s | self displayStringOn: s]
```

which doesn't print `#` for symbols.

I just override `#stDisplayString` in the class `Symbol` to display the character `#`