### PR TITLE
Move methods from Manifest

### DIFF
--- a/src/NewTools-CodeCritiques/ClassDescription.extension.st
+++ b/src/NewTools-CodeCritiques/ClassDescription.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'ClassDescription' }
+
+{ #category : '*NewTools-CodeCritiques' }
+ClassDescription >> criticNameOn: aStream [
+	"This behavior may be folded later by changing the name of this method or using another one."
+
+	aStream << self name << ' (' << self package name << ')'
+]

--- a/src/NewTools-CodeCritiques/CompiledMethod.extension.st
+++ b/src/NewTools-CodeCritiques/CompiledMethod.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'CompiledMethod' }
+
+{ #category : '*NewTools-CodeCritiques' }
+CompiledMethod >> criticNameOn: aStream [
+	"This behavior may be folded later by changing the name of this method or using another one."
+
+	aStream
+		<< self methodClass name
+		<< '>>#'
+		<< self selector
+		<< ' ('
+		<< self methodClass package name
+		<< ')'
+]

--- a/src/NewTools-CodeCritiques/RPackage.extension.st
+++ b/src/NewTools-CodeCritiques/RPackage.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'RPackage' }
+
+{ #category : '*NewTools-CodeCritiques' }
+RPackage >> criticNameOn: aStream [
+	"This behavior may be folded later by changing the name of this method or using another one."
+
+	aStream << self packageName
+]

--- a/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
@@ -143,32 +143,28 @@ StCritiqueBrowserPresenter >> allRules [
 
 { #category : 'private' }
 StCritiqueBrowserPresenter >> applyRules [
+
 	| packageCount nbPackage process rules |
 	rules := self allRules.
 	nbPackage := rbEnvironment packages size.
 	packageCount := 0.
 	self updateTree.
-	process := [ rbEnvironment packages
-		do: [ :package | 
-			| windowTitle |
-			packageCount := packageCount + 1.
-			windowTitle := String
-				streamContents: [ :s | 
-					s << 'run rules on ' << package packageName << ' ('
-						<< packageCount asString << '/' << nbPackage asString << ')' ].
-			self setTitle: windowTitle.
-			checker
-				runRules: rules
-				onPackage: package
-				withoutTestCase: removeTestCase ].
-	checker rule: rules.
-	self setTitle: self defaultTitle.
-	cache packages: rbEnvironment.
-	cache initCache.
-	self rules: (self allRules select: [ :r | self hasBrokenRules: r]).
-    self rulesModel refresh.
-    self rebuildLayout.
-	self updateTree. ] newProcess.
+	process := [
+	           rbEnvironment packages do: [ :package |
+		           | windowTitle |
+		           packageCount := packageCount + 1.
+		           windowTitle := String streamContents: [ :s |
+			                          s << 'run rules on ' << package name << ' (' << packageCount asString << '/' << nbPackage asString << ')' ].
+		           self setTitle: windowTitle.
+		           checker runRules: rules onPackage: package withoutTestCase: removeTestCase ].
+	           checker rule: rules.
+	           self setTitle: self defaultTitle.
+	           cache packages: rbEnvironment.
+	           cache initCache.
+	           self rules: (self allRules select: [ :r | self hasBrokenRules: r ]).
+	           self rulesModel refresh.
+	           self rebuildLayout.
+	           self updateTree ] newProcess.
 	process name: 'SmallLint'.
 	process resume
 ]


### PR DESCRIPTION
Multiple methods are defined in the Manifest package but are used only for the critics UI. I propose to move them to the UI package.

I also used packages instead of categories and updated a call to a deprecated method.