### PR TITLE
Scrolling to selection when selecting path to the receiver class in the meta browser (Fix for the meta browser in the inspector)

### DIFF
--- a/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
+++ b/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
@@ -70,35 +70,41 @@ StMetaBrowserPresenter >> compile: aString [
 
 { #category : 'initialization' }
 StMetaBrowserPresenter >> initializePresenters [
+
 	| classHierarchy |
-	
 	classHierarchy := self model class withAllSuperclasses reversed.
 
 	classes := self newTreeTable
-		addColumn: (SpStringTableColumn title: 'Class hierarchy' evaluated: #name);
-		roots: { classHierarchy first };
-		children: [ :aClass | classHierarchy select: [ :subclass | subclass superclass == aClass ] ];
-		contextMenu: [ self classListMenu ];
-		yourself.
+		           addColumn:
+			           (SpStringTableColumn
+				            title: 'Class hierarchy'
+				            evaluated: #name);
+		           roots: { classHierarchy first };
+		           children: [ :aClass |
+			           classHierarchy select: [ :subclass |
+					           subclass superclass == aClass ] ];
+		           contextMenu: [ self classListMenu ];
+		           yourself.
 	methods := (self instantiate: SpFilteringListPresenter)
-		display: [ :each | each selector ];	
-		contextMenu: [ self methodListMenu ];
-		yourself.
+		           display: [ :each | each selector ];
+		           contextMenu: [ self methodListMenu ];
+		           yourself.
 
 	source := self newCode
-		lineNumbers: StPharoSettings codeShowLineNumbers;
-		beForMethod: self selectedMethod;
-		whenSubmitDo: [ :aString | self compile: aString ];
-		whenResetDo: [ self updateSourceWith: self selectedMethod  ];
-		yourself.
-		
-	classes 
-		transmitTo: methods 
-		transform: [ :aClass | self methodsOf: aClass ].
-	methods 
-		transmitDo: [ :aMethod | self updateSourceWith: aMethod ].
+		          lineNumbers: StPharoSettings codeShowLineNumbers;
+		          beForMethod: self selectedMethod;
+		          whenSubmitDo: [ :aString | self compile: aString ];
+		          whenResetDo: [ self updateSourceWith: self selectedMethod ];
+		          yourself.
 
-	classes selectPath: (Array new: classHierarchy size withAll: 1)
+	classes
+		transmitTo: methods
+		transform: [ :aClass | self methodsOf: aClass ].
+	methods transmitDo: [ :aMethod | self updateSourceWith: aMethod ].
+
+	classes
+		selectPath: (Array new: classHierarchy size withAll: 1)
+		scrollToSelection: true
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/14863

In `StMetaBrowser`, at the initialization, it selects the path to the class of the selected object

```Smalltalk
StMetaBrowserPresenter>>#initializePresenters
  ...
  classes selectPath: (Array new: classHierarchy size withAll: 1)
```

However, if the meta browser is too small, it would result in not showing the receiver class (and not even showing a scrollbar to get to it). This is the case in the debugger inspector which is smaller than the normal inspector (but I guess it would appear in the normal inspector if you have class hierearchy with big depths):

![image](https://github.com/pharo-spec/NewTools/assets/97704417/943743fa-79bc-4804-bbe8-d8487a3a853c)

I fixed it so that it automatically scrolls to the receiver class because it is (generally) the class of interest:

```Smalltalk
StMetaBrowserPresenter>>#initializePresenters
  	classes
		selectPath: (Array new: classHierarchy size withAll: 1)
		scrollToSelection: true
```

And now the scrollbar appears correctly and everything is fine: even in the debugger inspector

![image](https://github.com/pharo-spec/NewTools/assets/97704417/bcf0e281-1799-4988-8d2b-7416d0c5a1e5)
