### PR TITLE
StRewriterRuleEditorPresenter uses an old icon name.

### DIFF
--- a/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
@@ -45,7 +45,7 @@ StRewriterRuleEditorPresenter class >> icon [
 
 { #category : 'accessing' }
 StRewriterRuleEditorPresenter class >> iconName [
-	^ #workspaceIcon
+	^ #workspace
 ]
 
 { #category : 'world menu' }


### PR DESCRIPTION
 fix so that it does not always end up in compatibility code 