### PR TITLE
Refactor #inspectionIcons on ThemeIcons to use the #icons accessor

### DIFF
--- a/src/NewTools-Inspector-Extensions/ThemeIcons.extension.st
+++ b/src/NewTools-Inspector-Extensions/ThemeIcons.extension.st
@@ -5,7 +5,7 @@ ThemeIcons >> inspectionIcons [
 	<inspectorPresentationOrder: 0 title: 'Icons'>
 	
 	^ SpListPresenter new
-		items: (icons associations sorted: #key ascending);
+		items: (self icons associations sorted: #key ascending);
 		display: [ :each | each key ];
 		displayIcon: [ :each | each value ];
 		yourself


### PR DESCRIPTION
This pull request refactors `#inspectionIcons` on ThemeIcons to use the `#icons` accessor (instead of the ‘icons’ instance variable).