### PR TITLE
Remove ChangeSorter from loading

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -25,7 +25,6 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Gtk';
 			"Basic tools (inherited from Spec)"
 			package: 'NewTools-MethodBrowsers';
-			package: 'NewTools-ChangeSorter';
 			package: 'NewTools-KeymapBrowser';
 			"inspector"
 			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Inspector-Extensions' ) ];
@@ -113,7 +112,6 @@ BaselineOfNewTools >> baseline: spec [
 			group: 'SystemReporter' with: #( 'Core' 'NewTools-SystemReporter' );
 			group: 'Methods' with: #( 'Core' 'NewTools-MethodBrowsers' );
 			"Not in the image for the moment, we need a pass on them"
-			group: 'ChangeSorter' with: #( 'Core' 'NewTools-ChangeSorter' );
 			group: 'KeymapBrowser' with: #( 'Core' 'NewTools-KeymapBrowser' );
 			group: 'CritiqueBrowser' with: #( 'NewTools-CodeCritiques' 'NewTools-CodeCritiques-Tests' );
 			group: 'FontChooser' with: #( 'Core' 'NewTools-FontChooser' 'NewTools-FontChooser-Tests' );
@@ -138,7 +136,6 @@ BaselineOfNewTools >> baseline: spec [
 						'CritiqueBrowser' 
 						'Debugger'
 				   		'SystemReporter' 
-						'ChangeSorter' 
 						'FontChooser' 
 						'Methods'
 				   		'Spotter'


### PR DESCRIPTION
This PR is the first step to prevent loading the ChangeSet related tools from the image which are [considered legacy](https://github.com/pharo-project/pharo/issues/11940) from Pharo 12 onwards.
