### PR TITLE
Meta inspector tab unselection makes codepane nil

### DIFF
--- a/src/NewTools-Inspector-Tests/StDummyEmptyClass.class.st
+++ b/src/NewTools-Inspector-Tests/StDummyEmptyClass.class.st
@@ -1,0 +1,9 @@
+"
+Class for testing the inspector behavior when there are no behaviors on the inspectee.
+"
+Class {
+	#name : 'StDummyEmptyClass',
+	#superclass : 'Object',
+	#category : 'NewTools-Inspector-Tests',
+	#package : 'NewTools-Inspector-Tests'
+}

--- a/src/NewTools-Inspector-Tests/StInspectionTest.class.st
+++ b/src/NewTools-Inspector-Tests/StInspectionTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : 'StInspectionTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'inspectionClass',
+		'presenter'
+	],
+	#category : 'NewTools-Inspector-Tests',
+	#package : 'NewTools-Inspector-Tests'
+}

--- a/src/NewTools-Inspector-Tests/StMetaInspectionTest.class.st
+++ b/src/NewTools-Inspector-Tests/StMetaInspectionTest.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : 'StMetaInspectionTest',
+	#superclass : 'StInspectionTest',
+	#category : 'NewTools-Inspector-Tests',
+	#package : 'NewTools-Inspector-Tests'
+}
+
+{ #category : 'running' }
+StMetaInspectionTest >> newInspectionOn: anObject [
+	"Answer a new inspection presenter for testing"
+
+	^ (inspectionClass on: anObject) open presenter
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> setUp [
+
+	super setUp.
+	inspectionClass := StMetaBrowserPresenter.
+
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> tearDown [ 
+
+	presenter ifNotNil: [ : p | p delete ].
+	super tearDown.
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> testInspectionMeta [
+
+	presenter := self newInspectionOn: Object new.
+	self 
+		assert: Object new inspectionMeta class
+		equals: inspectionClass
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> testOpenAndClosePresenter [
+
+	self
+		shouldnt: [ 
+			(inspectionClass on: Object new) 
+				open;
+				delete ]
+		raise: Error
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> testSelectedMethod [
+
+	presenter := self newInspectionOn: Object new.
+	self 
+		assert: presenter selectedMethod isCompiledMethod
+		description: 'It tests that when open on a non-empty class there is a selected method'
+
+]
+
+{ #category : 'running' }
+StMetaInspectionTest >> testSelectedMethodEmptyClass [
+
+	presenter := self newInspectionOn: StDummyEmptyClass new.
+	self 
+		assert: presenter selectedMethod isNil
+		description: 'It tests that when open on a empty class has not a selected method'.
+
+
+]

--- a/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
+++ b/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
@@ -76,7 +76,10 @@ StMetaBrowserPresenter >> connectPresenters [
 		transform: [ :aClass | self methodsOf: aClass ]
 		postTransmission: [ :destination | destination selectIndex: 1 ].
 
-	methods transmitDo: [ :aMethod | self updateSourceWith: aMethod ]
+	methods transmitDo: [ :aMethod |
+		self selectedMethod
+			ifNotNil: [ : s | 	self updateSourceWith: aMethod ]
+			ifNil: [ source beForObject: self model ] ]
 ]
 
 { #category : 'initialization' }
@@ -102,11 +105,11 @@ StMetaBrowserPresenter >> initializePresenters [
 		           yourself.
 
 	source := self newCode
-		          lineNumbers: StPharoSettings codeShowLineNumbers;
-		          beForMethod: self selectedMethod;
-		          whenSubmitDo: [ :aString | self compile: aString ];
-		          whenResetDo: [ self updateSourceWith: self selectedMethod ];
-		          yourself.
+					lineNumbers: StPharoSettings codeShowLineNumbers;
+			 		beForScripting;
+					whenSubmitDo: [ :aString | self compile: aString ];
+					whenResetDo: [ self updateSourceWith: self selectedMethod ];
+					yourself.
 
 	classes
 		selectPath: (Array new: classHierarchy size withAll: 1)
@@ -127,7 +130,7 @@ StMetaBrowserPresenter >> methodsOf: aClass [
 
 ]
 
-{ #category : 'accessing' }
+{ #category : 'backstops' }
 StMetaBrowserPresenter >> selectedClass [
 
 	^ classes selection selectedItem

--- a/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
+++ b/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
@@ -69,6 +69,17 @@ StMetaBrowserPresenter >> compile: aString [
 ]
 
 { #category : 'initialization' }
+StMetaBrowserPresenter >> connectPresenters [ 
+
+	classes
+		transmitTo: methods
+		transform: [ :aClass | self methodsOf: aClass ]
+		postTransmission: [ :destination | destination selectIndex: 1 ].
+
+	methods transmitDo: [ :aMethod | self updateSourceWith: aMethod ]
+]
+
+{ #category : 'initialization' }
 StMetaBrowserPresenter >> initializePresenters [
 
 	| classHierarchy |
@@ -96,11 +107,6 @@ StMetaBrowserPresenter >> initializePresenters [
 		          whenSubmitDo: [ :aString | self compile: aString ];
 		          whenResetDo: [ self updateSourceWith: self selectedMethod ];
 		          yourself.
-
-	classes
-		transmitTo: methods
-		transform: [ :aClass | self methodsOf: aClass ].
-	methods transmitDo: [ :aMethod | self updateSourceWith: aMethod ].
 
 	classes
 		selectPath: (Array new: classHierarchy size withAll: 1)

--- a/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
+++ b/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
@@ -79,7 +79,10 @@ StMetaBrowserPresenter >> connectPresenters [
 	methods transmitDo: [ :aMethod |
 		self selectedMethod
 			ifNotNil: [ : s | 	self updateSourceWith: aMethod ]
-			ifNil: [ source beForObject: self model ] ]
+			ifNil: [ 
+				source 
+					beForObject: self model;
+					text: String empty ] ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This PR handles the behavior when the Meta inspection tab is selected. If the class of the inspectee has methods, then automatically select the first available method in the code presenter and update its contents. If the class of the inspectee has no methods, then the code presenter acts an evaluator.

- Add post transmission to select automatically a method.
- Add tests for meta inspection presenter.
- Refactoring to connectPresenters.

Fixes: #507 
