### PR TITLE
Fixed SubscriptionRegistry inspection freezing image

### DIFF
--- a/src/NewTools-Inspector-Extensions/Announcer.extension.st
+++ b/src/NewTools-Inspector-Extensions/Announcer.extension.st
@@ -8,34 +8,9 @@ Announcer >> hasSubscriptions [
 
 { #category : '*NewTools-Inspector-Extensions' }
 Announcer >> inspectionSubscriptions [
+
 	<inspectorPresentationOrder: 0 title: 'Subscriptions'>
-	| table |
-	
-	^ (table := SpTablePresenter new)
-		items: registry subscriptions asOrderedCollection;
-		beMultipleSelection;
-		addColumn: (SpStringTableColumn 
-			title: 'Subscriber' 
-			evaluated: [ :each | each subscriber asString ]);
-		addColumn: (SpStringTableColumn 
-			title: 'Announcement' 
-			evaluated: [ :each | each announcementClass printString ]);
-		addColumn: (SpStringTableColumn 
-			title: 'Kind' 
-			evaluated: [ :each | each className ]);
-		"addAction: (GLMGenericAction new
-				action: [ :table | self subscriptions reset. table update ]; 
-				iconName: #glamorousCancel;
-				title: 'Reset All(!)' translated;
-				shouldShowTitle: true);"
-		contextMenu: (SpMenuPresenter new 
-			addItem: [ :item | item
-				name: 'Reset subscription(s)';
-				action: [ 
-					table selectedItems do: [ :each | self removeSubscription: each ].
-					table refresh ] ];
-			yourself);
-		yourself
+	^ registry inspectionSubscriptions
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }

--- a/src/NewTools-Inspector-Extensions/SubscriptionRegistry.extension.st
+++ b/src/NewTools-Inspector-Extensions/SubscriptionRegistry.extension.st
@@ -2,11 +2,28 @@ Extension { #name : 'SubscriptionRegistry' }
 
 { #category : '*NewTools-Inspector-Extensions' }
 SubscriptionRegistry >> inspectionSubscriptions [
-	<inspectorPresentationOrder: 0 title: 'Subscriptions'>
 
-	^ SpTablePresenter new
-		items: self subscriptions asOrderedCollection;
-		addColumn: (SpStringTableColumn title: 'Class' evaluated: [ :each | each announcementClass ]);
-		addColumn: (SpStringTableColumn title: 'Subscriber' evaluated: [ :each | each subscriber ]);
-		yourself
+	<inspectorPresentationOrder: 0 title: 'Subscriptions'>
+	| table |
+	^ (table := SpTablePresenter new)
+		  items: self subscriptions asOrderedCollection;
+		  beMultipleSelection;
+		  addColumn: (SpStringTableColumn
+				   title: 'Subscriber'
+				   evaluated: [ :each | each subscriber asString ]);
+		  addColumn: (SpStringTableColumn
+				   title: 'Announcement'
+				   evaluated: [ :each | each announcementClass printString ]);
+		  addColumn: (SpStringTableColumn
+				   title: 'Kind'
+				   evaluated: [ :each | each className ]);
+		  contextMenu: (SpMenuPresenter new
+				   addItem: [ :item |
+					   item
+						   name: 'Remove selected subscription(s)';
+						   action: [
+							   table selectedItems do: [ :each | self remove: each ].
+							   table items: self subscriptions asOrderedCollection ] ];
+				   yourself);
+		  yourself
 ]


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/15005

There was a table of subscriptions in both `Announcer` and `SubscriptionRegistry`, showing same items, yet each implemented separately and differently, only `SubscriptionRegistry` causing the issue.

This PR replaces the implementation in `SubscriptionRegistry` by the one from `Announcer`, as well as making the one in `Announcer` just call the one from `SubscriptionRegistry`, thus removing duplicated code.