### PR TITLE
adding a command to the debugger stack toolbar, which opens a popover to quickly activate/unactivate debugger extensions

### DIFF
--- a/src/NewTools-Core/CmCommand.extension.st
+++ b/src/NewTools-Core/CmCommand.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #CmCommand }
+Extension { #name : 'CmCommand' }
 
-{ #category : #'*NewTools-Core' }
+{ #category : '*NewTools-Core' }
 CmCommand >> appliesTo: aTool [
 
 	^ true
 ]
 
-{ #category : #'*NewTools-Core' }
+{ #category : '*NewTools-Core' }
 CmCommand class >> commandClassesFromPragma: aSymbol [
 	"Collects command classes matching the pragma aSymbol. 
 	 WARNING: The collection will happen takign the caller class and subclasses. If you 
@@ -28,7 +28,7 @@ CmCommand class >> commandClassesFromPragma: aSymbol [
 		collect: [ :pragma | pragma methodClass soleInstance ]
 ]
 
-{ #category : #'*NewTools-Core' }
+{ #category : '*NewTools-Core' }
 CmCommand class >> instantiateCommands: commandClasses for: aTool [
 
 	^ commandClasses
@@ -36,7 +36,7 @@ CmCommand class >> instantiateCommands: commandClasses for: aTool [
 		thenSelect: [ :debugCommand | debugCommand decoratedCommand appliesTo: aTool ]
 ]
 
-{ #category : #'*NewTools-Core' }
+{ #category : '*NewTools-Core' }
 CmCommand class >> instantiateCommandsFromPragma: pragmaName for: aTool [
 
 	^ self 

--- a/src/NewTools-Core/SpPresenter.extension.st
+++ b/src/NewTools-Core/SpPresenter.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SpPresenter }
+Extension { #name : 'SpPresenter' }
 
-{ #category : #'*NewTools-Core' }
+{ #category : '*NewTools-Core' }
 SpPresenter >> addWindowShortcutsTo: aWindowPresenter [
 	"override this method to add window shortcuts defined in an inner presenter. 
 	 (for example, see *class:StHeaderPanel* who adds a shortcut to access the 

--- a/src/NewTools-Core/StCommand.class.st
+++ b/src/NewTools-Core/StCommand.class.st
@@ -6,30 +6,32 @@ I define common behavior that all commands can have:
 - maybe a shortcut
 "
 Class {
-	#name : #StCommand,
-	#superclass : #CmCommand,
-	#category : #'NewTools-Core-Command'
+	#name : 'StCommand',
+	#superclass : 'CmCommand',
+	#category : 'NewTools-Core-Command',
+	#package : 'NewTools-Core',
+	#tag : 'Command'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StCommand class >> defaultIconName [
 
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StCommand class >> defaultShortcut [
 
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StCommand >> application [
 
 	^ context application
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 StCommand >> asSpecCommand [ 
 	| command |
 	

--- a/src/NewTools-Core/StHeaderBar.class.st
+++ b/src/NewTools-Core/StHeaderBar.class.st
@@ -3,18 +3,20 @@ I am a generic header bar for tool component panels.
 I am used to add title, a toolbar and shortcut used to get to the panel.
 "
 Class {
-	#name : #StHeaderBar,
-	#superclass : #SpPresenter,
+	#name : 'StHeaderBar',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'titleLabel',
 		'toolbar',
 		'closeButton',
 		'shortcutLabel'
 	],
-	#category : #'NewTools-Core-Presenters'
+	#category : 'NewTools-Core-Presenters',
+	#package : 'NewTools-Core',
+	#tag : 'Presenters'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 StHeaderBar class >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
@@ -28,14 +30,14 @@ StHeaderBar class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderBar >> beCloseable [
 
 	self isCloseable ifTrue: [ ^ self ].
 	self enableCloseDoing: [  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderBar >> beNotCloseable [
 
 	closeButton ifNil: [ ^ self ].
@@ -44,7 +46,7 @@ StHeaderBar >> beNotCloseable [
 	closeButton := nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StHeaderBar >> enableCloseDoing: aBlock [
 
 	closeButton := self newButton
@@ -57,7 +59,7 @@ StHeaderBar >> enableCloseDoing: aBlock [
 	layout addLast: closeButton expand: false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StHeaderBar >> initializePresenters [
 
 	self layout: (SpBoxLayout newLeftToRight
@@ -76,37 +78,43 @@ StHeaderBar >> initializePresenters [
 	toolbar beIcons	"is a mini toolbar, items should be... tiny :)"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 StHeaderBar >> isCloseable [
 
 	^ closeButton notNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderBar >> label: aString [
 
 	titleLabel label: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderBar >> shortcut: aShortcut [ 
 
 	self shortcutLabel: (KMShortcutPrinter toString: aShortcut)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StHeaderBar >> shortcutLabel: aString [ 
 
 	shortcutLabel label: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
+StHeaderBar >> toolbar [
+
+	^ toolbar
+]
+
+{ #category : 'accessing' }
 StHeaderBar >> toolbarActions: aCommandGroup [
 
 	toolbar fillWith: aCommandGroup
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 StHeaderBar >> whenClosedDo: aBlock [
 
 	self isCloseable ifFalse: [ self enableCloseDoing: aBlock ].

--- a/src/NewTools-Core/StHeaderPanel.class.st
+++ b/src/NewTools-Core/StHeaderPanel.class.st
@@ -8,17 +8,19 @@ Through its property ==headerBar== (see *class:StHeaderBar*), it provides: a lab
 This presenter is used to homogenize the panels in tools.
 "
 Class {
-	#name : #StHeaderPanel,
-	#superclass : #SpPresenter,
+	#name : 'StHeaderPanel',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'headerBar',
 		'presenter',
 		'shortcut'
 	],
-	#category : #'NewTools-Core-Presenters'
+	#category : 'NewTools-Core-Presenters',
+	#package : 'NewTools-Core',
+	#tag : 'Presenters'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StHeaderPanel >> addWindowShortcutsTo: aWindowPresenter [
 
 	shortcut ifNil: [ ^ self ].
@@ -27,7 +29,7 @@ StHeaderPanel >> addWindowShortcutsTo: aWindowPresenter [
 		toAction: [ presenter takeKeyboardFocus ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StHeaderPanel >> initializePresenters [
 
 	headerBar := self instantiate: StHeaderBar.
@@ -37,19 +39,19 @@ StHeaderPanel >> initializePresenters [
 		yourself
 ]
 
-{ #category : #'accessing - header' }
+{ #category : 'accessing - header' }
 StHeaderPanel >> label: aString [
 
 	headerBar label: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderPanel >> number: aNumber [
 
 	self shortcut: (self shortcutForPanel: aNumber)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StHeaderPanel >> presenter: aPresenter [
 
 	presenter ifNotNil: [ layout remove: presenter ].
@@ -57,14 +59,14 @@ StHeaderPanel >> presenter: aPresenter [
 	layout add: presenter
 ]
 
-{ #category : #'accessing - header' }
+{ #category : 'accessing - header' }
 StHeaderPanel >> shortcut: aShortcut [
 
 	shortcut := aShortcut.
 	headerBar shortcut: aShortcut
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StHeaderPanel >> shortcutForPanel: aNumber [
 	"This is a convenience method to assign shortcuts to panels. 
 	 panels will be different areas of a tool: a package panel in a browser, an inspector in 
@@ -77,7 +79,7 @@ StHeaderPanel >> shortcutForPanel: aNumber [
 		| char control unix
 ]
 
-{ #category : #'accessing - header' }
+{ #category : 'accessing - header' }
 StHeaderPanel >> toolbarActions: aCommandGroup [
 
 	headerBar toolbarActions: aCommandGroup

--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -2,41 +2,43 @@
 The application for the Pharo IDE.
 "
 Class {
-	#name : #StPharoApplication,
-	#superclass : #SpApplication,
+	#name : 'StPharoApplication',
+	#superclass : 'SpApplication',
 	#classVars : [
 		'Current'
 	],
-	#category : #'NewTools-Core-Application'
+	#category : 'NewTools-Core-Application',
+	#package : 'NewTools-Core',
+	#tag : 'Application'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 StPharoApplication class >> current [ 
 	
 	^ Current ifNil: [ Current := self new ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 StPharoApplication class >> initialize [ 
 
 	SessionManager default registerToolClassNamed: self name
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 StPharoApplication class >> shutDown: quitting [
 
 	Current ifNil: [ ^ self ].
 	Current shutDown: quitting
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 StPharoApplication class >> startUp: resuming [
 
 	Current ifNil: [ ^ self ].
 	Current startUp: resuming
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StPharoApplication class >> use: application during: aBlock [ 
 	| oldCurrent |
 	
@@ -45,14 +47,14 @@ StPharoApplication class >> use: application during: aBlock [
 	^ aBlock ensure: [ Current := oldCurrent ]
 ]
 
-{ #category : #'accessing - resources' }
+{ #category : 'accessing - resources' }
 StPharoApplication >> defaultWindowExtent [
 	
 	self flag: #TODO. "Replace this with a real real estate"
 	^ 800@600
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPharoApplication >> initialize [
 
 	super initialize.
@@ -63,20 +65,20 @@ StPharoApplication >> initialize [
 		to: self
 ]
 
-{ #category : #'private - factory' }
+{ #category : 'private - factory' }
 StPharoApplication >> newIconProvider [
 
 	^ StPharoDefaultIconProvider new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPharoApplication >> resetConfiguration [
 	
 	self flag: #TODO. "Invalidating for a moment because I need to align with Spec"
 	self configuration reset
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StPharoApplication >> run [ 
 
 	Current ifNotNil: [ Current close ].
@@ -84,29 +86,29 @@ StPharoApplication >> run [
 	Current := self
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 StPharoApplication >> shutDown: quitting [
 ]
 
-{ #category : #'private - running' }
+{ #category : 'private - running' }
 StPharoApplication >> start [
 
 	
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 StPharoApplication >> startUp: resuming [
 
 	self resetConfiguration
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoApplication >> toolbarDisplayMode [
 
 	^ StPharoSettings toolbarDisplayMode
 ]
 
-{ #category : #'accessing - resources' }
+{ #category : 'accessing - resources' }
 StPharoApplication >> tools [
 
 	^ Smalltalk tools

--- a/src/NewTools-Core/StPharoDefaultIconProvider.class.st
+++ b/src/NewTools-Core/StPharoDefaultIconProvider.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #StPharoDefaultIconProvider,
-	#superclass : #SpPharoThemeIconProvider,
+	#name : 'StPharoDefaultIconProvider',
+	#superclass : 'SpPharoThemeIconProvider',
 	#instVars : [
 		'synonyms'
 	],
-	#category : #'NewTools-Core-Application'
+	#category : 'NewTools-Core-Application',
+	#package : 'NewTools-Core',
+	#tag : 'Application'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StPharoDefaultIconProvider >> iconNamed: aSymbol [
 
 	^ super iconNamed: (synonyms 
@@ -15,7 +17,7 @@ StPharoDefaultIconProvider >> iconNamed: aSymbol [
 		ifAbsent: [ aSymbol ])
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPharoDefaultIconProvider >> initialize [
 
 	super initialize. 
@@ -23,7 +25,7 @@ StPharoDefaultIconProvider >> initialize [
 	self initializeSynonyms
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPharoDefaultIconProvider >> initializeSynonyms [
 
 	synonyms 

--- a/src/NewTools-Core/StPharoSettings.class.st
+++ b/src/NewTools-Core/StPharoSettings.class.st
@@ -1,39 +1,41 @@
 Class {
-	#name : #StPharoSettings,
-	#superclass : #Object,
+	#name : 'StPharoSettings',
+	#superclass : 'Object',
 	#classVars : [
 		'CodeShowLineNumbers',
 		'ToolbarDisplayMode'
 	],
-	#category : #'NewTools-Core-Application'
+	#category : 'NewTools-Core-Application',
+	#package : 'NewTools-Core',
+	#tag : 'Application'
 }
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoSettings class >> codeShowLineNumbers [
 	"Defines if code editors will display line numbers"
 
 	^ CodeShowLineNumbers ifNil: [ CodeShowLineNumbers := self defaultCodeShowLineNumbers ]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoSettings class >> codeShowLineNumbers: aBoolean [ 
 
 	CodeShowLineNumbers := aBoolean
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 StPharoSettings class >> defaultCodeShowLineNumbers [
 
 	^ true
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 StPharoSettings class >> defaultToolbarDisplayMode [
 
 	^ SpToolbarDisplayMode modeIconAndLabel
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoSettings class >> settingsOn: aBuilder [
 	<systemsettings>
 
@@ -55,14 +57,14 @@ StPharoSettings class >> settingsOn: aBuilder [
 		label: 'Toolbar display mode'		
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoSettings class >> toolbarDisplayMode [
 	"Defines how the toolbar will be displayed (icons+text, icons, text)"
 
 	^ ToolbarDisplayMode ifNil: [ ToolbarDisplayMode := self defaultToolbarDisplayMode ]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 StPharoSettings class >> toolbarDisplayMode: aMode [
 	"self toolbarDisplayMode: SpToolbarDisplayMode modeIcon"
 	

--- a/src/NewTools-Core/StPresenter.class.st
+++ b/src/NewTools-Core/StPresenter.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #StPresenter,
-	#superclass : #SpPresenter,
-	#category : #'NewTools-Core-Presenters'
+	#name : 'StPresenter',
+	#superclass : 'SpPresenter',
+	#category : 'NewTools-Core-Presenters',
+	#package : 'NewTools-Core',
+	#tag : 'Presenters'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 StPresenter class >> currentApplication [
 
 	^ SpToolCurrentApplication value ifNil: [ StPharoApplication current ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 StPresenter class >> new [
 
 	^ self newApplication: self currentApplication
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 StPresenter class >> owner: anOwningPresenter [
 
 	^ self 
@@ -24,7 +26,7 @@ StPresenter class >> owner: anOwningPresenter [
 		owner: anOwningPresenter
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 StPresenter class >> owner: anOwningPresenter on: aDomainObject [
 
 	^ self 
@@ -33,13 +35,13 @@ StPresenter class >> owner: anOwningPresenter on: aDomainObject [
 		model: aDomainObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StPresenter class >> preferredExtent [
 
 	^ 600@400
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPresenter >> initializeWindow: aWindowPresenter [
 	"All tools should call its parent"
 
@@ -47,13 +49,13 @@ StPresenter >> initializeWindow: aWindowPresenter [
 		each addWindowShortcutsTo: aWindowPresenter ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StPresenter >> preferredExtent [
 
 	^ self class preferredExtent
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StPresenter >> shortcutForPanel: aNumber [
 	"This is a convenience method to assign shortcuts to panels. 
 	 panels will be different areas of a tool: a package panel in a browser, an inspector in 

--- a/src/NewTools-Core/package.st
+++ b/src/NewTools-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'NewTools-Core' }
+Package { #name : 'NewTools-Core' }

--- a/src/NewTools-Debugger-Commands/StDebuggerExtensionSettingsCommand.class.st
+++ b/src/NewTools-Debugger-Commands/StDebuggerExtensionSettingsCommand.class.st
@@ -1,0 +1,45 @@
+"
+I open a table to activate or unactivate debugger extensions
+"
+Class {
+	#name : 'StDebuggerExtensionSettingsCommand',
+	#superclass : 'StDebuggerCommand',
+	#category : 'NewTools-Debugger-Commands',
+	#package : 'NewTools-Debugger-Commands'
+}
+
+{ #category : 'default' }
+StDebuggerExtensionSettingsCommand class >> defaultDescription [
+
+	^ 'I open a table in a popover that allows to activate or unactivate any debugger extension'
+]
+
+{ #category : 'initialization' }
+StDebuggerExtensionSettingsCommand class >> defaultIconName [
+
+	^ #config
+]
+
+{ #category : 'default' }
+StDebuggerExtensionSettingsCommand class >> defaultName [
+
+	^ 'Extension settings'
+]
+
+{ #category : 'initialization' }
+StDebuggerExtensionSettingsCommand class >> defaultShortcut [
+
+	^ nil
+]
+
+{ #category : 'executing' }
+StDebuggerExtensionSettingsCommand >> execute [
+
+	| settings |
+	settings := StDebuggerExtensionSettingsPresenter new.
+	self context newPopover
+		bePositionLeft;
+		presenter: settings;
+		relativeTo: self context stackHeader toolbar;
+		popup
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerConfigurationCommandTreeBuilderTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerConfigurationCommandTreeBuilderTest.class.st
@@ -27,6 +27,7 @@ StDebuggerConfigurationCommandTreeBuilderTest >> testConfigurationCommands [
 StDebuggerConfigurationCommandTreeBuilderTest >> testConfigurationCommandsClasses [
 
 	self assertCollection: builder configurationCommandClasses equals: {
+			StDebuggerExtensionSettingsCommand.
 			StDebuggerToggleFilterStackCommand.
 			StDebuggerSettingsCommand }
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -266,7 +266,6 @@ StDebugger class >> usesExtensions [
 	^ self hasAnyActivatedExtension: self extensionToolsClasses
 ]
 
-
 { #category : 'code pane' }
 StDebugger >> acceptCodeChanges: newSource forContext: aContext [
 
@@ -354,7 +353,6 @@ StDebugger >> clear [
 	self clearDebugSession
 ]
 
-
 { #category : 'code pane' }
 StDebugger >> clearCode [
 	
@@ -364,7 +362,6 @@ StDebugger >> clearCode [
 		clearContent
 ]
 
-
 { #category : 'actions' }
 StDebugger >> clearDebugSession [
 
@@ -372,13 +369,11 @@ StDebugger >> clearDebugSession [
 		debugActionModel clearDebugSession ]
 ]
 
-
 { #category : 'actions' }
 StDebugger >> clearDebuggerActionModel [
 	
 	self debuggerActionModel ifNotNil: [ :debugActionModel | debugActionModel clear ]
 ]
-
 
 { #category : 'code pane' }
 StDebugger >> clearUnsavedCodeChanges [
@@ -394,7 +389,6 @@ StDebugger >> close [
 		debuggerActionModel ifNotNil: [ :actionModel |
 			actionModel clearDebugSession ] ]
 ]
-
 
 { #category : 'accessing - presenters' }
 StDebugger >> code [
@@ -1204,6 +1198,12 @@ StDebugger >> stackColorForContext: context [
 					  mixed: 0.5
 					  with: self theme textColor ]
 				  ifFalse: [ self theme textColor ] ]
+]
+
+{ #category : 'accessing - presenters' }
+StDebugger >> stackHeader [
+
+	^ stackHeader
 ]
 
 { #category : 'stack' }

--- a/src/NewTools-Debugger/StDebuggerConfigurationCommandTreeBuilder.class.st
+++ b/src/NewTools-Debugger/StDebuggerConfigurationCommandTreeBuilder.class.st
@@ -42,6 +42,7 @@ StDebuggerConfigurationCommandTreeBuilder >> buildDebuggerCommandGroup [
 StDebuggerConfigurationCommandTreeBuilder >> configurationCommandClasses [
 
 	^ {
+		  StDebuggerExtensionSettingsCommand.
 		  StDebuggerToggleFilterStackCommand.
 		  StDebuggerSettingsCommand }
 ]

--- a/src/NewTools-Debugger/StDebuggerExtensionSettingsPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionSettingsPresenter.class.st
@@ -1,0 +1,92 @@
+"
+I am a presenter that provides a table to activate or unactivate debugger extensions
+"
+Class {
+	#name : 'StDebuggerExtensionSettingsPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'debuggerExtensionClasses',
+		'extensionClassesTable',
+		'toolbar'
+	],
+	#category : 'NewTools-Debugger-View',
+	#package : 'NewTools-Debugger',
+	#tag : 'View'
+}
+
+{ #category : 'accessing' }
+StDebuggerExtensionSettingsPresenter class >> debuggerClass [
+
+	^ StDebugger
+]
+
+{ #category : 'accessing' }
+StDebuggerExtensionSettingsPresenter >> debuggerClass [
+
+	^ self class debuggerClass
+]
+
+{ #category : 'layout' }
+StDebuggerExtensionSettingsPresenter >> defaultLayout [
+
+	^ SpBoxLayout newVertical
+		  borderWidth: 15;
+		  spacing: 5;
+		  add: (self newLabel label: 'Debugger extension settings')
+		  expand: false;
+		  add: #extensionClassesTable;
+		  add: #toolbar expand: false;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StDebuggerExtensionSettingsPresenter >> initialize [
+
+	debuggerExtensionClasses := self debuggerClass extensionToolsClasses
+		                            asOrderedCollection.
+	super initialize
+]
+
+{ #category : 'initialization' }
+StDebuggerExtensionSettingsPresenter >> initializePresenters [
+
+	| activateAllButton unactivateAllButton |
+	extensionClassesTable := self newTable
+		                         beResizable;
+		                         addColumn: (SpStringTableColumn
+				                          title: 'Extension class'
+				                          evaluated: [ :class |
+					                          class basicNew
+						                          debuggerExtensionToolName ]) yourself;
+		                         addColumn: ((SpCheckBoxTableColumn
+				                           title: 'Activated'
+				                           evaluated: [ :class |
+					                           class showInDebugger ])
+				                          width: 60;
+				                          onActivation: [ :class |
+					                          class showInDebugger: true ];
+				                          onDeactivation: [ :class |
+					                          class showInDebugger: false ]);
+		                         items: debuggerExtensionClasses;
+		                         yourself.
+
+	activateAllButton := self newToolbarButton
+		                     action: [ self showAllInDebugger: true ];
+		                     label: 'Activate all'.
+	unactivateAllButton := self newToolbarButton
+		                       action: [ self showAllInDebugger: false ];
+		                       label: 'Unactivate all'.
+	toolbar := self newToolbar
+		           addItem: activateAllButton;
+		           addItem: unactivateAllButton;
+		           yourself
+]
+
+{ #category : 'actions' }
+StDebuggerExtensionSettingsPresenter >> showAllInDebugger: aBoolean [
+
+	debuggerExtensionClasses do: [ :class |
+		class showInDebugger: aBoolean ].
+	extensionClassesTable updateItemsKeepingSelection:
+		debuggerExtensionClasses
+]

--- a/src/NewTools-Debugger/StDebuggerExtensionSettingsPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerExtensionSettingsPresenter.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'debuggerExtensionClasses',
 		'extensionClassesTable',
-		'toolbar'
+		'activateAllCheckbox'
 	],
 	#category : 'NewTools-Debugger-View',
 	#package : 'NewTools-Debugger',
@@ -34,8 +34,8 @@ StDebuggerExtensionSettingsPresenter >> defaultLayout [
 		  spacing: 5;
 		  add: (self newLabel label: 'Debugger extension settings')
 		  expand: false;
+		  add: #activateAllCheckbox expand: false;
 		  add: #extensionClassesTable;
-		  add: #toolbar expand: false;
 		  yourself
 ]
 
@@ -50,7 +50,6 @@ StDebuggerExtensionSettingsPresenter >> initialize [
 { #category : 'initialization' }
 StDebuggerExtensionSettingsPresenter >> initializePresenters [
 
-	| activateAllButton unactivateAllButton |
 	extensionClassesTable := self newTable
 		                         beResizable;
 		                         addColumn: (SpStringTableColumn
@@ -70,16 +69,16 @@ StDebuggerExtensionSettingsPresenter >> initializePresenters [
 		                         items: debuggerExtensionClasses;
 		                         yourself.
 
-	activateAllButton := self newToolbarButton
-		                     action: [ self showAllInDebugger: true ];
-		                     label: 'Activate all'.
-	unactivateAllButton := self newToolbarButton
-		                       action: [ self showAllInDebugger: false ];
-		                       label: 'Unactivate all'.
-	toolbar := self newToolbar
-		           addItem: activateAllButton;
-		           addItem: unactivateAllButton;
-		           yourself
+	activateAllCheckbox := self newCheckBox
+		                       label: '(Un)Activate all';
+		                       state:
+			                       (debuggerExtensionClasses allSatisfy: [
+					                        :class | class showInDebugger ]);
+		                       whenActivatedDo: [
+			                       self showAllInDebugger: true ];
+		                       whenDeactivatedDo: [
+			                       self showAllInDebugger: false ];
+		                       yourself
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
Screenshot:

![image](https://github.com/pharo-spec/NewTools/assets/97704417/cd3db430-9b65-40c3-84c1-ffdd9d7347d5)
