### PR TITLE
Improve the inspector for Pragma to highlight the pragma in the source

### DIFF
--- a/src/NewTools-Inspector-Extensions/Pragma.extension.st
+++ b/src/NewTools-Inspector-Extensions/Pragma.extension.st
@@ -5,7 +5,10 @@ Pragma >> inspectionSourceCodeMethod [
 	<inspectorPresentationOrder: 30 title: 'Method'>
 
 	^ SpCodePresenter new 
-		beForMethod: self method;
-		text: self method sourceCode;
+		beForMethod: method ast;
+		text: (method sourceCode);
+		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
+			interval: (self sourceNode sourceInterval first to: self sourceNode sourceInterval last + 1);
+			yourself);
 		yourself
 ]

--- a/src/NewTools-Inspector-Extensions/Pragma.extension.st
+++ b/src/NewTools-Inspector-Extensions/Pragma.extension.st
@@ -3,12 +3,14 @@ Extension { #name : 'Pragma' }
 { #category : '*NewTools-Inspector-Extensions' }
 Pragma >> inspectionSourceCodeMethod [
 	<inspectorPresentationOrder: 30 title: 'Method'>
-
+	| interval |
+	
+	interval := self sourceNode sourceInterval.
 	^ SpCodePresenter new 
 		beForMethod: method ast;
-		text: (method sourceCode);
+		text: method sourceCode;
 		addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
-			interval: (self sourceNode sourceInterval first to: self sourceNode sourceInterval last + 1);
+			interval: (interval first to: interval last + 1);
 			yourself);
 		yourself
 ]


### PR DESCRIPTION
.. uses #sourceNode introduced by https://github.com/pharo-project/pharo/pull/15092