### PR TITLE
Simpler stack items

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -641,14 +641,16 @@ StDebuggerTest >> testNewDebuggerContextFor [
 
 { #category : 'tests - stack table' }
 StDebuggerTest >> testPrintReceiverClassInContext [
-	|ctx result|
+	|ctx stream |
 	ctx := Context sender: nil receiver: Set new method: (Collection>>#add:) arguments: Array new. 
-	result := self debugger printReceiverClassInContext: ctx.
-	self assert: result equals: 'Set (Collection)'.
+	stream := WriteStream on: String new.
+	StContextPrinter printReceiverClassInContext: ctx on: stream.
+	self assert: stream contents equals: 'Set (Collection)'.
 	
 	ctx := Context sender: nil receiver: Set new method: (Set>>#add:) arguments: Array new. 
-	result := self debugger printReceiverClassInContext: ctx.
-	self assert: result equals: 'Set'.
+	stream := WriteStream on: String new.
+	StContextPrinter printReceiverClassInContext: ctx on: stream.
+	self assert: stream contents equals: 'Set'.
 ]
 
 { #category : 'tests - receiver inspector' }
@@ -950,68 +952,8 @@ StDebuggerTest >> testStackTableAfterStepIn [
 ]
 
 { #category : 'tests - stack table' }
-StDebuggerTest >> testStackTableElementsPrinting [
-	| columns classColumn methodColumn method block context |
-
-	self debugger session: session.
-	columns := self initializedDebugger stackTable columns.
-	classColumn := columns second.
-	methodColumn := columns third.
-	"The following column was removed to experiment a new layout, just keeping the test in case of roolback."
-	"senderColumn := columns third."
-	method := self class >> #testStackTableElementsPrinting.
-	block := [ :a | a ].
-	
-	context := (Context newForMethod: method) setSender: self receiver: self method: method arguments: #(  ).
-	self assert: (classColumn evaluation value: context) equals: self class name.
-	self assert: (methodColumn evaluation value: context) equals: method selector.
-	"The following column was removed to experiment a new layout, just keeping the test in case of roolback."
-	"self assert: (senderColumn evaluation value: context) equals: self stDisplayString."
-	
-	context := (Context newForMethod: method) setSender: self receiver: self method: block method arguments: #(  ).
-	self assert: (classColumn evaluation value: context) equals: self class name.
-	self assert: (methodColumn evaluation value: context) equals: block sourceNode sourceCode.
-	"The following column was removed to experiment a new layout, just keeping the test in case of roolback."
-	"self assert: (senderColumn evaluation value: context) equals: self stDisplayString."
-]
-
-{ #category : 'tests - stack table' }
 StDebuggerTest >> testStackTableInitialization [
 	self assert: self debugger stackTable isNil
-]
-
-{ #category : 'tests - stack table' }
-StDebuggerTest >> testStackTablePackagesLabels [
-	|stackTable packageColumn ctx|
-	self debugger session: session.
-	stackTable := self initializedDebugger stackTable.
-	packageColumn := stackTable columns last.
-	
-	"The method is defined in the same package as its class"
-	ctx := Context
-		sender: nil
-		receiver: nil
-		method: (StTestDebuggerProvider >> #debuggerWithDNUContext)
-		arguments: #().
-	self assert: (packageColumn readObject: ctx) equals: StTestDebuggerProvider package name.
-	
-	"The extension method is defined in another package than its class"
-	ctx := Context
-		sender: nil
-		receiver: nil
-		method: (StDebugger >> #inspector)
-		arguments: #().
-	self assert: (packageColumn readObject: ctx) equals: StTestDebuggerProvider package name.
-	
-	"Doit methods have no package."
-	ctx := Context
-		sender: nil
-		receiver: nil
-		method: (Smalltalk compiler compile: 'DoIt 1 + 1')
-		arguments: #().
-	self assert: (packageColumn readObject: ctx) equals: '-'
-	
-
 ]
 
 { #category : 'tests - stack table' }

--- a/src/NewTools-Debugger/StContextPrinter.class.st
+++ b/src/NewTools-Debugger/StContextPrinter.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : 'StContextPrinter',
+	#superclass : 'Object',
+	#category : 'NewTools-Debugger-Model',
+	#package : 'NewTools-Debugger',
+	#tag : 'Model'
+}
+
+{ #category : 'printing' }
+StContextPrinter class >> printContext: aContext [
+
+	^ String streamContents: [ :stream |
+		  self printPackage: aContext method package on: stream.
+		  self printReceiverClassInContext: aContext on: stream.
+		  self printMethod: aContext method on: stream ]
+]
+
+{ #category : 'printing' }
+StContextPrinter class >> printMethod: aCompiledMethod on: aStream [
+	aStream << '>>'.
+	aStream << (aCompiledMethod isCompiledBlock
+		ifTrue: [ aCompiledMethod sourceNode sourceCode ]
+		ifFalse: [ aCompiledMethod selector ])
+]
+
+{ #category : 'printing' }
+StContextPrinter class >> printPackage: aPackage on: aStream [
+
+	aPackage ifNil: [ ^ self ].
+	aStream << '['.
+	aStream << aPackage name asString.
+	aStream << ']'.
+	aStream space
+]
+
+{ #category : 'printing' }
+StContextPrinter class >> printReceiverClassInContext: aContext on: aStream [
+
+	| receiverClass methodClass |
+	receiverClass := aContext receiver class.
+	methodClass := aContext method methodClass.
+	aStream << receiverClass name.
+	receiverClass == methodClass ifTrue: [ ^ self ].
+	aStream space.
+	aStream << '('.
+	aStream << methodClass name.
+	aStream << ')'
+]

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -93,9 +93,6 @@ Class {
 		'EnableStackColoring',
 		'FastTDD'
 	],
-	#classInstVars : [
-		'layoutConfigurator'
-	],
 	#category : 'NewTools-Debugger-View',
 	#package : 'NewTools-Debugger',
 	#tag : 'View'

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1159,7 +1159,7 @@ StDebugger >> stackHeader [
 StDebugger >> stackIconForContext: context [
 
 	self unsavedCodeChanges at: context ifAbsent: [ ^ nil ].
-	^ self iconNamed: #overlayDirty
+	^ self iconNamed: #repair
 ]
 
 { #category : 'specs' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -93,6 +93,9 @@ Class {
 		'EnableStackColoring',
 		'FastTDD'
 	],
+	#classInstVars : [
+		'layoutConfigurator'
+	],
 	#category : 'NewTools-Debugger-View',
 	#package : 'NewTools-Debugger',
 	#tag : 'View'
@@ -760,37 +763,13 @@ StDebugger >> initializeShortcuts: aWindowPresenter [
 { #category : 'stack' }
 StDebugger >> initializeStack [
 
-	stackTable := self newTable.
+	stackTable := self newList.
 	stackTable
 		activateOnDoubleClick;
 		whenActivatedDo: [ :selection | self doBrowseClass ].
-	stackTable
-		addColumn: ((SpImageTableColumn title: '' evaluated: [ :context | self stackIconForContext: context ])
-				 width: 8;
-				 sortFunction: nil;
-				 yourself);
-		addColumn: ((SpStringTableColumn title: 'Class' evaluated: [ :context | self printReceiverClassInContext: context ])
-				 displayColor: [ :context | self stackColorForContext: context ];
-				 sortFunction: nil;
-				 yourself);
-		addColumn: ((SpStringTableColumn title: 'Method' evaluated: [ :context |
-					  | method |
-					  method := context method.
-					  method isCompiledBlock
-						  ifTrue: [ method sourceNode sourceCode ]
-						  ifFalse: [ method selector ] ])
-				 displayColor: [ :context | self stackColorForContext: context ];
-				 sortFunction: nil;
-				 yourself);
-		addColumn: ((SpStringTableColumn title: 'Package' evaluated: [ :context |
-					  | package |
-					  package := context method package.
-					  package
-						  ifNil: [ '-' ]
-						  ifNotNil: [ package name asString ] ])
-				 displayColor: [ :context | self stackColorForContext: context ];
-				 sortFunction: nil;
-				 yourself).
+	stackTable display:[:selection| StContextPrinter printContext: selection].
+	stackTable displayColor:[ :context | self stackColorForContext: context ].
+	stackTable displayIcon: [ :context| self stackIconForContext: context ].	
 	stackTable transmitDo: [ :context |
 		stackTable selection isEmpty ifFalse: [
 			self updateInspectorFromContext: context.
@@ -933,22 +912,6 @@ StDebugger >> peelToFirstLike: aContext [
 	self debuggerActionModel peelToFirstLike: aContext.
 	self clearUnsavedCodeChanges.
 	self code text: self currentContext sourceCode
-]
-
-{ #category : 'printing' }
-StDebugger >> printReceiverClassInContext: aContext [
-
-	| receiverClass methodClass |
-	receiverClass := aContext receiver class.
-	methodClass := aContext method methodClass.
-	receiverClass == methodClass ifTrue: [ ^ receiverClass name ].
-	^ (WriteStream on: String new)
-		  nextPutAll: receiverClass name;
-		  space;
-		  nextPut: $(;
-		  nextPutAll: methodClass name;
-		  nextPut: $);
-		  contents
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
Changed the debugger stack from a table to a list.
All features are conserved.

![Capture d’écran 2023-11-30 à 14 07 26](https://github.com/pharo-spec/NewTools/assets/26929529/4d169ff9-cdee-40c5-81c3-7583af5ad926)
