### PR TITLE
remove  spotterForBytecodesFor:

### DIFF
--- a/src/NewTools-Spotter-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Spotter-Extensions/CompiledMethod.extension.st
@@ -1,17 +1,6 @@
 Extension { #name : 'CompiledMethod' }
 
 { #category : '*NewTools-Spotter-Extensions' }
-CompiledMethod >> spotterForBytecodesFor: aStep [
-	<stSpotterOrder: 15>
-	
-	aStep listProcessor
-		title: 'Bytecode';
-		allCandidates: [ self symbolicBytecodes ];
-		itemName: #printString;
-		filter: StFilterSubstring
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
 CompiledMethod >> spotterForImplementorsFor: aStep [
 	<stSpotterOrder: 10>
 	

--- a/src/NewTools-Spotter-Extensions/Pragma.extension.st
+++ b/src/NewTools-Spotter-Extensions/Pragma.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'Pragma' }
 
 { #category : '*NewTools-Spotter-Extensions' }
-Pragma >> spotterForBytecodesFor: aStep [
-	<stSpotterOrder: 15>
-	self method spotterForBytecodesFor: aStep
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
 Pragma >> spotterForImplementorsFor: aStep [
 	<stSpotterOrder: 10>
 	self method spotterForImplementorsFor: aStep

--- a/src/NewTools-Spotter-Extensions/ReflectiveMethod.extension.st
+++ b/src/NewTools-Spotter-Extensions/ReflectiveMethod.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'ReflectiveMethod' }
 
 { #category : '*NewTools-Spotter-Extensions' }
-ReflectiveMethod >> spotterForBytecodesFor: aStep [
-	<stSpotterOrder: 15>
-	compiledMethod spotterForBytecodesFor: aStep
-]
-
-{ #category : '*NewTools-Spotter-Extensions' }
 ReflectiveMethod >> spotterForImplementorsFor: aStep [
 	<stSpotterOrder: 10>
 	self compiledMethod spotterForImplementorsFor: aStep


### PR DESCRIPTION
- Seems to be not used
- makes no sense. Who would ever want to search the symbolic print of bytecode? With a script, yes but using the UI?