### PR TITLE
Remove WorkingCopy spotter entries

### DIFF
--- a/src/NewTools-MethodBrowsers/MessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/MessageListPresenter.class.st
@@ -302,7 +302,8 @@ MessageListPresenter >> packageOf: anItem [
 
 { #category : 'private' }
 MessageListPresenter >> protocolNameForItem: anItem [
-	^ anItem category ifNil: [ '' ]
+
+	^ anItem protocolName ifNil: [ '' ]
 ]
 
 { #category : 'actions' }

--- a/src/NewTools-Spotter-Extensions/MCWorkingCopy.extension.st
+++ b/src/NewTools-Spotter-Extensions/MCWorkingCopy.extension.st
@@ -1,19 +1,6 @@
 Extension { #name : 'MCWorkingCopy' }
 
 { #category : '*NewTools-Spotter-Extensions' }
-MCWorkingCopy >> spotterAllRepositoriesFor: aStep [
-	<stSpotterOrder: 20>
-	aStep listProcessor
-		title: 'All other repositories';
-		allCandidates: [ MCRepositoryGroup default repositories \ self repositoryGroup repositories ];
-		itemName: [ :item | item description ];
-		actLogic: [ :item :step | 
-			step exit.
-			self spotterCommit: self in: item ];
-		filter: StFilterSubstring
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
 MCWorkingCopy >> spotterAncestorsFor: aStep [
 	<stSpotterOrder: 2>
 	self flag: #maybeRewriteForDirectStreaming.
@@ -21,18 +8,6 @@ MCWorkingCopy >> spotterAncestorsFor: aStep [
 		title: 'Ancestors';
 		allCandidates: [ self allAncestors ];
 		filter: StFilterSubstring
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
-MCWorkingCopy >> spotterCommit: workingCopy in: aRepository [
-	| newVersion |
-
-	newVersion := workingCopy newVersionIn: aRepository.
-	newVersion ifNil: [ ^ self ].
-	Cursor wait showWhile: [
-		[ 	aRepository storeVersion: newVersion.
-			aRepository storeDependencies: newVersion ] 
-		ensure: [ (MCVersionInspector new version: newVersion) show ]]
 ]
 
 { #category : '*NewTools-Spotter-Extensions' }
@@ -58,18 +33,5 @@ MCWorkingCopy >> spotterPackageFor: aStep [
 			ifNil: [ { } ] ];
 		itemName: [ :item | item name ];
 		itemIconName: [ :item | #package ];
-		filter: StFilterSubstring
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
-MCWorkingCopy >> spotterPackageRepositoriesFor: aStep [
-	<stSpotterOrder: 10>
-	aStep listProcessor
-		title: 'Package repositories';
-		allCandidates: [ self repositoryGroup repositories ];
-		itemName: [ :item | item description ];
-		actLogic: [ :item :step |
-			step exit.
-			self spotterCommit: self in: item ];
 		filter: StFilterSubstring
 ]


### PR DESCRIPTION
Those entries are the only remanent calling some GUI of Monticello. I propose to remove them especially since they are written in Morph and dealing with low level stuff such as manipulating the cursor