### PR TITLE
Preventing "Run to" debugger command from raising update events, in order to prevent unnecessary (and broken) updates

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -1151,40 +1151,60 @@ StDebuggerActionModelTest >> testUpdateTopContext [
 
 { #category : 'tests - contexts' }
 StDebuggerActionModelTest >> testUpdateTopContextAfterSessionOperation [
-	|mockDebugActionModel context|
+
+	| mockDebugActionModel context |
 	context := [  ] asContext.
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepInto: context.
-	self assert: mockDebugActionModel tag equals: #updateTopContext.	
-	mockDebugActionModel clear; clearDebugSession.
-	
+	self assert: mockDebugActionModel tag equals: #updateTopContext.
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepOver: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
-	
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel stepThrough: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
-	
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
 	mockDebugActionModel restartContext: context.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
-	
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel returnValueFromExpression: 'nil' fromContext: [] asContext.
+	mockDebugActionModel
+		returnValueFromExpression: 'nil'
+		fromContext: [  ] asContext.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
-	
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel runToSelection: nil inContext: nil.
+	mockDebugActionModel runToSelection: nil inContext: StMockContext new.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession.
-	
+	mockDebugActionModel
+		clear;
+		clearDebugSession.
+
 	mockDebugActionModel := StMockDebuggerActionModel new.
-	mockDebugActionModel implement: nil inClass: nil forContext: nil.
+	mockDebugActionModel
+		implement: nil
+		inClass: nil
+		forContext: StMockContext new.
 	self assert: mockDebugActionModel tag equals: #updateTopContext.
-	mockDebugActionModel clear; clearDebugSession
+	mockDebugActionModel
+		clear;
+		clearDebugSession
 ]

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -406,6 +406,59 @@ StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlined
 ]
 
 { #category : 'tests - context inspector' }
+StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlinedBlocksWithRunTo [
+
+	| contextItems inspectorTable newContextItems sourceCode targetCode beginIndex |
+	dbg := self debuggerOn:
+		       StTestDebuggerProvider new sessionWithInlinedLoop.
+	inspectorTable := dbg inspector getRawInspectorPresenterOrNil
+		                  attributeTable.
+
+	"We stop on the node `b := 0` node"
+	4 timesRepeat: [ dbg stepOver ].
+
+	contextItems := inspectorTable roots copy.
+	sourceCode := dbg context compiledCode sourceCode.
+
+	"We enter inlined block"
+	targetCode := 'nbMonth := nbMonth + 1'.
+	beginIndex := sourceCode indexOfSubCollection: targetCode.
+	dbg code selectionInterval:
+		(Interval from: beginIndex to: beginIndex + targetCode size).
+	dbg runToSelection.
+
+	newContextItems := inspectorTable roots.
+
+	self assert: newContextItems size equals: contextItems size + 1.
+
+	1 to: contextItems size do: [ :i |
+		self
+			assert: (newContextItems at: i)
+			identicalTo: (contextItems at: i) ].
+
+	self assert:
+		(newContextItems at: contextItems size + 1) tempVariable
+			isTempVariable.
+	self
+		assert:
+		(newContextItems at: contextItems size + 1) tempVariable name
+		equals: 'list'.
+
+	"We leave inlined block"
+	targetCode := 'a := b * 42'.
+	beginIndex := sourceCode indexOfSubCollection: targetCode.
+	dbg code selectionInterval:
+		(Interval from: beginIndex to: beginIndex + targetCode size).
+	dbg runToSelection.
+
+	self assert: newContextItems size equals: contextItems size.
+	1 to: contextItems size do: [ :i |
+		self
+			assert: (newContextItems at: i)
+			identicalTo: (contextItems at: i) ]
+]
+
+{ #category : 'tests - context inspector' }
 StDebuggerTest >> testContextUnchangedAfterStepOver [
 	| currentContext |
 	

--- a/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
+++ b/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
@@ -267,6 +267,35 @@ StTestDebuggerProvider >> sessionWithDNUAfterStep [
 ]
 
 { #category : 'helpers' }
+StTestDebuggerProvider >> sessionWithInlinedLoop [
+
+	| context process sessionForTests |
+	context := [
+	           | a b nbMonth |
+	           a := 20.
+	           b := 0.
+	           nbMonth := 0.
+	           [ a > b ] whileTrue: [
+		           | list |
+		           nbMonth := nbMonth + 1.
+		           list := #( 1 2 3 ) asOrderedCollection collect: [ :e |
+			                   e + nbMonth ].
+		           b := b + 1 ].
+	           a := b * 42.
+	           ^ a ] asContext.
+	process := Process
+		           forContext: context
+		           priority: Processor userInterruptPriority.
+	sessionForTests := DebugSession
+		                   named: 'test sessionProviderForDebuggerTestsWithInlinedLoop'
+		                   on: process
+		                   startedAt: context.
+	sessionForTests exception:
+		(OupsNullException fromSignallerContext: context).
+	^ sessionForTests
+]
+
+{ #category : 'helpers' }
 StTestDebuggerProvider >> terminate [ 
 	session ifNotNil:[session clear].
 	session := nil

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -413,7 +413,10 @@ StDebuggerActionModel >> returnValueFromExpression: aString fromContext: aContex
 
 { #category : 'debug - execution' }
 StDebuggerActionModel >> runToSelection: aSelectionInterval inContext: aContext [
-	self session runToSelection: aSelectionInterval inContext: aContext.
+
+	previousASTScope := aContext sourceNodeExecuted scope.
+	self preventUpdatesDuring: [
+		self session runToSelection: aSelectionInterval inContext: aContext ].
 	self updateTopContext
 ]
 


### PR DESCRIPTION
Fixes #607 

In the debugger, "run to" from the debugger action model is doing steps on the debug session, which raise an update for each step.

However, to update the variable list in the inspector, the debugger uses the `previousASTScope` from the debugger action model, which isn't updated after each step when performing "run to". This could lead to duplicated temp variables when using "run to" to execute an inlined loop (see #607).

One simple solution is to prevent the debugger from updating after each step performed by the command, making only one big update after all steps instead.

This is cohesive with what the command should do because if we perform "run to" instead of steps, this is because we don't care of the intermediary updates.
This also makes the "run to" command A LOT faster.


The fix is for P12 but another similar fix should be done for P11 to fix #607 on P11