### PR TITLE
Debugger dynamic layouts

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -125,6 +125,17 @@ StDebugger class >> closeAllDebuggers [
 	self allInstancesDo: [ :dbg | dbg close ]
 ]
 
+{ #category : 'accessing' }
+StDebugger class >> configureLayout [
+	 ^self layoutConfigurator selectedLayout
+]
+
+{ #category : 'accessing' }
+StDebugger class >> configureLayout: aSymbol [
+	aSymbol crTrace.
+	self layoutConfigurator selectedLayout: aSymbol 
+]
+
 { #category : 'instance creation' }
 StDebugger class >> debugSession: aDebugSession [
 
@@ -141,6 +152,21 @@ StDebugger class >> debugSession: aDebugSession [
 { #category : 'accessing' }
 StDebugger class >> debuggerContextClass [
 	^ StDebuggerContext
+]
+
+{ #category : 'accessing' }
+StDebugger class >> debuggerLayoutSettingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder pickOne: #configureLayout)
+		parent: #debugging;
+		label: 'Debugger Layout';
+		target: StDebugger;
+		default: #beVerticalStackThenCode;
+		domainValues:
+			#( #beHorizontalCodeThenStack #beHorizontalStackThenCode
+			   #beVerticalCodeThenStack #beVerticalStackThenCode );
+		description: ''
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -93,6 +93,9 @@ Class {
 		'EnableStackColoring',
 		'FastTDD'
 	],
+	#classInstVars : [
+		'layoutConfigurator'
+	],
 	#category : 'NewTools-Debugger-View',
 	#package : 'NewTools-Debugger',
 	#tag : 'View'
@@ -199,6 +202,13 @@ StDebugger class >> hasAnyActivatedExtension: extensionsClasses [
 StDebugger class >> initialize [ 
 
 	EnableStackColoring := true
+]
+
+{ #category : 'accessing' }
+StDebugger class >> layoutConfigurator [
+
+	^ layoutConfigurator ifNil: [
+		  layoutConfigurator := StDebuggerLayoutConfiguration new ]
 ]
 
 { #category : 'opening' }
@@ -1147,11 +1157,9 @@ StDebugger >> stack [
 { #category : 'layout' }
 StDebugger >> stackAndCodeLayout [
 
-	^ SpPanedLayout newTopToBottom
-		positionOfSlider: 30 percent;
-		add: self stackLayout;
-		add: self codeLayout;
-		yourself
+	^ self class layoutConfigurator configureForLayouts: {
+			  (#stack -> self stackLayout).
+			  (#code -> self codeLayout) } asDictionary
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -206,7 +206,7 @@ StDebugger class >> initialize [
 
 { #category : 'accessing' }
 StDebugger class >> layoutConfigurator [
-	'here' crTrace.
+
 	^ layoutConfigurator ifNil: [
 		  layoutConfigurator := StDebuggerLayoutConfiguration new ]
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -132,8 +132,10 @@ StDebugger class >> configureLayout [
 
 { #category : 'accessing' }
 StDebugger class >> configureLayout: aSymbol [
-	aSymbol crTrace.
-	self layoutConfigurator selectedLayout: aSymbol 
+
+	self layoutConfigurator selectedLayout: aSymbol.
+	SystemAnnouncer uniqueInstance announce:
+		StDebuggerLayoutChangedAnnouncement new
 ]
 
 { #category : 'instance creation' }
@@ -707,6 +709,7 @@ StDebugger >> initialize [
 	self debuggerActionModel updateContextPredicate.
 	self forceSessionUpdate.
   	self susbcribeToExtensionToggleAnnouncement.
+	self susbcribeToLayoutChangesAnnouncement.
 	
 	programmaticallyClosed := false.
 ]
@@ -1325,6 +1328,15 @@ StDebugger >> susbcribeToExtensionToggleAnnouncement [
 		to: self
 ]
 
+{ #category : 'subscription' }
+StDebugger >> susbcribeToLayoutChangesAnnouncement [
+
+	SystemAnnouncer uniqueInstance weak
+		when: StDebuggerLayoutChangedAnnouncement
+		send: #updateLayout
+		to: self
+]
+
 { #category : 'accessing - presenters' }
 StDebugger >> toolbar [
 
@@ -1475,6 +1487,13 @@ StDebugger >> updateInspectorFromContext: aContext [
 	inspector updateWith: (self newDebuggerContextFor: aContext).
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
+]
+
+{ #category : 'updating' }
+StDebugger >> updateLayout [
+
+	self setStackAndCodeContainer.
+	self layout: self defaultLayout
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -206,7 +206,7 @@ StDebugger class >> initialize [
 
 { #category : 'accessing' }
 StDebugger class >> layoutConfigurator [
-
+	'here' crTrace.
 	^ layoutConfigurator ifNil: [
 		  layoutConfigurator := StDebuggerLayoutConfiguration new ]
 ]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -370,7 +370,7 @@ StDebugger >> code [
 	^ code
 ]
 
-{ #category : 'specs' }
+{ #category : 'layout' }
 StDebugger >> codeLayout [
 
 	^ SpBoxLayout newTopToBottom
@@ -1144,7 +1144,7 @@ StDebugger >> stack [
 
 ]
 
-{ #category : 'specs' }
+{ #category : 'layout' }
 StDebugger >> stackAndCodeLayout [
 
 	^ SpPanedLayout newTopToBottom
@@ -1154,7 +1154,7 @@ StDebugger >> stackAndCodeLayout [
 		yourself
 ]
 
-{ #category : 'specs' }
+{ #category : 'layout' }
 StDebugger >> stackAndCodeWithExtensionsLayout [
 
 	^ (SpPanedLayout newLeftToRight
@@ -1199,7 +1199,7 @@ StDebugger >> stackIconForContext: context [
 	^ self iconNamed: #overlayDirty
 ]
 
-{ #category : 'specs' }
+{ #category : 'layout' }
 StDebugger >> stackLayout [
 	^ SpBoxLayout newTopToBottom
 		add: #stackHeader

--- a/src/NewTools-Debugger/StDebuggerLayoutChangedAnnouncement.class.st
+++ b/src/NewTools-Debugger/StDebuggerLayoutChangedAnnouncement.class.st
@@ -1,0 +1,10 @@
+"
+I am announced when the debugger layout has changed, to allow open debuggers to dynamically update their layouts.
+"
+Class {
+	#name : 'StDebuggerLayoutChangedAnnouncement',
+	#superclass : 'Announcement',
+	#category : 'NewTools-Debugger-Model',
+	#package : 'NewTools-Debugger',
+	#tag : 'Model'
+}

--- a/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
+++ b/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
@@ -69,3 +69,15 @@ StDebuggerLayoutConfiguration >> initialize [
 	order := #( #stack #code ).
 	selectedLayout := #beVerticalStackThenCode
 ]
+
+{ #category : 'accessing' }
+StDebuggerLayoutConfiguration >> selectedLayout [
+
+	^ selectedLayout
+]
+
+{ #category : 'accessing' }
+StDebuggerLayoutConfiguration >> selectedLayout: anObject [
+
+	selectedLayout := anObject
+]

--- a/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
+++ b/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
@@ -1,0 +1,70 @@
+"
+A trivial layout configurator for the `StDebugger`. 
+It is configureable through api methods.
+To change the layout, it takes as input a dictionary with the name of the element to layout associated to the element itself.
+"
+Class {
+	#name : 'StDebuggerLayoutConfiguration',
+	#superclass : 'Object',
+	#instVars : [
+		'layout',
+		'order'
+	],
+	#category : 'NewTools-Debugger-Model',
+	#package : 'NewTools-Debugger',
+	#tag : 'Model'
+}
+
+{ #category : 'configuration' }
+StDebuggerLayoutConfiguration >> beHorizontalCodeThenStack [
+
+	layout := SpPanedLayout newLeftToRight
+		          positionOfSlider: 30 percent;
+		          yourself.
+	order := #( #code #stack )
+]
+
+{ #category : 'configuration' }
+StDebuggerLayoutConfiguration >> beHorizontalStackThenCode [
+
+	layout := SpPanedLayout newLeftToRight
+		          positionOfSlider: 30 percent;
+		          yourself.
+	order := #( #stack #code )
+]
+
+{ #category : 'configuration' }
+StDebuggerLayoutConfiguration >> beVerticalCodeThenStack [
+
+	layout := SpPanedLayout newTopToBottom
+		          positionOfSlider: 30 percent;
+		          yourself.
+	order := #( #code #stack )
+]
+
+{ #category : 'configuration' }
+StDebuggerLayoutConfiguration >> beVerticalStackThenCode [
+
+	layout := SpPanedLayout newTopToBottom 
+		          positionOfSlider: 30 percent;
+		          yourself.
+	order := #( #stack #code )
+]
+
+{ #category : 'configuration' }
+StDebuggerLayoutConfiguration >> configureForLayouts: layoutsDictionary [
+
+	order do: [ :layoutSymbol |
+		layoutsDictionary at: layoutSymbol ifPresent: [ :l | layout add: l ] ].
+
+	^ layout
+]
+
+{ #category : 'initialization' }
+StDebuggerLayoutConfiguration >> initialize [
+
+	layout := SpPanedLayout newTopToBottom
+		          positionOfSlider: 30 percent;
+		          yourself.
+	order := #( #stack #code )
+]

--- a/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
+++ b/src/NewTools-Debugger/StDebuggerLayoutConfiguration.class.st
@@ -7,8 +7,8 @@ Class {
 	#name : 'StDebuggerLayoutConfiguration',
 	#superclass : 'Object',
 	#instVars : [
-		'layout',
-		'order'
+		'order',
+		'selectedLayout'
 	],
 	#category : 'NewTools-Debugger-Model',
 	#package : 'NewTools-Debugger',
@@ -18,41 +18,44 @@ Class {
 { #category : 'configuration' }
 StDebuggerLayoutConfiguration >> beHorizontalCodeThenStack [
 
-	layout := SpPanedLayout newLeftToRight
-		          positionOfSlider: 30 percent;
-		          yourself.
-	order := #( #code #stack )
+	order := #( #code #stack ).
+	^ SpPanedLayout newLeftToRight
+		  positionOfSlider: 30 percent;
+		  yourself
 ]
 
 { #category : 'configuration' }
 StDebuggerLayoutConfiguration >> beHorizontalStackThenCode [
 
-	layout := SpPanedLayout newLeftToRight
-		          positionOfSlider: 30 percent;
-		          yourself.
-	order := #( #stack #code )
+	order := #( #stack #code ).
+	^ SpPanedLayout newLeftToRight
+		  positionOfSlider: 30 percent;
+		  yourself
 ]
 
 { #category : 'configuration' }
 StDebuggerLayoutConfiguration >> beVerticalCodeThenStack [
 
-	layout := SpPanedLayout newTopToBottom
-		          positionOfSlider: 30 percent;
-		          yourself.
-	order := #( #code #stack )
+	order := #( #code #stack ).
+	^ SpPanedLayout newTopToBottom
+		  positionOfSlider: 30 percent;
+		  yourself
 ]
 
 { #category : 'configuration' }
 StDebuggerLayoutConfiguration >> beVerticalStackThenCode [
 
-	layout := SpPanedLayout newTopToBottom 
-		          positionOfSlider: 30 percent;
-		          yourself.
-	order := #( #stack #code )
+	order := #( #stack #code ).
+	^ SpPanedLayout newTopToBottom
+		  positionOfSlider: 30 percent;
+		  yourself
 ]
 
 { #category : 'configuration' }
 StDebuggerLayoutConfiguration >> configureForLayouts: layoutsDictionary [
+
+	| layout |
+	layout := self perform: selectedLayout.
 
 	order do: [ :layoutSymbol |
 		layoutsDictionary at: layoutSymbol ifPresent: [ :l | layout add: l ] ].
@@ -63,8 +66,6 @@ StDebuggerLayoutConfiguration >> configureForLayouts: layoutsDictionary [
 { #category : 'initialization' }
 StDebuggerLayoutConfiguration >> initialize [
 
-	layout := SpPanedLayout newTopToBottom
-		          positionOfSlider: 30 percent;
-		          yourself.
-	order := #( #stack #code )
+	order := #( #stack #code ).
+	selectedLayout := #beVerticalStackThenCode
 ]


### PR DESCRIPTION
A first implementation of this proposal https://github.com/pharo-spec/NewTools/pull/629
It is a first step:
* I did not change the columns, because actually the table in general makes no sense for the stack and I would like to go back to a list (we can still move the slider to enlarge columns manually)
* The configuration is from the settings, but it should be from the debugger itself somewhere
* Only the stack and the code and interchangeable, but why not all other elements? It requires more work and a more solid model

Short video:

https://github.com/pharo-spec/NewTools/assets/26929529/5d3ecf4d-c1e5-48af-9f38-3fc4d1a83d58

