### PR TITLE
fix #testStackTablePackagesLabels: use correct DoIt selector

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -1007,7 +1007,7 @@ StDebuggerTest >> testStackTablePackagesLabels [
 	ctx := Context
 		sender: nil
 		receiver: nil
-		method: (Smalltalk compiler compile: 'doIt 1 + 1')
+		method: (Smalltalk compiler compile: 'DoIt 1 + 1')
 		arguments: #().
 	self assert: (packageColumn readObject: ctx) equals: '-'
 	


### PR DESCRIPTION
testStackTablePackagesLabels uses the wrong selector for the DoIt (thus #isDoIt would return false)