### PR TITLE
Pharo issue #15545: Restore author and time stamp to method versions

### DIFF
--- a/src/NewTools-MethodBrowsers/MessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/MessageListPresenter.class.st
@@ -36,6 +36,11 @@ MessageListPresenter class >> defaultLayout [
 		yourself
 ]
 
+{ #category : 'private' }
+MessageListPresenter >> authorOf: anItem [
+	^ anItem author
+]
+
 { #category : 'actions' }
 MessageListPresenter >> browseClassRefs [
 
@@ -183,6 +188,8 @@ MessageListPresenter >> initializePresenters [
 		addColumn: (SpStringTableColumn title: 'Location' evaluated: [ :item | self locationOf: item ]);
 		addColumn: (SpStringTableColumn title: 'Selector' evaluated: [ :item | self selectorOf: item ]);
 		addColumn: (SpStringTableColumn title: 'Package' evaluated: [ :item | self packageOf: item ]);
+		addColumn: (SpStringTableColumn title: 'Time' evaluated: [ :item | self timeStampOf: item ]);
+		addColumn: (SpStringTableColumn title: 'Author' evaluated: [ :item | self authorOf: item ]);
 		beResizable.
 		
 	listPresenter outputActivationPort transmitDo: [ :aMethod | self doBrowseMethod ].
@@ -374,6 +381,11 @@ MessageListPresenter >> sortClassesInCachedHierarchy: aMethodDefinition b: other
 { #category : 'api' }
 MessageListPresenter >> sortingBlock: aBlock [
 	listPresenter sortingBlock: aBlock
+]
+
+{ #category : 'private' }
+MessageListPresenter >> timeStampOf: anItem [
+	^ anItem timeStamp
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
In previous Pharo versions we had these information.
So, when navigating method version history we could tell when it was done, and by whom