### PR TITLE
Fastening debugger stack navigation

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -127,8 +127,7 @@ StDebuggerContext >> printOn: aStream [
 { #category : 'nodes' }
 StDebuggerContext >> receiverNodes [
 
-	^ self context receiver allInspectorNodes reject: [ :node | 
-		  node label = 'self' ]
+	^ self context receiver inspectorNodes
 ]
 
 { #category : 'nodes' }

--- a/src/NewTools-Debugger/StDebuggerInspector.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspector.class.st
@@ -8,11 +8,11 @@ I add specific debugger functionalities:
 Class {
 	#name : 'StDebuggerInspector',
 	#superclass : 'SpPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'inspector',
 		'model',
 		'label',
-		'rawInspectionSelectionCache',
 		'assertionFailure',
 		'lateralToolbar',
 		'currentLayoutSelector',
@@ -187,46 +187,6 @@ StDebuggerInspector >> model: aModel [
 	inspector model: model
 ]
 
-{ #category : 'accessing' }
-StDebuggerInspector >> rawInspectionSelectionCache [
-	^ rawInspectionSelectionCache ifNil: [ 
-		  rawInspectionSelectionCache := Dictionary new ]
-]
-
-{ #category : 'private' }
-StDebuggerInspector >> restoreRawInspectionSelectionForContext: aContext [
-	aContext ifNil: [ ^ self ].
-	self getRawInspectorPresenterOrNil
-		ifNotNil: [ :raw | 
-			| receiverClass selector path |
-			receiverClass := aContext receiver class.
-			selector := aContext selector.
-			path := self rawInspectionSelectionCache
-				at: receiverClass -> selector
-				ifAbsent: [ #() ].
-			path ifEmpty: [ self rawInspectionSelectionCache at: receiverClass ifAbsent: [ #() ] ].
-			path ifEmpty: [ | roots pathStart |
-					roots := raw attributeTable roots.
-					pathStart := 1.
-					1 to: roots size do: [ :i | 
-						(roots at: i) key = 'Temps' ifTrue: [ pathStart := i ] ].
-					path := {pathStart. 1} ].
-			raw selectPath: path ]
-]
-
-{ #category : 'private' }
-StDebuggerInspector >> saveRawInspectionSelectionForContext: aContext [
-	| selectionPath |
-	aContext ifNil: [ ^ self ].
-	selectionPath := self getRawInspectorSelectedPath.
-	self rawInspectionSelectionCache
-		at: aContext receiver class -> aContext selector
-		put: selectionPath.
-	self rawInspectionSelectionCache
-		at: aContext receiver class
-		put: selectionPath
-]
-
 { #category : 'layout' }
 StDebuggerInspector >> setAssertionLayout [
 	currentLayoutSelector := self assertionLayoutSelector.
@@ -298,14 +258,13 @@ StDebuggerInspector >> updateLayoutForContexts: aContext isAssertionFailure: isT
 StDebuggerInspector >> updateWith: inspectedObject [
 
 	| oldContext newContext |
-	oldContext := self model inspectedObject ifNotNil: [ :dbgCtx | 
+	oldContext := self model inspectedObject ifNotNil: [ :dbgCtx |
 		              dbgCtx context ].
 	newContext := inspectedObject ifNotNil: [ :dbgCtx | dbgCtx context ].
-	(self shouldUpdateContext: oldContext with: newContext) ifFalse: [ ^ self ].
+	(self shouldUpdateContext: oldContext with: newContext) ifFalse: [
+		^ self ].
 
 	shouldBeUpdated := false.
-	self saveRawInspectionSelectionForContext: oldContext.
 	self model: (self debuggerInspectorModelClass on: inspectedObject).
-	self updateEvaluationPaneReceiver.
-	self restoreRawInspectionSelectionForContext: newContext
+	self updateEvaluationPaneReceiver
 ]

--- a/src/NewTools-Debugger/StDebuggerInspector.class.st
+++ b/src/NewTools-Debugger/StDebuggerInspector.class.st
@@ -8,7 +8,6 @@ I add specific debugger functionalities:
 Class {
 	#name : 'StDebuggerInspector',
 	#superclass : 'SpPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'inspector',
 		'model',


### PR DESCRIPTION
Fixes #584
The whole discussion is in this issue.

To fasten the navigation of the debugger stack, I removed the debugger inspector selection remembrance mechanism because it :

- makes the debugger inspector too long to update. Removing it speeds up makes the  process  twice faster
- is not accurate
- is not much useful, in the end ?

Furthermore, I modified the way the `#receiverNodes` are built for an `StDebuggerContext` object. It used to collect allInspectorNodes and then reject the `self` node, like this:

```Smalltalk
receiverNodes

	^ self context receiver allInspectorNodes reject: [ :node | 
		  node label = 'self' ]
```

while `#allInspectorNodes` actually adds a `self` node to the nodes returned by `#inspectorNodes`:

```Smalltalk
allInspectorNodes
	"Answer a list of attributes as nodes"

	^ { StInspectorSelfNode hostObject: self }, 
		self inspectorNodes
```

So to spare an unncessary filter, I changed `#receiverNodes` to this equivalent method:

```Smalltalk
receiverNodes

	^ self context receiver inspectorNodes
```

If you have some examples of programs to debug for which the stack navigation was slow, I'm eager to know
