### PR TITLE
Prevent font chooser open error listing

### DIFF
--- a/src/NewTools-FontChooser/StFontChooserPresenter.class.st
+++ b/src/NewTools-FontChooser/StFontChooserPresenter.class.st
@@ -357,7 +357,7 @@ StFontChooserPresenter >> updateWithFont: aFont [
 	initialFamily := fontFamilyList items
 		                 detect: [ :e | e familyName = aFont familyName ]
 		                 ifNone: [ 
-									self inform: ('Requested font {1} not found' format: { aFont familyName }).
+									('Requested font {1} not found' format: { aFont familyName }) traceCr.
 									fontFamilyList items anyOne ].
 
 	fontFamilyList selectItem: initialFamily.

--- a/src/NewTools-FontChooser/StFontChooserPresenter.class.st
+++ b/src/NewTools-FontChooser/StFontChooserPresenter.class.st
@@ -347,13 +347,18 @@ StFontChooserPresenter >> updatePreview [
 
 { #category : 'initialization' }
 StFontChooserPresenter >> updateWithFont: aFont [
+	"Try to update the receiver's listing with the selected aFont. 
+	If we do not find a font family matching aFont (for example not yet loaded fonts), inform and then select the first family in the system.
+	If we do not find a font style, select the first one available as initial style"
 
 	| initialFamily initialStyle |
 	fontFamilyList items: self model fontList.
 
 	initialFamily := fontFamilyList items
 		                 detect: [ :e | e familyName = aFont familyName ]
-		                 ifNone: [ nil ].
+		                 ifNone: [ 
+									self inform: ('Requested font {1} not found' format: { aFont familyName }).
+									fontFamilyList items anyOne ].
 
 	fontFamilyList selectItem: initialFamily.
 
@@ -362,7 +367,7 @@ StFontChooserPresenter >> updateWithFont: aFont [
 			                style weightValue = aFont weightValue and: [ 
 				                style stretchValue = aFont stretchValue and: [ 
 					                style slantValue = aFont slantValue ] ] ]
-		                ifNone: [ nil ].
+		                ifNone: [ self selectedFontFamily members anyOne ].
 
 	fontStyleList selectItem: initialStyle.
 

--- a/src/NewTools-FontChooser/StFontChooserPresenterTest.class.st
+++ b/src/NewTools-FontChooser/StFontChooserPresenterTest.class.st
@@ -38,6 +38,15 @@ StFontChooserPresenterTest >> newDefaultFamilyFontChooserFont: aLogicalFont [
 		yourself.	
 ]
 
+{ #category : 'tests' }
+StFontChooserPresenterTest >> openPresenterShouldntRaiseError [
+
+	self shouldnt: [ 
+			| window | 
+			window := presenter open.
+			window close ] raise: Error
+]
+
 { #category : 'running' }
 StFontChooserPresenterTest >> setUp [
 
@@ -74,10 +83,7 @@ StFontChooserPresenterTest >> testOpenAllOnNonExistantFontFamily [
 	fontChooser := self newAllFamilyFontChooser: 'dd08sadna80nsazczxcz'.
 	presenter := StFontChooserPresenter on: fontChooser.
 
-	self shouldnt: [ 
-			| window | 
-			window := presenter open.
-			window close ] raise: Error
+	self openPresenterShouldntRaiseError.
 ]
 
 { #category : 'tests' }
@@ -88,10 +94,7 @@ StFontChooserPresenterTest >> testOpenAllOnUnloadedFontFamily [
 	fontChooser := self newAllFamilyFontChooser: 'Arial'.
 	presenter := StFontChooserPresenter on: fontChooser.
 
-	self shouldnt: [ 
-			| window | 
-			window := presenter open.
-			window close ] raise: Error
+	self openPresenterShouldntRaiseError.
 ]
 
 { #category : 'tests' }
@@ -102,10 +105,7 @@ StFontChooserPresenterTest >> testOpenDefaultOnNonExistantFontFamily [
 	fontChooser := self newDefaultFamilyFontChooser: 'dd08sadna80nsazczxcz'.
 	presenter := StFontChooserPresenter on: fontChooser.
 
-	self shouldnt: [ 
-			| window | 
-			window := presenter open.
-			window close ] raise: Error
+	self openPresenterShouldntRaiseError.
 ]
 
 { #category : 'tests' }
@@ -116,10 +116,7 @@ StFontChooserPresenterTest >> testOpenDefaultOnUnloadedFontFamily [
 	fontChooser := self newDefaultFamilyFontChooser: 'Arial'.
 	presenter := StFontChooserPresenter on: fontChooser.
 
-	self shouldnt: [ 
-			| window | 
-			window := presenter open.
-			window close ] raise: Error
+	self openPresenterShouldntRaiseError.
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-FontChooser/StFontChooserPresenterTest.class.st
+++ b/src/NewTools-FontChooser/StFontChooserPresenterTest.class.st
@@ -9,15 +9,43 @@ Class {
 }
 
 { #category : 'running' }
+StFontChooserPresenterTest >> newAllFamilyFontChooser: aFamilyName [
+
+	^ FontChooser newWithAllFamilies
+		font: (LogicalFont familyName: aFamilyName pointSize: 12);
+		yourself.	
+]
+
+{ #category : 'running' }
+StFontChooserPresenterTest >> newAllFamilyFontChooserFont: aLogicalFont [
+
+	^ FontChooser newWithAllFamilies
+		font: aLogicalFont;
+		yourself.	
+]
+
+{ #category : 'running' }
+StFontChooserPresenterTest >> newDefaultFamilyFontChooser: aFamilyName [
+
+	^ self newDefaultFamilyFontChooserFont: (LogicalFont familyName: aFamilyName pointSize: 12)
+]
+
+{ #category : 'running' }
+StFontChooserPresenterTest >> newDefaultFamilyFontChooserFont: aLogicalFont [
+
+	^ FontChooser newWithDefaultFamilies
+		font: aLogicalFont;
+		yourself.	
+]
+
+{ #category : 'running' }
 StFontChooserPresenterTest >> setUp [
 
 	| fontChooser |
 	
 	super setUp.
 	
-	fontChooser := FontChooser newWithDefaultFamilies
-		font: (LogicalFont familyName: 'Bitmap DejaVu Sans' pointSize: 12);
-		yourself.
+	fontChooser := self newDefaultFamilyFontChooser: 'Bitmap DejaVu Sans'.
 	
 	presenter := StFontChooserPresenter on: fontChooser.
 	
@@ -36,6 +64,62 @@ StFontChooserPresenterTest >> testFamilyListCorrectAtInitialization [
 StFontChooserPresenterTest >> testFirstStyleIsSelected [
 	
 	self assert: (presenter fontStyleList selectedItems collect: [:each | each styleName ]) equals: #('Regular')
+]
+
+{ #category : 'tests' }
+StFontChooserPresenterTest >> testOpenAllOnNonExistantFontFamily [
+
+	| fontChooser |
+
+	fontChooser := self newAllFamilyFontChooser: 'dd08sadna80nsazczxcz'.
+	presenter := StFontChooserPresenter on: fontChooser.
+
+	self shouldnt: [ 
+			| window | 
+			window := presenter open.
+			window close ] raise: Error
+]
+
+{ #category : 'tests' }
+StFontChooserPresenterTest >> testOpenAllOnUnloadedFontFamily [
+
+	| fontChooser |
+
+	fontChooser := self newAllFamilyFontChooser: 'Arial'.
+	presenter := StFontChooserPresenter on: fontChooser.
+
+	self shouldnt: [ 
+			| window | 
+			window := presenter open.
+			window close ] raise: Error
+]
+
+{ #category : 'tests' }
+StFontChooserPresenterTest >> testOpenDefaultOnNonExistantFontFamily [
+
+	| fontChooser |
+
+	fontChooser := self newDefaultFamilyFontChooser: 'dd08sadna80nsazczxcz'.
+	presenter := StFontChooserPresenter on: fontChooser.
+
+	self shouldnt: [ 
+			| window | 
+			window := presenter open.
+			window close ] raise: Error
+]
+
+{ #category : 'tests' }
+StFontChooserPresenterTest >> testOpenDefaultOnUnloadedFontFamily [
+
+	| fontChooser |
+
+	fontChooser := self newDefaultFamilyFontChooser: 'Arial'.
+	presenter := StFontChooserPresenter on: fontChooser.
+
+	self shouldnt: [ 
+			| window | 
+			window := presenter open.
+			window close ] raise: Error
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
### Issue
Opening font chooser with a non-existent font family raises an exception.

### Solution
Try updating Font Chooser with the selected font; if not found, inform and select the first available font family and style.

Add tests

Fixes #637.
