### PR TITLE
Editable inspector values

### DIFF
--- a/src/NewTools-Inspector/StRawInspectionPresenter.class.st
+++ b/src/NewTools-Inspector/StRawInspectionPresenter.class.st
@@ -178,7 +178,9 @@ StRawInspectionPresenter >> valuesColumn [
 		title: 'Value';
 		evaluated: #stringValue;
 		beEditable;
-		onAcceptEdition: [ :node :value | self write: node value: value ];
+		onAcceptEdition: [ :node :value | 
+			self write: node value: value.
+			self window title: self window presenter windowTitle ];
 		sortFunction: #stringValue ascending;
 		yourself
 ]

--- a/src/NewTools-Inspector/StRawInspectionPresenter.class.st
+++ b/src/NewTools-Inspector/StRawInspectionPresenter.class.st
@@ -172,6 +172,16 @@ StRawInspectionPresenter >> step [
 ]
 
 { #category : 'building' }
+StRawInspectionPresenter >> updatePresenterTitle [
+	"Callback after changing a receiver's value (in a column for an instance variable). Update the window title and its header to display the new value"
+	| wp |
+
+	wp := self window presenter.
+	wp firstPage updateHeaderBar.
+	self window title: wp windowTitle
+]
+
+{ #category : 'building' }
 StRawInspectionPresenter >> valuesColumn [
 
 	^ SpStringTableColumn new
@@ -180,7 +190,7 @@ StRawInspectionPresenter >> valuesColumn [
 		beEditable;
 		onAcceptEdition: [ :node :value | 
 			self write: node value: value.
-			self window title: self window presenter windowTitle ];
+			self updatePresenterTitle ];
 		sortFunction: #stringValue ascending;
 		yourself
 ]

--- a/src/NewTools-Inspector/StRawInspectionPresenter.class.st
+++ b/src/NewTools-Inspector/StRawInspectionPresenter.class.st
@@ -177,9 +177,8 @@ StRawInspectionPresenter >> valuesColumn [
 	^ SpStringTableColumn new
 		title: 'Value';
 		evaluated: #stringValue;
-		"beEditable;"
-		onAcceptEdition: [ :node :value | 
-			self inform: node label , '=' , value asString	"node value: value" ];
+		beEditable;
+		onAcceptEdition: [ :node :value | self write: node value: value ];
 		sortFunction: #stringValue ascending;
 		yourself
 ]
@@ -199,4 +198,14 @@ StRawInspectionPresenter >> variablesColumn [
 			yourself);
 		sortFunction: #label ascending;
 		yourself
+]
+
+{ #category : 'writing' }
+StRawInspectionPresenter >> write: aStInspectorSlotNode value: aString [ 
+	"Update the value of aStInspectorSlotNode with new value aString.
+	Convert aString to the 'native' object parsing it as number or using parseLiterals (for booleans or strings)"
+	
+	aStInspectorSlotNode slot 
+		write: (NumberParser parse: aString onError: [ aString parseLiterals first ]) 
+		to: aStInspectorSlotNode hostObject
 ]


### PR DESCRIPTION
### Issue
Currently in Pharo 12, the inspector doesn't allow direct editing of object variables, requiring additional steps for modification.

### Proposed Solution
I propose enhancing the inspector to support direct editing of object variables, streamlining the debugging process and improving developer efficiency.

### Implementation
- Introduce inline editing for object variables.
- Ensure proper validation and handling of edited values.
- Maintain compatibility with existing inspector functionality.

This change aims to enhance the developer experience and reduce the time spent on debugging tasks.

Closes #501