### PR TITLE
New Finder

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -91,9 +91,10 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Scopes-Resources-A-Tests';
 			package: 'NewTools-Scopes-Resources-B-Tests';
 			package: 'NewTools-Scopes-Resources-C-Tests';
+			package: 'NewTools-Scopes-Tests';
 			"Finder"			
 			package: 'NewTools-Finder';
-			package: 'NewTools-Scopes-Tests' with: [ spec requires: #('NewTools-Finder') ].
+			package: 'NewTools-Finder-Tests' with: [ spec requires: #('NewTools-Finder') ].
 
 		spec
 			group: 'Core' with: #( 'NewTools-Core' 'NewTools-Morphic' );

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -90,7 +90,10 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Scopes-Tests';
 			package: 'NewTools-Scopes-Resources-A-Tests';
 			package: 'NewTools-Scopes-Resources-B-Tests';
-			package: 'NewTools-Scopes-Resources-C-Tests'.
+			package: 'NewTools-Scopes-Resources-C-Tests';
+			"Finder"			
+			package: 'NewTools-Finder';
+			package: 'NewTools-Scopes-Tests' with: [ spec requires: #('NewTools-Finder') ].
 
 		spec
 			group: 'Core' with: #( 'NewTools-Core' 'NewTools-Morphic' );
@@ -147,6 +150,11 @@ BaselineOfNewTools >> baseline: spec [
 						'NewTools-Scopes-Resources-B-Tests' 
 						'NewTools-Scopes-Resources-C-Tests' 
 						'NewTools-Scopes-Tests');
+			"Finder"
+			group: #Finder with: #(
+						'NewTools-Finder'
+						'NewTools-Finder-Tests');
+
 			group: 'default' with: #( 
 						'Playground' 
 						'Inspector' 
@@ -158,7 +166,8 @@ BaselineOfNewTools >> baseline: spec [
 				   		'Spotter'
             			'RewriterTools'
 						'ScopesEditor'
-						'FileBrowser') ]
+						'FileBrowser'
+						'Finder') ]
 ]
 
 { #category : 'external projects' }

--- a/src/NewTools-Finder-Tests/StFinderClassTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderClassTest.class.st
@@ -1,0 +1,104 @@
+Class {
+	#name : 'StFinderClassTest',
+	#superclass : 'StFinderTest',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}
+
+{ #category : 'running' }
+StFinderClassTest >> setUp [
+
+	super setUp.
+	presenterModel currentSearch: StFinderClassSearch new
+	
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForExactCaseInsensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'stfindermock'.
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForExactCaseInsensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'stfindermocka'.
+
+	results := presenter resultTree roots.
+	self 
+		assertCollection: (results collect: [ : r | r content name ])
+		hasSameElements: #(#StFinderMockA #StFinderMocka).
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForExactCaseSensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'StFinderMock'.
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForExactCaseSensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'StFinderMockA'.
+
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForRegexpStartWithCaseInsensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseInsensitive.
+	self doSearch: '^StFinderMockA'.	
+	results := presenter resultTree roots.
+
+	self 
+		assertCollection: (results collect: [ : r | r content name ])
+		hasSameElements: #(#StFinderMockA #StFinderMocka).
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSearchForRegexpStartWithCaseSensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseSensitive.
+	self doSearch: '^StFinderMockA'.
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderClassTest >> testSubstringSearchNonExistingClass [
+
+	self openInstance.
+	self doSearch: 'NonExistingClass'.
+
+	self assertEmpty: presenter resultTree roots
+]

--- a/src/NewTools-Finder-Tests/StFinderClassTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderClassTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'StFinderClassTest',
 	#superclass : 'StFinderTest',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Core',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Finder-Tests/StFinderClassTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderClassTest.class.st
@@ -32,12 +32,12 @@ StFinderClassTest >> testSearchForExactCaseInsensitiveStringSucess [
 	
 	self openInstance.
 	self setExactAndCaseInsensitive.
-	self doSearch: 'stfindermocka'.
+	self doSearch: 'stfindermockc'.
 
 	results := presenter resultTree roots.
 	self 
 		assertCollection: (results collect: [ : r | r content name ])
-		hasSameElements: #(#StFinderMockA #StFinderMocka).
+		hasSameElements: #(#StFinderMockC).
 ]
 
 { #category : 'tests' }
@@ -58,7 +58,7 @@ StFinderClassTest >> testSearchForExactCaseSensitiveStringSucess [
 	
 	self openInstance.
 	self setExactAndCaseSensitive.
-	self doSearch: 'StFinderMockA'.
+	self doSearch: 'StFinderMockC'.
 
 	results := presenter resultTree roots.
 	self 
@@ -73,12 +73,12 @@ StFinderClassTest >> testSearchForRegexpStartWithCaseInsensitive [
 	
 	self openInstance.
 	self setRegexAndCaseInsensitive.
-	self doSearch: '^StFinderMockA'.	
+	self doSearch: '^StFinderMock'.	
 	results := presenter resultTree roots.
 
 	self 
 		assertCollection: (results collect: [ : r | r content name ])
-		hasSameElements: #(#StFinderMockA #StFinderMocka).
+		hasSameElements: #(#StFinderMockC #StFinderMocka #StFinderMockB).
 ]
 
 { #category : 'tests' }
@@ -88,7 +88,7 @@ StFinderClassTest >> testSearchForRegexpStartWithCaseSensitive [
 	
 	self openInstance.
 	self setRegexAndCaseSensitive.
-	self doSearch: '^StFinderMockA'.
+	self doSearch: '^StFinderMockC'.
 	results := presenter resultTree roots.
 	self 
 		assert: results size

--- a/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'StFinderExampleTest',
+	#superclass : 'StFinderTest',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}
+
+{ #category : 'running' }
+StFinderExampleTest >> setUp [
+
+	super setUp.
+	presenterModel currentSearch: StFinderExampleSearch new.
+	self openInstance.
+	
+]
+
+{ #category : 'running' }
+StFinderExampleTest >> testConcatenationSearch [
+
+	| results |
+	
+	self doSearch: '''a''. ''b''. ''ab'''.
+	
+	results := presenter resultTree roots.
+	self assert: results size equals: 2.
+]

--- a/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
@@ -24,3 +24,44 @@ StFinderExampleTest >> testConcatenationSearch [
 	results := presenter resultTree roots.
 	self assert: results size equals: 2.
 ]
+
+{ #category : 'running' }
+StFinderExampleTest >> testFactorialSearch [
+
+	| results firstResult secondResult |
+	
+	self doSearch: '3 . 6'.
+	
+	results := presenter resultTree roots.
+	firstResult := results contents first.
+	secondResult := results contents second.
+
+	self assert: firstResult content selector equals: #slowFactorial.
+	self assert: secondResult content selector equals: #factorial.
+
+]
+
+{ #category : 'running' }
+StFinderExampleTest >> testIndexOfSearch [
+
+	| results |
+	
+	self doSearch: '{2. 4. 5. 1}. 5. 3'.
+	
+	results := presenter resultTree roots.
+
+	self assert: (results contents anySatisfy: [ : r | r content selector = #indexOf: ])
+
+]
+
+{ #category : 'running' }
+StFinderExampleTest >> testNegatedSearch [
+
+	| results singleResult |
+	
+	self doSearch: '2 . -2'.
+	
+	results := presenter resultTree roots.
+	singleResult := results contents anyOne.
+	self assert: singleResult content selector equals: #negated.
+]

--- a/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'StFinderExampleTest',
 	#superclass : 'StFinderTest',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Core',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Finder-Tests/StFinderMockB.class.st
+++ b/src/NewTools-Finder-Tests/StFinderMockB.class.st
@@ -1,0 +1,6 @@
+Class {
+	#name : 'StFinderMockB',
+	#superclass : 'Object',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}

--- a/src/NewTools-Finder-Tests/StFinderMockB.class.st
+++ b/src/NewTools-Finder-Tests/StFinderMockB.class.st
@@ -1,6 +1,7 @@
 Class {
 	#name : 'StFinderMockB',
 	#superclass : 'Object',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Mocks',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Mocks'
 }

--- a/src/NewTools-Finder-Tests/StFinderMockC.class.st
+++ b/src/NewTools-Finder-Tests/StFinderMockC.class.st
@@ -1,0 +1,30 @@
+"
+Class to hold sample selectors to find.
+"
+Class {
+	#name : 'StFinderMockC',
+	#superclass : 'Object',
+	#category : 'NewTools-Finder-Tests-Mocks',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Mocks'
+}
+
+{ #category : 'accessing' }
+StFinderMockC >> aBCSelectorSearchForRegexpStartWithCase [
+	"mock example"
+]
+
+{ #category : 'accessing' }
+StFinderMockC >> abcSelectorSearchForRegexpStartWithoutCase [
+	"mock example"
+]
+
+{ #category : 'accessing' }
+StFinderMockC >> selectorSearchForRegexpWithCaseEndsWithAbc [
+	"mock example"
+]
+
+{ #category : 'accessing' }
+StFinderMockC >> selectorSearchForRegexpWithoutCaseEndsWithabc [
+	"mock example"
+]

--- a/src/NewTools-Finder-Tests/StFinderMocka.class.st
+++ b/src/NewTools-Finder-Tests/StFinderMocka.class.st
@@ -1,0 +1,6 @@
+Class {
+	#name : 'StFinderMocka',
+	#superclass : 'Object',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}

--- a/src/NewTools-Finder-Tests/StFinderMocka.class.st
+++ b/src/NewTools-Finder-Tests/StFinderMocka.class.st
@@ -1,6 +1,7 @@
 Class {
 	#name : 'StFinderMocka',
 	#superclass : 'Object',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Mocks',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Mocks'
 }

--- a/src/NewTools-Finder-Tests/StFinderPackageTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderPackageTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'StFinderPackageTest',
 	#superclass : 'StFinderTest',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Core',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Finder-Tests/StFinderPackageTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderPackageTest.class.st
@@ -1,0 +1,104 @@
+Class {
+	#name : 'StFinderPackageTest',
+	#superclass : 'StFinderTest',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}
+
+{ #category : 'running' }
+StFinderPackageTest >> setUp [
+
+	super setUp.
+	presenterModel currentSearch: StFinderPackageSearch new
+	
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForExactCaseInsensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'newtools-finder'.
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForExactCaseInsensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'newtools-finder-tests'.
+
+	results := presenter resultTree roots.
+	self 
+		assertCollection: (results collect: [ : r | r content name ])
+		hasSameElements: #('NewTools-Finder-Tests').
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForExactCaseSensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'NewTools-Finder'.	
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForExactCaseSensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'NewTools-Finder-Tests'.
+
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForRegexpStartWithCaseInsensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseInsensitive.
+	self doSearch: '^newTools-finder'.	
+	results := presenter resultTree roots.
+
+	self 
+		assertCollection: (results collect: [ : r | r content name ])
+		hasSameElements: #(#'NewTools-Finder-Tests').
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSearchForRegexpStartWithCaseSensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseSensitive.
+	self doSearch: '^NewTools-Finder'.	
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderPackageTest >> testSubstringSearchNonExistingPackage [
+
+	self openInstance.
+	
+	self doSearch: 'NonExistingPackage'.
+	self assertEmpty: presenter resultTree roots
+]

--- a/src/NewTools-Finder-Tests/StFinderSelectorTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderSelectorTest.class.st
@@ -1,0 +1,135 @@
+Class {
+	#name : 'StFinderSelectorTest',
+	#superclass : 'StFinderTest',
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}
+
+{ #category : 'running' }
+StFinderSelectorTest >> setUp [
+
+	super setUp.
+	presenterModel currentSearch: StFinderSelectorSearch new
+	
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForExactCaseInsensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'abcSelector'.
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForExactCaseInsensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseInsensitive.
+	self doSearch: 'abcSelectorSearchForRegexpStartWithoutCase'.
+
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForExactCaseSensitiveStringMissing [
+
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'abcselectorSearchForRegexpStartWithoutCase'.	
+
+	self assertEmpty: presenter resultTree roots.
+
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForExactCaseSensitiveStringSucess [
+
+	| results |
+	
+	self openInstance.
+	self setExactAndCaseSensitive.
+	self doSearch: 'abcSelectorSearchForRegexpStartWithoutCase'.
+
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForRegexpEndsWithCaseInsensitive [
+
+	| results |
+	
+	self setRegexAndCaseInsensitive.
+	self doSearch: '.*EndsWithAbc$'.
+	results := presenter resultTree roots.
+
+	self 
+		assertCollection: (results collect: #content)
+		hasSameElements: #(#selectorSearchForRegexpWithCaseEndsWithAbc #selectorSearchForRegexpWithoutCaseEndsWithabc).
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForRegexpEndsWithCaseSensitive [
+
+	| results |
+	
+	self setRegexAndCaseSensitive.
+	self doSearch: '.*EndsWithAbc$'.
+	results := presenter resultTree roots.
+
+	self 
+		assertCollection: (results collect: #content)
+		hasSameElements: #(#selectorSearchForRegexpWithCaseEndsWithAbc).
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForRegexpStartWithCaseInsensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseInsensitive.
+	self doSearch: '^aBC.*'.
+	results := presenter resultTree roots.
+
+	self 
+		assertCollection: (results collect: #content)
+		hasSameElements: #(#aBCSelectorSearchForRegexpStartWithCase #abcSelectorSearchForRegexpStartWithoutCase).
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSearchForRegexpStartWithCaseSensitive [
+
+	| results |
+	
+	self openInstance.
+	self setRegexAndCaseSensitive.
+	self doSearch: '^aBC.*'.
+
+	results := presenter resultTree roots.
+	self 
+		assert: results size
+		equals: 1.
+]
+
+{ #category : 'tests' }
+StFinderSelectorTest >> testSubstringSearchNonExistingSelector [
+
+	self openInstance.
+	
+	presenterModel 
+		currentSearch: StFinderSelectorSearch new;	
+		search: 'lalala'.
+	self assertEmpty: presenter resultTree roots
+]

--- a/src/NewTools-Finder-Tests/StFinderSelectorTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderSelectorTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'StFinderSelectorTest',
 	#superclass : 'StFinderTest',
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Core',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -77,7 +77,6 @@ StFinderTest >> setRegexAndCaseSensitive [
 StFinderTest >> setUp [
 	super setUp.
 
-	StFinderMockA new.
 	presenter := self classToTest basicNew. 
 	presenter setModelBeforeInitialization: StFinderModel new.
 	presenter 

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : 'StFinderTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'application',
+		'presenter',
+		'presenterModel'
+	],
+	#category : 'NewTools-Finder-Tests',
+	#package : 'NewTools-Finder-Tests'
+}
+
+{ #category : 'running' }
+StFinderTest >> classToTest [
+
+	^ StFinderPresenter
+]
+
+{ #category : 'tests' }
+StFinderTest >> doSearch: searchPattern [
+
+	presenter searchBar searchInput text: searchPattern.
+	presenterModel 
+		searchString: searchPattern;
+		search.
+]
+
+{ #category : 'running' }
+StFinderTest >> finderPackagesForTests [
+
+	^ #('NewTools-Finder-Tests')
+]
+
+{ #category : 'running' }
+StFinderTest >> openInstance [
+
+	presenter open.
+	presenter window initialPosition: 1 @ 1.
+]
+
+{ #category : 'initialization' }
+StFinderTest >> setExactAndCaseInsensitive [
+
+	presenter searchOptions exactCheckBox click.
+	presenter searchOptions caseCheckBox state: false.
+]
+
+{ #category : 'initialization' }
+StFinderTest >> setExactAndCaseSensitive [
+
+	presenter searchOptions exactCheckBox click.
+	presenter searchOptions caseCheckBox click.
+]
+
+{ #category : 'tests' }
+StFinderTest >> setRegex [
+		
+	presenter searchOptions regexpCheckBox click.
+]
+
+{ #category : 'tests' }
+StFinderTest >> setRegexAndCaseInsensitive [
+		
+	self setRegex.
+	presenter searchOptions caseCheckBox state: false.
+]
+
+{ #category : 'tests' }
+StFinderTest >> setRegexAndCaseSensitive [
+		
+	self setRegex.
+	presenter searchOptions caseCheckBox click.
+]
+
+{ #category : 'running' }
+StFinderTest >> setUp [
+	super setUp.
+
+	presenter := self classToTest basicNew. 
+	presenter setModelBeforeInitialization: StFinderModel new.
+	presenter 
+		application: StPharoApplication new;
+		initialize;
+		searchInPackages: self finderPackagesForTests.
+	presenterModel := presenter model.
+]
+
+{ #category : 'running' }
+StFinderTest >> tearDown [
+
+	presenter withWindowDo: [ :window | window close ].
+	super tearDown
+]

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -6,8 +6,9 @@ Class {
 		'presenter',
 		'presenterModel'
 	],
-	#category : 'NewTools-Finder-Tests',
-	#package : 'NewTools-Finder-Tests'
+	#category : 'NewTools-Finder-Tests-Core',
+	#package : 'NewTools-Finder-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'StFinderTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'application',
 		'presenter',
 		'presenterModel'
 	],

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -77,6 +77,7 @@ StFinderTest >> setRegexAndCaseSensitive [
 StFinderTest >> setUp [
 	super setUp.
 
+	StFinderMockA new.
 	presenter := self classToTest basicNew. 
 	presenter setModelBeforeInitialization: StFinderModel new.
 	presenter 

--- a/src/NewTools-Finder-Tests/package.st
+++ b/src/NewTools-Finder-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Finder-Tests' }

--- a/src/NewTools-Finder/CompiledMethod.extension.st
+++ b/src/NewTools-Finder/CompiledMethod.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'CompiledMethod' }
+
+{ #category : '*NewTools-Finder' }
+CompiledMethod >> selectorForFinder [
+	"Answer a <Symbol> with the receiver's selector for the Finder tool"
+
+	^ self selector.
+]

--- a/src/NewTools-Finder/MethodFinder.extension.st
+++ b/src/NewTools-Finder/MethodFinder.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'MethodFinder' }
+
+{ #category : '*NewTools-Finder' }
+MethodFinder >> methodFinderSendClass [
+
+	^ MethodFinderSend
+]
+
+{ #category : '*NewTools-Finder' }
+MethodFinder >> possibleSolutionsForInput: inputCollection [
+
+	| sends |
+	
+	sends := OrderedCollection new.
+	inputCollection permutationsDo: [ :permutation |
+		| foundPermutationSends args receiver |
+		args := permutation allButFirst.
+		receiver := permutation first.
+		foundPermutationSends := 
+			(receiver evaluate class allSelectorsToTestInMethodFinderWithArity: inputCollection size - 1) collect: [ : method |
+			                         self methodFinderSendClass
+				                         receiver: receiver evaluate
+				                         selector: method
+				                         withArguments: (args collect: #evaluate) ].
+		sends addAll: foundPermutationSends ].
+	^ sends
+]

--- a/src/NewTools-Finder/OpalCompiler.extension.st
+++ b/src/NewTools-Finder/OpalCompiler.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'OpalCompiler' }
+
+{ #category : '*NewTools-Finder' }
+OpalCompiler >> evaluateWithTimeOut: anInteger [ 
+
+	| runner |
+
+	runner := TKTLocalProcessTaskRunner new.
+	^ runner 
+		schedule: [ self evaluate ] asTask
+		timeout: anInteger milliSeconds.
+
+]

--- a/src/NewTools-Finder/RBLiteralValueNode.extension.st
+++ b/src/NewTools-Finder/RBLiteralValueNode.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'RBLiteralValueNode' }
+
+{ #category : '*NewTools-Finder' }
+RBLiteralValueNode >> evaluateForReceiver: aReceiver withTimeout: anInteger [ 
+	"evaluate the AST binding self to the receiver and taking its variables"
+
+	^ value
+]

--- a/src/NewTools-Finder/RBValueNode.extension.st
+++ b/src/NewTools-Finder/RBValueNode.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : 'RBValueNode' }
+
+{ #category : '*NewTools-Finder' }
+RBValueNode >> evaluateForReceiver: aReceiver withTimeout: anInteger [ 
+	"evaluate the AST binding self to the receiver and taking its variables"
+
+	^ aReceiver class compiler
+		ast: self asDoit;
+		receiver: aReceiver;
+		logged: false;
+		evaluateWithTimeOut: anInteger
+]
+
+{ #category : '*NewTools-Finder' }
+RBValueNode >> evaluateWithTimeOut: anInteger [ 
+	"evaluate the AST with a nil  receiver"
+	
+	^ self 
+		evaluateForReceiver: nil 
+		withTimeout: anInteger
+]

--- a/src/NewTools-Finder/StFinderBrowseCommand.class.st
+++ b/src/NewTools-Finder/StFinderBrowseCommand.class.st
@@ -1,0 +1,50 @@
+"
+Command to spawn a browser opened on the selected result item.
+"
+Class {
+	#name : 'StFinderBrowseCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderBrowseCommand class >> defaultDescription [
+
+	^ 'Browse selection'
+]
+
+{ #category : 'initialization' }
+StFinderBrowseCommand class >> defaultIconName [
+
+	^ #smallHierarchyBrowser
+]
+
+{ #category : 'default' }
+StFinderBrowseCommand class >> defaultName [
+
+	^ 'Browse'
+]
+
+{ #category : 'initialization' }
+StFinderBrowseCommand class >> defaultShortcut [
+
+	^ $b meta
+]
+
+{ #category : 'testing' }
+StFinderBrowseCommand >> canBeExecuted [ 
+
+	^ super canBeExecuted and: [ 
+		self resultTree selectedItems size = 1
+			and: [ self selectedItem isClassResult ] ]
+]
+
+{ #category : 'executing' }
+StFinderBrowseCommand >> execute [
+	"Browse the selection"
+
+	self selectedItem browseAction
+
+]

--- a/src/NewTools-Finder/StFinderClassResult.class.st
+++ b/src/NewTools-Finder/StFinderClassResult.class.st
@@ -87,13 +87,19 @@ StFinderClassResult >> getCompiledMethodFrom: aStFinderSelectorResult [
 	^ self content >> aStFinderSelectorResult content
 ]
 
+{ #category : 'copying' }
+StFinderClassResult >> hasSelectorParent [
+
+	^ self parent notNil and: [ self parent isSelectorResult ]
+]
+
 { #category : 'action' }
 StFinderClassResult >> referencesAction [
 
 	self navigation browseAllUsersOfClassOrTrait: self content
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 StFinderClassResult >> selectItemIn: aSpTreePresenter [ 
 
 	| pathIndexCollection |

--- a/src/NewTools-Finder/StFinderClassResult.class.st
+++ b/src/NewTools-Finder/StFinderClassResult.class.st
@@ -1,0 +1,104 @@
+"
+I represent a class as a ̀FinderResult̀.
+"
+Class {
+	#name : 'StFinderClassResult',
+	#superclass : 'StFinderResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderClassResult class >> matches: aCompiledMethod [ 
+	"Answer <true> if aClassOraTaCompositionElement is a <Class>"
+	
+	^ aCompiledMethod methodClass isClass
+]
+
+{ #category : 'action' }
+StFinderClassResult >> browseAction [
+	"Opens the system browser on its content. If it has a `StFinderSelectorResult` as a parent,
+	then opens the system browser on its content with the selector from its parent focused."
+
+	self hasSelectorParent
+		ifTrue: [
+			self browser
+				openOnClass: self content
+				selector: self parent content ]
+		ifFalse: [ content browse ]
+]
+
+{ #category : 'accessing' }
+StFinderClassResult >> content: aCompiledMethodOrClass [
+
+	content := aCompiledMethodOrClass isCompiledMethod 
+		ifTrue: [  aCompiledMethodOrClass methodClass ]
+		ifFalse: [ aCompiledMethodOrClass ]
+]
+
+{ #category : 'copying' }
+StFinderClassResult >> copyTo: aWriteStream [ 
+
+	aWriteStream << self content name.
+	self hasSelectorParent
+		ifTrue: [ 
+			aWriteStream
+				<< '>>#';
+				<< self parent content ]
+]
+
+{ #category : 'displaying' }
+StFinderClassResult >> displayIcon [
+
+	(self content inheritsFrom: Exception) ifTrue: [ ^ self iconNamed: #exception ].
+	self content isAbstract ifTrue: [ ^ self iconNamed: #classAbstract ].
+	self content isDeprecated ifTrue: [ ^ self iconNamed: #smallNew ].
+	self content isObsolete ifTrue: [ ^ self iconNamed: #error ].
+	^ self iconNamed: #class
+]
+
+{ #category : 'action' }
+StFinderClassResult >> forFinderPreview: aSpCodePresenter [ 
+
+	^ (self content isClass and: [ self parent notNil and: [ self parent isPackageResult not ] ])
+		ifTrue: [ 
+			self 
+				displaySource: self getCompiledMethod
+				in: aSpCodePresenter ]
+		ifFalse: [ 
+			aSpCodePresenter 
+				beForScripting;
+				text: self content definitionString ]
+]
+
+{ #category : 'accessing' }
+StFinderClassResult >> getCompiledMethod [
+	"Answer a <CompiledMethod> representing the currently found content"
+
+	^ self parent content isCompiledMethod
+		ifTrue: [ self parent content ]
+		ifFalse: [ self content >> self parent content ]
+]
+
+{ #category : 'instance creation' }
+StFinderClassResult >> getCompiledMethodFrom: aStFinderSelectorResult [ 
+
+	^ self content >> aStFinderSelectorResult content
+]
+
+{ #category : 'action' }
+StFinderClassResult >> referencesAction [
+
+	self navigation browseAllUsersOfClassOrTrait: self content
+]
+
+{ #category : 'as yet unclassified' }
+StFinderClassResult >> selectItemIn: aSpTreePresenter [ 
+
+	| pathIndexCollection |
+	pathIndexCollection := aSpTreePresenter pathIndexOf: { self }.
+	aSpTreePresenter 
+		selectPath: pathIndexCollection scrollToSelection: true;
+		clickAtPath: pathIndexCollection
+]

--- a/src/NewTools-Finder/StFinderClassSearch.class.st
+++ b/src/NewTools-Finder/StFinderClassSearch.class.st
@@ -1,0 +1,99 @@
+"
+I implement a search for classes in a given environment.
+
+I am a subclass of ̀FinderSearch̀ and am used by ̀FinderModel̀ to perform searches
+for classes.
+
+"
+Class {
+	#name : 'StFinderClassSearch',
+	#superclass : 'StFinderSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'private' }
+StFinderClassSearch >> buildResult: aListOfClasses [
+
+	^ aListOfClasses
+		  collect: [ :each |
+			  | newResult |
+			  newResult := StFinderClassResult new content: each.
+			  each selectors sort do: [ :selector |
+				 newResult addChild: (StFinderSelectorResult new content: selector) ].
+			  newResult ]
+		  as: OrderedCollection
+]
+
+{ #category : 'information' }
+StFinderClassSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Classes'
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchByRegexCaseInsensitive: aString in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	| regex |
+	regex := aString asRegexIgnoringCase.
+	^ self 
+		buildResult: (self 
+			searchClasses: [ :class | regex search: class name ] 
+			in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchByRegexCaseSensitive: aString in: aRBBrowserEnvironment [ 
+	"Perform a search given aString representing a regular expression in aRBBrowserEnvironment."
+
+	| regex |
+	regex := aString asRegex.
+	^ self 
+		buildResult: (self 
+			searchClasses: [ :class | regex search: class name ] 
+			in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchByStringExactInsensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchClasses: [ : class | class name asLowercase = aString asLowercase ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchByStringExactSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchClasses: [ : class | class name = aString ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchByStringSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchClasses: [ :class | class name includesSubstring: aString caseSensitive: true ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	^ self 
+		buildResult: (self searchClasses: [ :class | class name includesSubstring: aString caseSensitive: false ] 
+		in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderClassSearch >> searchClasses: aSelectBlock in: anEnvironment [
+
+	^ OrderedCollection streamContents: [ :stream |
+		  anEnvironment classesAndTraitsDo: [ :class |
+			  (aSelectBlock value: class) ifTrue: [ stream nextPut: class ] ] ]
+]

--- a/src/NewTools-Finder/StFinderCollapseAllCommand.class.st
+++ b/src/NewTools-Finder/StFinderCollapseAllCommand.class.st
@@ -1,0 +1,40 @@
+"
+Command to open a settings browser focused on the Finder settings.
+"
+Class {
+	#name : 'StFinderCollapseAllCommand',
+	#superclass : 'StFinderListingCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderCollapseAllCommand class >> defaultDescription [
+
+	^ 'Command to collapse all displayed results'
+]
+
+{ #category : 'default' }
+StFinderCollapseAllCommand class >> defaultIconName [
+
+	^ #refresh
+]
+
+{ #category : 'default' }
+StFinderCollapseAllCommand class >> defaultName [ 
+
+	^ 'Collapse all'
+]
+
+{ #category : 'default' }
+StFinderCollapseAllCommand class >> defaultShortcut [
+
+	^ $c meta
+]
+
+{ #category : 'executing' }
+StFinderCollapseAllCommand >> execute [
+
+	self resultTree collapseAll.
+]

--- a/src/NewTools-Finder/StFinderCommand.class.st
+++ b/src/NewTools-Finder/StFinderCommand.class.st
@@ -1,0 +1,58 @@
+"
+Abstract class grouping behavior for Finder tool operations. 
+It is based in the Commander frameworks.
+
+"
+Class {
+	#name : 'StFinderCommand',
+	#superclass : 'CmCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'accessing' }
+StFinderCommand >> application [
+
+	^ self context application
+]
+
+{ #category : 'accessing' }
+StFinderCommand >> applicationClass [
+
+	^ self application class
+]
+
+{ #category : 'testing' }
+StFinderCommand >> canBeExecuted [
+	"See superimplementor's comment"
+
+	^ self resultTreeItems notEmpty
+]
+
+{ #category : 'accessing' }
+StFinderCommand >> resultTree [
+
+	^ 	self context resultTree.
+]
+
+{ #category : 'accessing' }
+StFinderCommand >> resultTreeItems [
+	"Answer a <Collection> of finder results, each one an instance of a <StFinderResult> subclass"
+	
+	^ self resultTree roots
+]
+
+{ #category : 'accessing' }
+StFinderCommand >> selectedItem [
+	"Answer the currently selected <StFinderResult>. Valid for operations on a single selection"
+	
+	^ self resultTree selectedItem
+]
+
+{ #category : 'accessing' }
+StFinderCommand >> selectedItems [
+	"Answer a <Collection> of <StFinderResult> if there are selections, otherwise answer an empty collection"
+	
+	^ self resultTree selectedItems
+]

--- a/src/NewTools-Finder/StFinderCopySelectionCommand.class.st
+++ b/src/NewTools-Finder/StFinderCopySelectionCommand.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'StFinderCopySelectionCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderCopySelectionCommand class >> defaultDescription [
+
+	^ 'Copy the selected results'
+]
+
+{ #category : 'initialization' }
+StFinderCopySelectionCommand class >> defaultIconName [
+
+	^ #smallCopy
+]
+
+{ #category : 'default' }
+StFinderCopySelectionCommand class >> defaultName [ 
+
+	^ 'Copy selection'
+]
+
+{ #category : 'initialization' }
+StFinderCopySelectionCommand class >> defaultShortcut [
+
+	^ $f meta, $c meta
+]
+
+{ #category : 'executing' }
+StFinderCopySelectionCommand >> execute [
+	"Copy the selected finder results to the clipboard"
+
+	| selectorsText |
+	selectorsText := String streamContents: [ : stream | 
+		self selectedItems do: [ : r |
+			r copyTo: stream.
+			stream cr ] ].
+	Clipboard 
+		clipboardText: selectorsText 
+		informing: self selectedItems size asString , ' selectors copied to the Clipboard'
+]

--- a/src/NewTools-Finder/StFinderDebugItCommand.class.st
+++ b/src/NewTools-Finder/StFinderDebugItCommand.class.st
@@ -1,0 +1,43 @@
+"
+Command to debug a resulting expression from the Examples search mode in the Finder tool
+
+"
+Class {
+	#name : 'StFinderDebugItCommand',
+	#superclass : 'StFinderExecutionCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderDebugItCommand class >> defaultDescription [
+
+	^ 'Debug the selected example'
+]
+
+{ #category : 'initialization' }
+StFinderDebugItCommand class >> defaultIconName [
+
+	^ #smallDebugIt
+]
+
+{ #category : 'default' }
+StFinderDebugItCommand class >> defaultName [ 
+
+	^ 'Debug It'
+]
+
+{ #category : 'initialization' }
+StFinderDebugItCommand class >> defaultShortcut [
+
+	^ $d meta
+]
+
+{ #category : 'executing' }
+StFinderDebugItCommand >> execute [
+	"Debug the selected example result"
+
+	self selectedItem content debug
+
+]

--- a/src/NewTools-Finder/StFinderEnvironmentBar.class.st
+++ b/src/NewTools-Finder/StFinderEnvironmentBar.class.st
@@ -1,0 +1,73 @@
+"
+I am a widget for the ̀Finder̀ tool. I contain all widgets regarding the search environment.
+"
+Class {
+	#name : 'StFinderEnvironmentBar',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'chosenPackagesButton',
+		'allPackagesButton',
+		'statusLabel'
+	],
+	#category : 'NewTools-Finder-Widgets',
+	#package : 'NewTools-Finder',
+	#tag : 'Widgets'
+}
+
+{ #category : 'updating - widgets' }
+StFinderEnvironmentBar >> activateAllPackages [
+
+	allPackagesButton iconName: #radioButtonSelected.
+	chosenPackagesButton iconName: #radioButtonUnselected
+]
+
+{ #category : 'updating - widgets' }
+StFinderEnvironmentBar >> activateChosenPackages [
+
+	allPackagesButton iconName: #radioButtonUnselected.
+	chosenPackagesButton iconName: #radioButtonSelected
+]
+
+{ #category : 'layout' }
+StFinderEnvironmentBar >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  spacing: 2;
+		  vAlignCenter;
+		  add: statusLabel width: 180;
+		  add: allPackagesButton;
+		  add: chosenPackagesButton;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StFinderEnvironmentBar >> initializePresenters [
+
+	statusLabel := self newLabel.
+	chosenPackagesButton := self newButton
+		                        label: 'Packages…';
+		                        iconName: #radioButtonUnselected;
+		                        yourself.
+	allPackagesButton := self newButton
+		                     label: 'All Packages';
+		                     iconName: #radioButtonSelected;
+		                     yourself
+]
+
+{ #category : 'instance creation' }
+StFinderEnvironmentBar >> status: aString [
+
+	statusLabel label: aString
+]
+
+{ #category : 'events' }
+StFinderEnvironmentBar >> whenAllPackagesSelectedDo: aBlock [
+
+	allPackagesButton action: aBlock
+]
+
+{ #category : 'events' }
+StFinderEnvironmentBar >> whenPackagesSelectedDo: aBlock [
+
+	chosenPackagesButton action: aBlock
+]

--- a/src/NewTools-Finder/StFinderExampleResult.class.st
+++ b/src/NewTools-Finder/StFinderExampleResult.class.st
@@ -1,0 +1,58 @@
+"
+It wraps a `StMethodFinderSend`
+"
+Class {
+	#name : 'StFinderExampleResult',
+	#superclass : 'StFinderResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderExampleResult class >> matches: aCollection [ 
+
+	^ false
+]
+
+{ #category : 'do-its' }
+StFinderExampleResult >> debugIt [
+
+	self content debug.
+]
+
+{ #category : 'displaying' }
+StFinderExampleResult >> displayIcon [
+
+	^ self iconNamed: #page
+]
+
+{ #category : 'displaying' }
+StFinderExampleResult >> displayString [
+
+	^ self content selector
+]
+
+{ #category : 'private' }
+StFinderExampleResult >> forFinderPreview: aSpCodePresenter [ 
+
+	^ String empty
+]
+
+{ #category : 'instance creation' }
+StFinderExampleResult >> getCompiledMethodFrom: aStFinderSelectorResult [ 
+
+	^ self content receiver class lookupSelector: self content selector
+]
+
+{ #category : 'testing' }
+StFinderExampleResult >> isExampleResult [
+
+	^ true
+]
+
+{ #category : 'private' }
+StFinderExampleResult >> selectItemIn: aSpTreePresenter [ 
+
+
+]

--- a/src/NewTools-Finder/StFinderExampleSearch.class.st
+++ b/src/NewTools-Finder/StFinderExampleSearch.class.st
@@ -1,0 +1,137 @@
+"
+Implements a search for given example expressions.
+
+"
+Class {
+	#name : 'StFinderExampleSearch',
+	#superclass : 'StFinderSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'execution' }
+StFinderExampleSearch >> buildResult: aListOfStMethodFinderSend [
+
+	| results |
+	results := OrderedCollection new.
+
+	aListOfStMethodFinderSend do: [ : methodSend |
+		| foundResult |
+
+		foundResult := StFinderSelectorResult new content: methodSend.
+		results
+			detect: [ :elem | 	elem content selector = methodSend selector ]
+			ifFound: [ :elem | elem addChild: foundResult ]
+			ifNone: [
+				| newResult |
+				newResult := StFinderExampleResult new
+					             content: methodSend;
+					             addChild: foundResult;
+					             yourself.
+				results add: newResult ] ].
+
+	^ results
+]
+
+{ #category : 'execution' }
+StFinderExampleSearch >> computeDataObjects: aString [
+
+	| data dataObjects |
+	(aString includes: $.) ifFalse: [ ^ #(  ) ].
+	data := aString trimRight: [ :char |
+		        char isSeparator or: [ char = $. ] ].
+	
+	[
+		dataObjects := self parseAsNodes: data.
+		dataObjects do: [ : e | e evaluateWithTimeOut: self evaluationTimeout ] ]
+	on: CodeError , RuntimeSyntaxError
+	do: [ :e |
+		self inform: 'Error: ' , e messageText.
+		^ #(  ) ] .
+
+	dataObjects size < 2 ifFalse: [ ^ dataObjects ].
+	self inform:
+		'If you are giving an example of receiver, \args, and result, please put periods between the parts.\Otherwise just type one selector fragment'
+			withCRs.
+	^ #(  )
+]
+
+{ #category : 'execution' }
+StFinderExampleSearch >> computeWithMethodFinder: aString [
+	"Compute the selectors for the single example of receiver and args, in the very top pane"
+
+	^ (self computeDataObjects: aString) 
+		ifNotEmpty: [ : dataObjects | 
+			StMethodFinder new 
+				findMethodsByExampleInput: dataObjects allButLast 
+				andExpectedResult: dataObjects last
+				timeout: self evaluationTimeout ]
+		ifEmpty: [ Array empty ]
+]
+
+{ #category : 'execution' }
+StFinderExampleSearch >> evaluationTimeout [
+	"Answer a <Number> representing the timeout for individual calls in the receiver's search"
+
+	^ StFinderSettings evaluationTimeout
+]
+
+{ #category : 'testing' }
+StFinderExampleSearch >> isFinderExampleSearch [
+
+	^ true
+]
+
+{ #category : 'information' }
+StFinderExampleSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Examples'
+]
+
+{ #category : 'parsing' }
+StFinderExampleSearch >> parseAsNodes: anExpression [
+
+	^ (RBParser parseExpression: '{', anExpression , '}') statements asArray
+]
+
+{ #category : 'accessing' }
+StFinderExampleSearch >> previewPresenter [
+
+	^ MicrodownPresenter
+]
+
+{ #category : 'accessing' }
+StFinderExampleSearch >> previewText [
+	
+	^ StFinderPresenter methodFinderExplanation
+]
+
+{ #category : 'accessing' }
+StFinderExampleSearch >> search: aString in: aRBBrowserEnvironment [ 
+	"Answer a <Collection> of results"
+	"ToDo: Evaluate in the context of aRBBrowserEnvironment methodsDo: [ : method |"
+
+	^ self buildResult: (self computeWithMethodFinder: aString)
+
+]
+
+{ #category : 'initialization' }
+StFinderExampleSearch >> setSearchStrategyFrom: aDictionary [
+	"Set the receiver's search strategy according to aCollection of options"
+
+]
+
+{ #category : 'information' }
+StFinderExampleSearch >> updateDefaultPreview: aSpCodePresenter [ 
+
+	aSpCodePresenter text: StFinderPresenter methodFinderExplanation
+]
+
+{ #category : 'accessing' }
+StFinderExampleSearch >> validSearchOptions [
+	"Answer a <Collection> of valid search options for the receiver"
+	
+	^ #(#deactivateAll)
+]

--- a/src/NewTools-Finder/StFinderExecutionCommand.class.st
+++ b/src/NewTools-Finder/StFinderExecutionCommand.class.st
@@ -1,0 +1,17 @@
+"
+Abstract class to group execution behavior for example results.
+
+"
+Class {
+	#name : 'StFinderExecutionCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'testing' }
+StFinderExecutionCommand >> canBeExecuted [ 
+
+	^ super canBeExecuted and: [ self selectedItems ~= 0 and: [ self selectedItem isExampleResult ] ]
+]

--- a/src/NewTools-Finder/StFinderExpandAllCommand.class.st
+++ b/src/NewTools-Finder/StFinderExpandAllCommand.class.st
@@ -1,0 +1,40 @@
+"
+Command to open a settings browser focused on the Finder settings.
+"
+Class {
+	#name : 'StFinderExpandAllCommand',
+	#superclass : 'StFinderListingCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderExpandAllCommand class >> defaultDescription [
+
+	^ 'Command to expand all displayed finder results.'
+]
+
+{ #category : 'default' }
+StFinderExpandAllCommand class >> defaultIconName [
+
+	^ #expandBox
+]
+
+{ #category : 'default' }
+StFinderExpandAllCommand class >> defaultName [ 
+
+	^ 'Expand all'
+]
+
+{ #category : 'default' }
+StFinderExpandAllCommand class >> defaultShortcut [
+
+	^ $x meta
+]
+
+{ #category : 'executing' }
+StFinderExpandAllCommand >> execute [
+
+	self resultTree expandAll.
+]

--- a/src/NewTools-Finder/StFinderImplementorsCommand.class.st
+++ b/src/NewTools-Finder/StFinderImplementorsCommand.class.st
@@ -1,0 +1,50 @@
+"
+Command to spawn a browser of Implementors on the selected result item in the Finder tool.
+
+"
+Class {
+	#name : 'StFinderImplementorsCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderImplementorsCommand class >> defaultDescription [
+
+	^ 'Browse selection implementors'
+]
+
+{ #category : 'initialization' }
+StFinderImplementorsCommand class >> defaultIconName [
+
+	^ #glamorousBrowse
+]
+
+{ #category : 'default' }
+StFinderImplementorsCommand class >> defaultName [
+
+	^ 'Implementors'
+]
+
+{ #category : 'initialization' }
+StFinderImplementorsCommand class >> defaultShortcut [
+
+	^ $m meta
+]
+
+{ #category : 'testing' }
+StFinderImplementorsCommand >> canBeExecuted [ 
+
+	^ self resultTree selectedItems size = 1
+		and: [ self selectedItem isSelectorResult ]
+]
+
+{ #category : 'executing' }
+StFinderImplementorsCommand >> execute [
+	"Browse the selection implementors"
+
+	self selectedItem implementersAction
+
+]

--- a/src/NewTools-Finder/StFinderListingCommand.class.st
+++ b/src/NewTools-Finder/StFinderListingCommand.class.st
@@ -1,0 +1,17 @@
+"
+Abstract class to group behavior for listing related operations for result items.
+"
+Class {
+	#name : 'StFinderListingCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'testing' }
+StFinderListingCommand >> canBeExecuted [ 
+
+	^ super canBeExecuted and: [ self context searchMode isFinderExampleSearch not ]
+
+]

--- a/src/NewTools-Finder/StFinderModel.class.st
+++ b/src/NewTools-Finder/StFinderModel.class.st
@@ -1,0 +1,327 @@
+"
+I am the model for the `Finder` tool.
+
+I am responsible for holding the search environment, executing searches and
+returning search results.
+
+For searching I use the interface defined by ̀FinderSearch̀ and all searches
+should therefor be subclasses of ̀FinderSearch̀.
+
+"
+Class {
+	#name : 'StFinderModel',
+	#superclass : 'Model',
+	#instVars : [
+		'searchString',
+		'useRegex',
+		'searchEnvironment',
+		'availableSearches',
+		'currentSearch',
+		'results',
+		'useExact',
+		'useCase',
+		'time'
+	],
+	#category : 'NewTools-Finder-Core',
+	#package : 'NewTools-Finder',
+	#tag : 'Core'
+}
+
+{ #category : 'default values' }
+StFinderModel class >> defaultSearches [
+	"Returns a list of supported searches. Each item in the list is a subclass of `FinderSearch`."
+
+	"The first element is used as the default search mode."
+
+	^ {
+		StFinderSelectorSearch .
+		StFinderClassSearch .
+		StFinderPackageSearch .
+		StFinderSourceSearch .
+		StFinderPragmaSearch .
+		StFinderExampleSearch 
+		}
+]
+
+{ #category : 'adding' }
+StFinderModel >> addSearch: aFinderSearch [
+	"Add aFinderSearch to the availableSearches."
+
+	availableSearches add: aFinderSearch.
+	self searchTypesChanged
+]
+
+{ #category : 'information' }
+StFinderModel >> availablePackages [
+	"Returns for searching available packages by name."
+
+	^ searchEnvironment packages
+		  collect: [ :package | package name ]
+		  as: OrderedCollection
+]
+
+{ #category : 'accessing' }
+StFinderModel >> availableSearches [
+	"Returns the searches available to the model. The first one is used as the default search mode."
+
+	^ availableSearches
+]
+
+{ #category : 'accessing' }
+StFinderModel >> currentSearch [
+	"Returns the current search used by the model."
+
+	^ currentSearch
+]
+
+{ #category : 'accessing' }
+StFinderModel >> currentSearch: aSearch [
+	"Sets the search used by the model to aSearch. aSearch should be one of the availableSearches."
+
+	currentSearch := aSearch
+]
+
+{ #category : 'initialization' }
+StFinderModel >> initialize [
+
+	super initialize.
+	searchString := ''.
+	results := StFinderResult new.
+	useRegex := false.
+	useExact := false.
+	useCase := false.
+
+	availableSearches := self class defaultSearches
+		                     collect: [ :search | search new ]
+		                     as: OrderedCollection.
+	currentSearch := availableSearches first.
+	self selectAllPackages
+]
+
+{ #category : 'removing' }
+StFinderModel >> removeSearchByName: aString [
+	"Removes a search from availableSearches by its name."
+
+	availableSearches removeAllSuchThat: [ :each | each name = aString ].
+	self searchTypesChanged
+]
+
+{ #category : 'accessing' }
+StFinderModel >> results [
+
+	^ results
+]
+
+{ #category : 'searching' }
+StFinderModel >> search [
+	"Performs a search and stores the results in `self resultsDictionary`."
+
+	searchString isEmpty ifTrue: [ ^ self ].
+
+	[ : job |
+		self searchStarted.
+		time := Time millisecondsToRun: [ results := self search: searchString ].
+		self searchEnded 
+	] asJob
+			title: 'Searching...';
+			run.
+
+]
+
+{ #category : 'accessing' }
+StFinderModel >> search: aString [ 
+	"Main search callback method. Answer a <Collection> of results"
+
+	^ (currentSearch setSearchStrategyFrom: self searchOptions)
+		search: searchString
+		in: searchEnvironment.
+
+]
+
+{ #category : 'searching' }
+StFinderModel >> searchBy: aString [
+	"Perform a search by aString."
+
+	self searchString: aString.
+	self search
+]
+
+{ #category : 'announcing' }
+StFinderModel >> searchEnded [
+	"Announce the start of a new search."
+
+	"This method is used internally and called whenever a search has finished."
+
+	self announcer announce:
+		(StFinderSearchEnded 
+			results: self results 
+			time: self time)
+]
+
+{ #category : 'accessing' }
+StFinderModel >> searchOptions [
+	"Answer a <Dictionary> of searching options. This dictionary is set according to the receiver's selected options so their combinatios match a single search selector. At any point only a single entry of this dictionary can be <true>"
+	
+	^ Dictionary new
+		at: #searchByRegexCaseInsensitive:in: put: (useRegex and: [ useCase not ]);
+		at: #searchByRegexCaseSensitive:in: put: (useRegex and: [ useCase]);
+		at: #searchByStringExactSensitiveCase:in: put: (useExact and: [ useCase and: [ useRegex not ] ]);
+		at: #searchByStringExactInsensitiveCase:in: put: (useExact and: [ useCase not and: [ useRegex not ] ]);
+		at: #searchByStringSensitiveCase:in: put: (useExact not and: [ useCase and: [ useRegex not ] ]);
+		at: #searchBySubstring:in: put: (useExact not and: [ useCase not and: [ useRegex not ] ]);
+		yourself
+
+]
+
+{ #category : 'announcing' }
+StFinderModel >> searchStarted [
+	"Announce the start of a new search."
+
+	"This method is used internally and called whenever a search is started."
+
+	self announcer announce: StFinderSearchStarted new
+]
+
+{ #category : 'accessing' }
+StFinderModel >> searchString [
+	"Return the current search string."
+
+	^ searchString
+]
+
+{ #category : 'accessing' }
+StFinderModel >> searchString: aString [
+	"Set the search string, which is to be used for further searches."
+
+	searchString := aString
+]
+
+{ #category : 'announcing' }
+StFinderModel >> searchTypesChanged [
+	"Announce a modification of availableSearches."
+
+	"This method is used internally and called whenever a availableSearches modified."
+
+	self announcer announce:
+		(StFinderSearchTypesChanged newValue: self availableSearches)
+]
+
+{ #category : 'selection' }
+StFinderModel >> selectAllPackages [
+	"Selects all packages for searching."
+
+	| globalEnv |
+	
+	globalEnv := RBBrowserEnvironment new.
+	searchEnvironment := globalEnv forPackages: globalEnv packages
+]
+
+{ #category : 'information' }
+StFinderModel >> selectedPackages [
+
+	"Returns for searching selected packages by name."
+
+	^ searchEnvironment packageNames asOrderedCollection
+]
+
+{ #category : 'selection' }
+StFinderModel >> selectedPackagesByName: aCollection [
+	"Selects all packages given in aCollection by their names for searching."
+
+	searchEnvironment := RBBrowserEnvironment new forPackageNames: aCollection
+]
+
+{ #category : 'accessing' }
+StFinderModel >> time [
+	^ time
+]
+
+{ #category : 'information' }
+StFinderModel >> unselectedPackages [
+
+	"Returns for searching unselected packages by name."
+
+	^ self availablePackages removeAllFoundIn: self selectedPackages
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useCase [
+
+	^ useCase
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useCase: aBoolean [
+
+	useCase := aBoolean
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useExact [
+
+	^ useExact
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useExact: aBoolean [ 
+
+	useExact := aBoolean
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useRegex [
+
+	^ useRegex
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useRegex: aBoolean [
+
+	useRegex := aBoolean
+]
+
+{ #category : 'announcing' }
+StFinderModel >> whenSearchEnded: aBlock [
+	"Calls aBlock everytime a search has ended and passes the results to it."
+
+	"Culled block [ :results :announcement :announcer | ... ]"
+
+	| block |
+	block := [ :announcement :ann |
+	         aBlock
+		         cull: announcement results
+		         cull: announcement time
+		         cull: ann ].
+	self announcer when: StFinderSearchEnded do: block for: self
+]
+
+{ #category : 'announcing' }
+StFinderModel >> whenSearchStarted: aBlock [
+	"Calls aBlock everytime a search is started."
+
+	"aBlock [ :announcement :announcer | ... ]"
+
+	self announcer
+		when: StFinderSearchStarted
+		do: aBlock
+		for: aBlock receiver
+]
+
+{ #category : 'announcing' }
+StFinderModel >> whenSearchTypesChanged: aBlock [
+	"Calls aBlock everytime a search has been added or removed from availableSearches."
+
+	"Culled block [ :newValue oldValue :announcement :announcer | ... ]"
+
+	| block |
+	block := [ :announcement :ann |
+	         aBlock
+		         cull: announcement newValue
+		         cull: announcement oldValue
+		         cull: announcement
+		         cull: ann ].
+	self announcer
+		when: StFinderSearchTypesChanged
+		do: aBlock
+		for: aBlock receiver
+]

--- a/src/NewTools-Finder/StFinderPackageResult.class.st
+++ b/src/NewTools-Finder/StFinderPackageResult.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'StFinderPackageResult',
+	#superclass : 'StFinderResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderPackageResult class >> matches: aCollection [ 
+	
+	^ false
+]
+
+{ #category : 'copying' }
+StFinderPackageResult >> copyTo: aWriteStream [ 
+
+	aWriteStream << self content name
+]
+
+{ #category : 'displaying' }
+StFinderPackageResult >> displayIcon [
+
+	^ self iconNamed: #package
+]
+
+{ #category : 'displaying' }
+StFinderPackageResult >> displayString [
+
+	^ self content name
+]
+
+{ #category : 'private' }
+StFinderPackageResult >> forFinderPreview: aSpCodePresenter [ 
+
+	^ String empty
+]
+
+{ #category : 'testing' }
+StFinderPackageResult >> isPackageResult [
+
+	^ true
+]
+
+{ #category : 'private' }
+StFinderPackageResult >> selectItemIn: aSpTreePresenter [ 
+
+	| pathIndexCollection |
+	pathIndexCollection := aSpTreePresenter pathIndexOf: { self }.
+	aSpTreePresenter 
+		selectPath: pathIndexCollection scrollToSelection: true;
+		clickAtPath: pathIndexCollection
+]

--- a/src/NewTools-Finder/StFinderPackageSearch.class.st
+++ b/src/NewTools-Finder/StFinderPackageSearch.class.st
@@ -1,0 +1,100 @@
+"
+I implement a search for classes in a given environment.
+
+I am a subclass of ̀FinderSearch̀ and am used by ̀FinderModel̀ to perform searches
+for classes.
+
+"
+Class {
+	#name : 'StFinderPackageSearch',
+	#superclass : 'StFinderSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'private' }
+StFinderPackageSearch >> buildResult: aListOfPackages [
+
+	^ aListOfPackages
+		  collect: [ :each |
+			  | newResult |
+			  newResult := StFinderPackageResult new content: each.
+			  each definedClasses do: [ : class |
+				 newResult addChild: (StFinderClassResult new content: class) ].
+			  newResult  ]
+		  as: OrderedCollection
+]
+
+{ #category : 'information' }
+StFinderPackageSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Packages'
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchByRegexCaseInsensitive: aString in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	| regex |
+	regex := aString asRegexIgnoringCase.
+	^ self 
+		buildResult: (self 
+			searchPackages: [ :class | regex search: class name ] 
+			in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchByRegexCaseSensitive: aString in: aRBBrowserEnvironment [ 
+	"Perform a search given aString representing a regular expression in aRBBrowserEnvironment."
+
+	| regex |
+	regex := aString asRegex.
+	^ self 
+		buildResult: (self 
+			searchPackages: [ :class | regex search: class name ] 
+			in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchByStringExactInsensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPackages: [ : class | class name asLowercase = aString asLowercase ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchByStringExactSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPackages: [ : class | class name = aString ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchByStringSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPackages: [ :package | package name includesSubstring: aString caseSensitive: true ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPackageSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	^ self buildResult: 
+		(self 
+			searchPackages: [ :class | class name includesSubstring: aString caseSensitive: false ] 
+			in: anEnvironment)
+]
+
+{ #category : 'private' }
+StFinderPackageSearch >> searchPackages: aSelectBlock in: anEnvironment [
+
+	^ OrderedCollection streamContents: [ :stream |
+		  anEnvironment packages do: [ : package |
+			  (aSelectBlock value: package) ifTrue: [ stream nextPut: package ] ] ]
+]

--- a/src/NewTools-Finder/StFinderPragmaResult.class.st
+++ b/src/NewTools-Finder/StFinderPragmaResult.class.st
@@ -1,0 +1,63 @@
+"
+I represent a pragma as a ̀FinderResult̀.
+"
+Class {
+	#name : 'StFinderPragmaResult',
+	#superclass : 'StFinderResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderPragmaResult class >> matches: anObject [ 
+
+	^ anObject hasPragma
+]
+
+{ #category : 'displaying' }
+StFinderPragmaResult >> displayIcon [
+
+	^ self iconNamed: #changeUpdate
+]
+
+{ #category : 'private' }
+StFinderPragmaResult >> forFinderPreview: aSpCodePresenter [ 
+
+	self parent
+		ifNil: [ aSpCodePresenter text: 'Please select a method expanding the selected item' ]
+		ifNotNil: [ 
+			self 
+				displaySource: (self content >> self parent content) 
+				in: aSpCodePresenter ]
+]
+
+{ #category : 'instance creation' }
+StFinderPragmaResult >> getCompiledMethodFrom: aStFinderSelectorResult [ 
+
+	^ self content method
+]
+
+{ #category : 'testing' }
+StFinderPragmaResult >> isPragmaResult [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+StFinderPragmaResult >> resultPreview [
+	"Private - See superimplementor's comment"
+
+	^ self shouldBeImplemented 
+]
+
+{ #category : 'private' }
+StFinderPragmaResult >> selectItemIn: aSpTreePresenter [ 
+
+	| pathIndexCollection |
+	pathIndexCollection := aSpTreePresenter pathIndexOf: { self }.
+	aSpTreePresenter 
+		expandPath: pathIndexCollection;	
+		selectPath: pathIndexCollection scrollToSelection: true;
+		clickAtPath: pathIndexCollection
+]

--- a/src/NewTools-Finder/StFinderPragmaSearch.class.st
+++ b/src/NewTools-Finder/StFinderPragmaSearch.class.st
@@ -1,0 +1,136 @@
+"
+I implement a search for pragmas in a given environment.
+
+I am a subclass of ̀FinderSearch̀ and am used by ̀FinderModel̀ to perform searches
+for selectors.
+
+"
+Class {
+	#name : 'StFinderPragmaSearch',
+	#superclass : 'StFinderSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'private' }
+StFinderPragmaSearch >> buildResult: aDictionary [
+	"PragmaResult
+		|
+		\-> n SelectorResults
+				|
+				\-> 1 ClassResults."
+
+	| results isNewResult |
+	results := OrderedCollection new.
+	isNewResult := true.
+
+	aDictionary keysAndValuesDo: [ :pragma :methods |
+		| pragmaResult |
+		"Sadly Pragmas with the same selector are not unique keys in a Dictionary."
+		pragmaResult := results
+			                detect: [ :result |
+			                result content selector = pragma ]
+			                ifFound: [ :result |
+				                isNewResult := false.
+				                result ]
+			                ifNone: [ StFinderPragmaResult new content: pragma ].
+
+		methods do: [ :method |
+			| classResult |
+			classResult := StFinderClassResult new content: method methodClass.
+			pragmaResult children
+				detect: [ :elem | elem content = method selector ]
+				ifFound: [ :elem | elem addChild: classResult ]
+				ifNone: [
+					| selectorResult |
+					selectorResult := StFinderSelectorResult new
+						                  content: method;
+						                  addChild: classResult;
+						                  yourself.
+					pragmaResult addChild: selectorResult ] ].
+
+		isNewResult ifTrue: [ results add: pragmaResult ] ].
+
+	^ results
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> excludePragmaDelimiters: aString [
+
+	^ aString trimBoth: [ :c | { $< .$> } includes: c ]
+]
+
+{ #category : 'information' }
+StFinderPragmaSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Pragmas'
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> searchByRegexCaseInsensitive: aString in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	| regex |
+	regex := aString asRegexIgnoringCase.
+	^ self buildResult: (self
+			   searchPragmas: [ :pragma | regex search: pragma selector ]
+			   in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> searchByStringExactInsensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPragmas: [ : pragma | pragma selector asLowercase = (self excludePragmaDelimiters: aString asLowercase) ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> searchByStringExactSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPragmas: [ : pragma | pragma selector = (self excludePragmaDelimiters: aString) ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> searchByStringSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchPragmas: [ : pragma | pragma selector includesSubstring: (self excludePragmaDelimiters: aString) caseSensitive: true ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderPragmaSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	^ self buildResult: (self
+			   searchPragmas: [ :pragma |
+				   pragma selector 
+					   includesSubstring: (self excludePragmaDelimiters: aString)
+					   caseSensitive: false ]
+			   in: anEnvironment)
+]
+
+{ #category : 'private' }
+StFinderPragmaSearch >> searchPragmas: aSelectBlock in: anEnvironment [
+
+	| findings |
+	findings := Dictionary new.
+
+	anEnvironment classesAndTraitsDo: [ :class |
+		class pragmasDo: [ :pragma |
+			(aSelectBlock value: pragma) ifTrue: [
+				(findings at: pragma selector ifAbsentPut: OrderedCollection new)
+					add: pragma method ] ].
+		"Include Metaclasses too, since a lot of pragmas are only found there."
+		class class pragmasDo: [ :pragma |
+			(aSelectBlock value: pragma) ifTrue: [
+				(findings at: pragma ifAbsentPut: OrderedCollection new)
+					add: pragma method ] ] ].
+
+	^ findings
+]

--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -1,0 +1,575 @@
+"
+I am the presenter for the ̀Finder̀ tool.
+
+I define the user interface of the finder tool.
+"
+Class {
+	#name : 'StFinderPresenter',
+	#superclass : 'SpPresenterWithModel',
+	#instVars : [
+		'searchBar',
+		'resultTree',
+		'resultButtonBar',
+		'environmentBar',
+		'searchOptions',
+		'resultStatusBar',
+		'previewSourcePresenter',
+		'configButton'
+	],
+	#category : 'NewTools-Finder-Core',
+	#package : 'NewTools-Finder',
+	#tag : 'Core'
+}
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildBrowsingOperationsGroupWith: presenterInstance [
+
+	^ (CmCommandGroup named: 'BrowseOperationsMenu') asSpecGroup
+		register: ((StFinderBrowseCommand
+			forSpecWithIconNamed: StFinderBrowseCommand defaultIconName
+			shortcutKey: StFinderBrowseCommand defaultShortcut) context: presenterInstance);
+			
+		register: ((StFinderReferencesCommand
+			forSpecWithIconNamed: StFinderReferencesCommand defaultIconName
+			shortcutKey: StFinderReferencesCommand defaultShortcut) context: presenterInstance);
+			
+		register: ((StFinderSendersCommand
+			forSpecWithIconNamed: StFinderSendersCommand defaultIconName
+			shortcutKey: StFinderSendersCommand defaultShortcut) context: presenterInstance);
+			
+		register: ((StFinderImplementorsCommand
+			forSpecWithIconNamed: StFinderImplementorsCommand defaultIconName
+			shortcutKey: StFinderImplementorsCommand defaultShortcut) context: presenterInstance);
+		beDisplayedAsGroup;
+		yourself
+]
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildCommandsGroupWith: presenterInstance forRoot: rootCommandGroup [
+
+	rootCommandGroup
+		register: (self buildStFinderContextualGroupWith: presenterInstance)
+]
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildExecutionOperationsGroupWith: presenterInstance [
+
+	^ (CmCommandGroup named: 'ExecutionOperationsMenu') asSpecGroup
+
+		register: ((StFinderDebugItCommand
+			forSpecWithIconNamed: StFinderDebugItCommand defaultIconName
+			shortcutKey: StFinderDebugItCommand defaultShortcut) context: presenterInstance);
+
+		register: ((StFinderProfileItCommand
+			forSpecWithIconNamed: StFinderProfileItCommand defaultIconName
+			shortcutKey: StFinderProfileItCommand defaultShortcut) context: presenterInstance);
+			
+		beDisplayedAsGroup;
+		yourself
+]
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildListingOperationsGroupWith: presenterInstance [
+
+	^ (CmCommandGroup named: 'ListingOperationsMenu') asSpecGroup
+		register: ((StFinderExpandAllCommand
+			forSpecWithIconNamed: #expandBox
+			shortcutKey: StFinderExpandAllCommand defaultShortcut) 
+				context: presenterInstance);
+		register: ((StFinderCollapseAllCommand
+			forSpecWithIconNamed: #refresh
+			shortcutKey: StFinderCollapseAllCommand defaultShortcut) 
+				context: presenterInstance);				
+		beDisplayedAsGroup;
+		yourself
+]
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildSelectionOperationsGroupWith: presenterInstance [
+
+	^ (CmCommandGroup named: 'SelectionOperationsMenu') asSpecGroup
+		register: ((StFinderSelectAllCommand
+			forSpecWithIconNamed: StFinderSelectAllCommand defaultIconName
+			shortcutKey: StFinderSelectAllCommand defaultShortcut) 
+				context: presenterInstance);			
+		register: ((StFinderSelectNoneCommand 
+			forSpecWithIconNamed: StFinderSelectNoneCommand defaultIconName
+			shortcutKey: StFinderSelectNoneCommand defaultShortcut)
+				context: presenterInstance);
+		register: ((StFinderCopySelectionCommand 
+			forSpecWithIconNamed: StFinderCopySelectionCommand defaultIconName
+			shortcutKey: StFinderCopySelectionCommand defaultShortcut)
+				context: presenterInstance);
+		beDisplayedAsGroup;
+		yourself
+]
+
+{ #category : 'commands' }
+StFinderPresenter class >> buildStFinderContextualGroupWith: presenterInstance [
+
+	^ (CmCommandGroup named: 'StFinderSelContextualMenu') asSpecGroup
+		register: (self buildExecutionOperationsGroupWith: presenterInstance);	
+		register: (self buildBrowsingOperationsGroupWith: presenterInstance);
+		register: (self buildListingOperationsGroupWith: presenterInstance);
+		register: (self buildSelectionOperationsGroupWith: presenterInstance);
+		yourself
+]
+
+{ #category : 'default values' }
+StFinderPresenter class >> defaultExplanation [
+
+	^ 'The Finder can be used by default in 4 different ways:
+	- Selectors: your research is done among selectors
+	- Classes : your research is done among classes names
+	- Source : your research is done among all the source code
+	- Pragmas: your research is done among pragmas
+	- Examples : your research uses the Method Finder behavior 
+			   (for further informations, print ''FinderUI methodFinderExplanation'')
+	
+			
+In these four modes, you can also tick the ''Use RegEx'' checkbox.
+If you pick this box, your search will be done using regular expressions instead of just matching.
+
+The ''Select classes'' button opened a dialog window  to select which classes will be used for the search.
+The ''All classes'' button is used to reset the classes selection.'
+]
+
+{ #category : 'default values' }
+StFinderPresenter class >> methodFinderExplanation [
+	"MethodFinder new findMethodsByExampleInput: #( 1 2 ) andExpectedResult: 3."
+	"may be this method can be moved to the corresponding search "
+
+	^ 'Use an example to find a method in the system.  
+	
+   ''a''. ''b''. ''ab''       will find the message #, for strings concatenation
+   2. -2                will find the message #negated
+   3. 6                 will find the message #factorial
+   20. 10. 15. 15       will find the message #min:max:
+
+It works on collections too:
+
+   {2. 4. 5. 1}. 5. 3   will find the message #indexOf:
+   {2. 5. 1}. 5. true   will find the message #includes:
+	
+An example is made up of the following two or more items separated by a period: 
+	
+	receiver. answer
+	receiver. argument1. answer
+	receiver. argument1. argument2. answer
+	etc...
+	
+For example, type: 3. 4. 7. into the search box and click <Search>
+
+Take care on separating spaces because of floating point numbers.
+
+ 	3.4.7      will find nothing, it is interpreted two numbers, 3.4 and. 7
+	3. 4. 7    will find you the message #+
+	
+The examples array should contain one object for the receiver, one object per expected argument and then a final object with the expected result.	
+
+In other words 
+ - a unary method example expects an array of input objects #( receiver ) and an expected result
+ - a binary method example expects an array with two input objects #( receiver argument ) and an expected result
+ - a keyword method example expects an array with at least two elements  #( receiver argument1 argument2 ... ) and an expected results
+
+The method finder will take the input objects (receiver and arguments) and perform their permutation to be able to find more results.
+Then, it will lookup in the receiver''s hierarchy the approved and forbidden methods to run on the hierarchy and run them on the permutation of objects.
+
+Receiver and arguments do not have to be in the right order.
+
+Alternatively, in this bottom pane or in the Playground, use #findMethodsByExampleInput:andExpectedResult: directly to find a method in the system.  Select this line of code and choose "print it" or "inspect it.  
+
+	MethodFinder new findMethodsByExampleInput: #( 1 2 ) andExpectedResult: 3.
+
+It is useful when you want to look for computed objects:
+	
+	MethodFinder new 
+		findMethodsByExampleInput: {''29 Apr 1999'' asDate} 
+		andExpectedResult: ''30 Apr 1999'' asDate.
+
+This will find the message #next.
+
+	MethodFinder new 
+		findMethodsByExampleInput: {''30 Apr 1999'' asDate} 
+		andExpectedResult: ''Friday''. 
+
+This will find the message #dayOfWeekName
+
+The Method Finder is not trying all methods in the system so if it will find nothing, a method with requested behavior may still exist. '
+
+		
+
+]
+
+{ #category : 'instance creation' }
+StFinderPresenter class >> open [
+	<script>
+	
+	(self on: StFinderModel new) open
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> connectPresenters [
+
+	self connectSearchBar.
+
+	configButton action: [
+		SettingBrowser new
+			rootNodes: (SettingBrowser currentTree nodeNamed: #finder) allChildren;
+			open ].
+
+	self connectSearchOptions.
+
+	environmentBar
+		whenAllPackagesSelectedDo: [ self searchInAllPackages ];
+		whenPackagesSelectedDo: [ self openPackageChooserDialog ].
+
+	resultTree 
+		whenSelectedItemChangedDo: [ :newResult |
+			newResult 
+				ifNil: [ self resultButtonBar disableAll ] 
+				ifNotNil: [
+					newResult forFinderPreview: previewSourcePresenter.
+					self resultButtonBar enableButtonsFor: newResult ] ].
+
+	self connectResultButtons.
+	self subscribeToAnnouncements
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> connectResultButtons [
+
+	resultButtonBar browseAction: [ self selectedResult ifNotNil: [ :result | result browseAction ] ].
+	resultButtonBar sendersAction: [ self selectedResult ifNotNil: [ :result | result sendersAction ] ].
+	resultButtonBar implementersAction: [ self selectedResult ifNotNil: [ :result | result implementersAction ] ].
+	resultButtonBar versionsAction: [ self selectedResult ifNotNil: [ :result | result versionsAction ] ].
+	resultButtonBar inheritanceAction: [ self selectedResult ifNotNil: [ :result | result inheritanceAction ] ].
+	resultButtonBar hierarchyAction: [ self selectedResult ifNotNil: [ :result | result hierarchyAction ] ]
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> connectSearchBar [
+
+	searchBar
+		whenSubmitSearchDo: [ :text | self model searchBy: text ];
+		whenSearchModeChangedDo: [ :new | self model currentSearch: new ]
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> connectSearchOptions [
+
+	searchOptions
+		whenRegexActivatedDo: [ 
+			self model useRegex: true.
+			searchOptions disableExact. ];
+		whenRegexDeactivatedDo: [ 
+			self model useRegex: false.
+			searchOptions enableExact ];
+		whenCaseActivatedDo: [ self model useCase: true ];
+		whenCaseDeactivatedDo: [ self model useCase: false ];
+		whenExactActivatedDo: [
+			self model useExact: true.
+			searchOptions disableRegex ];
+		whenExactDeactivatedDo: [ 
+			self model useExact: false.
+			searchOptions enableRegex ].
+]
+
+{ #category : 'layout' }
+StFinderPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  spacing: 5;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: 2;
+				   add: searchBar;
+				   addLast: configButton;
+				   yourself)
+		  expand: false;
+			add: (SpBoxLayout newLeftToRight
+				   add: searchOptions;
+				   add: environmentBar;
+				   yourself)
+			expand: false;
+			add: resultTree;
+			add: resultButtonBar expand: false;		
+			add: previewSourcePresenter;
+			addLast: resultStatusBar expand: false;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> initialExtentForWindow [
+
+	^ (700 @ 500) scaledByDisplayScaleFactor
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> initializeFocus [
+
+	self focusOrder 
+		add: searchBar;
+		add: resultTree;
+		add: environmentBar;
+		add: previewSourcePresenter.
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> initializePresenters [
+
+	searchBar := self instantiate: StFinderSearchBar.
+	searchBar searchModes: self model availableSearches.
+
+	configButton := self newButton
+		              icon: (self iconNamed: #config);
+		              yourself.
+
+	searchOptions := self instantiate: StFinderSearchOptions.
+
+	environmentBar := self instantiate: StFinderEnvironmentBar.
+	self updateEnvironmentStatusFor: self model selectedPackages.
+
+	self initializeResultTree.
+		
+	previewSourcePresenter := self newCode.
+
+	resultButtonBar := self instantiate: StFinderResultButtonBar.
+
+	resultStatusBar := self newStatusBar.
+	self initializeFocus.
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> initializeResultTree [
+
+	resultTree := self newTree
+		beMultipleSelection;
+		display: [ :result | result displayString ];
+		displayIcon: [ :result | result displayIcon ];
+		contextMenu: [ (self rootCommandsGroup / 'StFinderSelContextualMenu') beRoot asMenuPresenter ].
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> initializeWindow: aSpWindowPresenter [
+
+	super initializeWindow: aSpWindowPresenter.
+
+	self setTitleTo: aSpWindowPresenter.
+	self setWindowIconTo: aSpWindowPresenter.
+	self setInitialExtentTo: aSpWindowPresenter
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> notifySearchStarted [
+	"Do nothing for now"
+
+
+]
+
+{ #category : 'private' }
+StFinderPresenter >> openPackageChooserDialog [
+	"Opens a `SpChooserPresenter` dialog to allow the user to choose the packages to search in."
+
+	((SpChooserPresenter
+		  sourceItems: self model unselectedPackages
+		  chosenItems: self model selectedPackages)
+		 sourceLabel: 'Available packages';
+		 targetLabel: 'Selected packages';
+		 openDialog)
+		title: 'Select packages for searching';
+		okAction: [ :dialog | self searchInPackages: dialog presenter chosenItems ]
+]
+
+{ #category : 'accessing' }
+StFinderPresenter >> resultButtonBar [
+
+	^ resultButtonBar
+]
+
+{ #category : 'accessing' }
+StFinderPresenter >> resultTree [
+
+	^ resultTree
+]
+
+{ #category : 'accessing' }
+StFinderPresenter >> searchBar [
+
+	^ searchBar
+]
+
+{ #category : 'private' }
+StFinderPresenter >> searchInAllPackages [
+	"Selects all packages for searching."
+
+	self model selectAllPackages.
+	environmentBar activateAllPackages.
+	self updateEnvironmentStatusFor: self model selectedPackages
+]
+
+{ #category : 'private' }
+StFinderPresenter >> searchInPackages: aCollection [
+	"Sets the search environment in the model to the package names given in aCollection."
+
+	self model selectedPackagesByName: aCollection.
+	environmentBar activateChosenPackages.
+	self updateEnvironmentStatusFor: aCollection
+]
+
+{ #category : 'accessing' }
+StFinderPresenter >> searchMode [
+	"Answer a <StFinderSearch> with the currently selected search mode"
+
+	^ searchBar searchMode
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> searchOptions [
+	"Answer the receiver's <StFinderSearchOptions>"
+
+	^ searchOptions
+]
+
+{ #category : 'accessing' }
+StFinderPresenter >> searchText [
+	"Answer a <String> with the currently typed text in the search bar"
+	
+	^ self searchBar searchText
+]
+
+{ #category : 'information' }
+StFinderPresenter >> selectedResult [
+
+	^ resultTree selectedItem
+]
+
+{ #category : 'accessing - properties' }
+StFinderPresenter >> selectedResults [
+	"Answer the receiver's <Collection> of selected results"
+
+	^ self application 
+		propertyAt: #selectedResults
+		ifAbsentPut: [ Set new ]
+]
+
+{ #category : 'accessing - properties' }
+StFinderPresenter >> selectedResults: aCollection [ 
+	"Set a <Collection> of results to be marked for future operations"
+
+	^ self application 
+		propertyAt: #selectedResults
+		put: aCollection asSet
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> setInitialExtentTo: aSpWindowPresenter [
+	
+	aSpWindowPresenter initialExtent: self initialExtentForWindow
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> setTitleTo: aSpWindowPresenter [
+
+	aSpWindowPresenter title: 'Finder'
+
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> setWindowIconTo: aSpWindowPresenter [
+	
+	aSpWindowPresenter	windowIcon: (self iconNamed: #smallFind).
+
+]
+
+{ #category : 'initialization' }
+StFinderPresenter >> subscribeToAnnouncements [
+
+	self model whenSearchStarted: [ self notifySearchStarted ].
+	self model whenSearchEnded: [ :results : time | self updateResultsWith: results time: time ].
+	self model whenSearchTypesChanged: [ self searchBar updateSearchModes ]
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateEnvironmentStatusFor: packages [
+
+	environmentBar status: packages size asString , ' Packages selected'
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updatePreview: aStFinderSearch [ 
+
+	self flag: #toDo.
+	previewSourcePresenter ifNotNil: [ : p | 
+		self searchMode updateDefaultPreview: p ].
+	"| newPresenter presenterToReplace |
+
+	newPresenter := self instantiate: aStFinderSearch previewPresenter.
+	newPresenter text: aStFinderSearch previewText.
+	presenterToReplace := self layout subpresenterOrLayoutNamed: #previewSourcePresenter of: self.
+	self layout 
+		replaceAtIndex: 3 
+		with: newPresenter"
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateResultsBehavior [
+	"Private - Callback to control events after a new search has finished"
+	
+	StFinderSettings expandResults
+		ifTrue: [ resultTree expandAll ].
+
+	resultTree roots 
+		ifNotEmpty: [ : items | self updateResultsSelection: items ]
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateResultsSelection: aCollection [
+	"Private - aCollection represents the found items. 
+	Search and select an exact match between the search text in aCollection, if possible. If not found then select the first item.
+	For expansion use the current settings"
+	
+	| itemToSelect |
+	itemToSelect := aCollection
+		                detect: [ :item | item matches: self searchText ]
+		                ifFound: [ :item | item ]
+		                ifNone: [ aCollection first ].
+	resultTree selectItem: itemToSelect.
+	itemToSelect hasChildren 
+		ifFalse: [ ^ self ].
+	itemToSelect selectItemIn: resultTree.
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateResultsWith: results time: time [
+	"Call to update resultTree with results."
+
+	resultTree
+		roots: results;
+		children: [ :result | result children ].
+	self updateResultsBehavior.
+	resultStatusBar pushMessage: (self updateStatusBarTextFrom: results time: time)
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateSearchOptions: aCollection [ 
+	"Private - Update the receiver's search options using aCollection which contains the selectors to enable"
+	
+	searchOptions
+		ifNotNil: [ aCollection do: [ : selector | searchOptions perform: selector ] ]
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> updateStatusBarTextFrom: results time: time [
+
+	^ String streamContents: [ : stream |
+		stream
+			<< 'Search of ';
+			<< searchBar searchModeName;
+			<< ' for ';
+			<< searchBar searchText surroundedBySingleQuotes;
+			<< ' found ';
+			<< results size asString;
+			<< ' results and took ';
+			<< time asStringWithCommas;
+			<< ' ms' ]
+]

--- a/src/NewTools-Finder/StFinderProfileItCommand.class.st
+++ b/src/NewTools-Finder/StFinderProfileItCommand.class.st
@@ -1,0 +1,43 @@
+"
+Command to debug a resulting expression from the Examples search mode in the Finder tool
+
+"
+Class {
+	#name : 'StFinderProfileItCommand',
+	#superclass : 'StFinderExecutionCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderProfileItCommand class >> defaultDescription [
+
+	^ 'Profile the selected example'
+]
+
+{ #category : 'initialization' }
+StFinderProfileItCommand class >> defaultIconName [
+
+	^ #smallProfile
+]
+
+{ #category : 'default' }
+StFinderProfileItCommand class >> defaultName [ 
+
+	^ 'Profile It'
+]
+
+{ #category : 'initialization' }
+StFinderProfileItCommand class >> defaultShortcut [
+
+	^ $p meta
+]
+
+{ #category : 'executing' }
+StFinderProfileItCommand >> execute [
+	"Debug the selected example result"
+
+	self selectedItem content profile
+
+]

--- a/src/NewTools-Finder/StFinderReferencesCommand.class.st
+++ b/src/NewTools-Finder/StFinderReferencesCommand.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'StFinderReferencesCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderReferencesCommand class >> defaultDescription [
+
+	^ 'Browse references'
+]
+
+{ #category : 'initialization' }
+StFinderReferencesCommand class >> defaultIconName [
+
+	^ #references
+]
+
+{ #category : 'default' }
+StFinderReferencesCommand class >> defaultName [
+
+	^ 'References'
+]
+
+{ #category : 'initialization' }
+StFinderReferencesCommand class >> defaultShortcut [
+
+	^ $r meta
+]
+
+{ #category : 'testing' }
+StFinderReferencesCommand >> canBeExecuted [ 
+
+	^ self resultTree selectedItems size = 1
+		and: [ self selectedItem isClassResult ]
+]
+
+{ #category : 'executing' }
+StFinderReferencesCommand >> execute [
+	"Browse the selection references"
+
+	self selectedItem referencesAction
+
+]

--- a/src/NewTools-Finder/StFinderResult.class.st
+++ b/src/NewTools-Finder/StFinderResult.class.st
@@ -1,0 +1,240 @@
+"
+I represent a result in the ̀Finder̀ tool.
+
+I am a composite object and subclasses of me reperesent different kinds of results.
+
+I have a content, which is the actual result, and define a specified set of actions
+for it.
+"
+Class {
+	#name : 'StFinderResult',
+	#superclass : 'Object',
+	#instVars : [
+		'content',
+		'parent',
+		'children'
+	],
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'instance creation' }
+StFinderResult class >> newFor: aCompiledMethod [
+	"Answer a <Class> matching aCompiledMethod to be represented as result item"
+
+	^ self allSubclasses
+		detect: [ : subclass | subclass matches: aCompiledMethod ]
+		ifFound: [ : subclass | subclass new content: aCompiledMethod ]
+		ifNone: [ self error: 'No matching result for ' , aCompiledMethod selector ]
+
+]
+
+{ #category : 'adding' }
+StFinderResult >> addChild: aFinderResult [
+
+	aFinderResult parent: self.
+	children add: aFinderResult
+]
+
+{ #category : 'action' }
+StFinderResult >> browseAction [
+	"Default does nothing. Subclasses may implement their own action for browsing."
+]
+
+{ #category : 'system tool access' }
+StFinderResult >> browser [
+	"We should check how to do it via the stApplication but ok for now"
+
+	self flag: #comeBack.
+	^ Smalltalk tools browser
+]
+
+{ #category : 'accessing' }
+StFinderResult >> children [
+
+	^ children
+]
+
+{ #category : 'accessing' }
+StFinderResult >> children: anObject [
+
+	children := anObject
+]
+
+{ #category : 'accessing' }
+StFinderResult >> content [
+
+	^ content
+]
+
+{ #category : 'accessing' }
+StFinderResult >> content: anObject [
+
+	content := anObject
+]
+
+{ #category : 'displaying' }
+StFinderResult >> displayIcon [
+
+	^ nil
+]
+
+{ #category : 'displaying' }
+StFinderResult >> displaySource: aCompiledMethod in: aSpCodePresenter [
+
+	aSpCodePresenter 
+		beForMethod: aCompiledMethod;
+		text: aCompiledMethod sourceCode
+]
+
+{ #category : 'displaying' }
+StFinderResult >> displayString [
+
+	^ content asString
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasBrowseAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasChildren [
+
+	^ self children notEmpty
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasHierarchyAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasImplementersAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasInheritanceAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasSendersAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> hasVersionsAction [
+
+	^ false
+]
+
+{ #category : 'action' }
+StFinderResult >> hierarchyAction [
+	"Default does nothing. Subclasses may implement their own action for hieracchy."
+]
+
+{ #category : 'action' }
+StFinderResult >> implementersAction [
+	"Default does nothing. Subclasses may implement their own action for implementers."
+]
+
+{ #category : 'action' }
+StFinderResult >> inheritanceAction [
+	"Default does nothing. Subclasses may implement their own action for inheritance."
+]
+
+{ #category : 'initialization' }
+StFinderResult >> initialize [
+
+	children := OrderedCollection new
+]
+
+{ #category : 'testing' }
+StFinderResult >> isClassResult [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> isExampleResult [
+
+	^ self parent notNil and: [ self parent isExampleResult ]
+]
+
+{ #category : 'testing' }
+StFinderResult >> isPackageResult [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> isPragmaResult [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> isSelectorResult [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StFinderResult >> matches: aString [ 
+	"Answer <true> if the receiver's displayed text match exactly aString"
+	
+	^ self displayString = aString
+]
+
+{ #category : 'system tool access' }
+StFinderResult >> navigation [
+	"We should check how to do it via the stApplication but ok for now"
+
+	self flag: #comeBack.
+	^ SystemNavigation default
+]
+
+{ #category : 'accessing' }
+StFinderResult >> parent [
+
+	^ parent
+]
+
+{ #category : 'accessing' }
+StFinderResult >> parent: anObject [
+
+	parent := anObject
+]
+
+{ #category : 'printing' }
+StFinderResult >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream space.
+	self content printOn: aStream.
+]
+
+{ #category : 'action' }
+StFinderResult >> sendersAction [
+	"Default does nothing. Subclasses may implement their own action for senders."
+]
+
+{ #category : 'system tool access' }
+StFinderResult >> versionBrowser [
+	"We should check how to do it via the stApplication but ok for now"
+	self flag: #comeBack.
+	^ Smalltalk tools versionBrowser
+]
+
+{ #category : 'action' }
+StFinderResult >> versionsAction [
+	"Default does nothing. Subclasses may implement their own action for versions."
+]

--- a/src/NewTools-Finder/StFinderResultButtonBar.class.st
+++ b/src/NewTools-Finder/StFinderResultButtonBar.class.st
@@ -1,0 +1,142 @@
+"
+I am a widget for the ̀Finder̀ tool. I represent contain the buttons used for
+interacting with the results of a search.
+"
+Class {
+	#name : 'StFinderResultButtonBar',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'browseButton',
+		'sendersButton',
+		'versionsButton',
+		'inheritanceButton',
+		'hierarchyButton',
+		'implementersButton'
+	],
+	#category : 'NewTools-Finder-Widgets',
+	#package : 'NewTools-Finder',
+	#tag : 'Widgets'
+}
+
+{ #category : 'api' }
+StFinderResultButtonBar >> browseAction: aBlock [
+
+	self browseButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> browseButton [
+
+	^ browseButton
+]
+
+{ #category : 'layout' }
+StFinderResultButtonBar >> defaultLayout [
+
+	^ 	SpBoxLayout newHorizontal
+		spacing: 2;
+		add: browseButton expand: false;
+		add: sendersButton expand: false;
+		add: implementersButton expand: false;
+		add: versionsButton expand: false;
+		add: inheritanceButton expand: false;
+		add: hierarchyButton expand: false;
+		yourself
+]
+
+{ #category : 'enabling' }
+StFinderResultButtonBar >> disableAll [
+
+	browseButton disable.
+	sendersButton disable.
+	implementersButton disable.
+	versionsButton disable.
+	inheritanceButton disable.
+	hierarchyButton disable
+]
+
+{ #category : 'enabling' }
+StFinderResultButtonBar >> enableButtonsFor: aFinderResult [
+	"Enables or disables result buttons depending on the defined
+	 actions for aFinderResult."
+
+	browseButton enabled: aFinderResult hasBrowseAction.
+	sendersButton enabled: aFinderResult hasSendersAction.
+	implementersButton enabled: aFinderResult hasImplementersAction.
+	versionsButton enabled: aFinderResult hasVersionsAction.
+	inheritanceButton enabled: aFinderResult hasInheritanceAction.
+	hierarchyButton enabled: aFinderResult hasHierarchyAction
+]
+
+{ #category : 'api' }
+StFinderResultButtonBar >> hierarchyAction: aBlock [
+
+	self hierarchyButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> hierarchyButton [
+
+	^ hierarchyButton
+]
+
+{ #category : 'api' }
+StFinderResultButtonBar >> implementersAction: aBlock [
+
+	self implementersButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> implementersButton [
+
+	^ implementersButton
+]
+
+{ #category : 'api' }
+StFinderResultButtonBar >> inheritanceAction: aBlock [
+
+	self inheritanceButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> inheritanceButton [
+
+	^ inheritanceButton
+]
+
+{ #category : 'initialization' }
+StFinderResultButtonBar >> initializePresenters [
+
+	browseButton := self newButton label: 'Browse'.
+	sendersButton := self newButton label: 'Senders'.
+	implementersButton := self newButton label: 'Implementors'.
+	versionsButton := self newButton label: 'Versions'.
+	inheritanceButton := self newButton label: 'Inheritance'.
+	hierarchyButton := self newButton label: 'Hierarchy'.
+
+	self disableAll
+]
+
+{ #category : 'api' }
+StFinderResultButtonBar >> sendersAction: aBlock [
+
+	self sendersButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> sendersButton [
+
+	^ sendersButton
+]
+
+{ #category : 'api' }
+StFinderResultButtonBar >> versionsAction: aBlock [
+
+	self versionsButton action: aBlock
+]
+
+{ #category : 'accessing' }
+StFinderResultButtonBar >> versionsButton [
+
+	^ versionsButton
+]

--- a/src/NewTools-Finder/StFinderSearch.class.st
+++ b/src/NewTools-Finder/StFinderSearch.class.st
@@ -1,0 +1,99 @@
+"
+I am an abstract base class for searches in the `Finder` Tool.
+
+I provide a common interface for performing searches and results are expected to be returned in
+form of a `FinderResult` composite object.
+
+# Subclass Responsibilities
+
+The following methods must be provided by subclasses of me.
+
+- **_name_** returns the name of the search
+- **_searchByString:in:_** performs a search for given search string.
+- **_searchByRegex:in:_** performs a search for a given `RxMatcher` object.
+
+
+"
+Class {
+	#name : 'StFinderSearch',
+	#superclass : 'Object',
+	#instVars : [
+		'searchSelector'
+	],
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'testing' }
+StFinderSearch >> isFinderExampleSearch [
+
+	^ false
+]
+
+{ #category : 'information' }
+StFinderSearch >> name [
+
+	"Returns the name of the search."
+
+	self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+StFinderSearch >> previewPresenter [
+	"Answer the presenter <Class> responsible to display the preview in the Finder according to the receiver's contents"
+	
+	^ SpCodePresenter 
+
+]
+
+{ #category : 'accessing' }
+StFinderSearch >> previewText [
+
+	^ String empty
+]
+
+{ #category : 'accessing' }
+StFinderSearch >> search: aString in: aRBBrowserEnvironment [ 
+	"Answer a <Collection> of results"
+
+	^ self 
+		perform: searchSelector 
+		withArguments: {
+			aString .
+			aRBBrowserEnvironment }
+]
+
+{ #category : 'searching' }
+StFinderSearch >> searchByRegexCaseInsensitive: aRegex in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	self subclassResponsibility
+]
+
+{ #category : 'searching' }
+StFinderSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	self subclassResponsibility
+]
+
+{ #category : 'initialization' }
+StFinderSearch >> setSearchStrategyFrom: aDictionary [
+	"Set the receiver's search strategy according to aCollection of options"
+	
+	searchSelector := aDictionary keyAtValue: true.
+]
+
+{ #category : 'information' }
+StFinderSearch >> updateDefaultPreview: aSpCodePresenter [ 
+
+	aSpCodePresenter text: 'Search for ' , self name
+]
+
+{ #category : 'accessing' }
+StFinderSearch >> validSearchOptions [
+	"Answer a <Collection> of valid search options for the receiver"
+	
+	^ #(#activateAll)
+]

--- a/src/NewTools-Finder/StFinderSearchBar.class.st
+++ b/src/NewTools-Finder/StFinderSearchBar.class.st
@@ -1,0 +1,191 @@
+"
+I am a widget for the ̀Finder̀ tool. I contain all widgets regarding the search bar.
+"
+Class {
+	#name : 'StFinderSearchBar',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'searchInput',
+		'searchButton',
+		'searchModeDropList'
+	],
+	#category : 'NewTools-Finder-Widgets',
+	#package : 'NewTools-Finder',
+	#tag : 'Widgets'
+}
+
+{ #category : 'layout' }
+StFinderSearchBar >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+			spacing: 2;
+			add: searchModeDropList expand: false;
+			add: searchInput;
+			add: searchButton;
+			yourself
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> initializeFocus [
+
+	self focusOrder 
+		add: searchInput;
+		add: searchModeDropList;
+		add: searchButton 
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> initializePresenters [
+
+	self 
+		initializeSearchModes;
+		initializeSearchInput;
+		initializeSearchButton;
+		initializeFocus.
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> initializeSearchButton [
+
+	searchButton := self newButton 
+		label: 'Search';
+		icon: (self iconNamed: #smallFind);
+		action: [ self searchBy: searchInput text ];
+		yourself.
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> initializeSearchInput [
+
+	searchInput := self newSearchInput
+		               placeholder: self placeHolderText;
+							whenTextChangedDo: [ :aString | self updateSearch: aString ];		
+		               yourself.
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> initializeSearchModes [
+
+	searchModeDropList := self newDropList
+		help: 'Select the type of elements to search for';
+		display: [ :search | search name ];
+		whenSelectedItemChangedDo: [ : modeType | 
+			self 
+				updateSearchOptions: modeType;
+				updatePreview: modeType ];
+		yourself.
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> placeHolderText [
+
+	| modeText |
+	modeText :=  searchModeDropList selectedItem 
+		ifNotNil: [ : sm | sm name ]
+		ifNil: [ String empty ].
+	^ String streamContents: [ : stream |
+			stream
+				<< 'Search ';
+				<< modeText asLowercase;
+				<< '... Hit return to accept' ]
+]
+
+{ #category : 'accessing' }
+StFinderSearchBar >> searchButton [
+
+	^ searchButton
+]
+
+{ #category : 'searching' }
+StFinderSearchBar >> searchBy: aString [ 
+
+	owner model searchBy: aString
+]
+
+{ #category : 'accessing' }
+StFinderSearchBar >> searchInput [
+
+	^ searchInput
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> searchMode [
+	"Answer a <StFinderSearch> with the currently selected search mode"
+	
+	^ searchModeDropList selectedItem
+]
+
+{ #category : 'accessing' }
+StFinderSearchBar >> searchModeDropList [
+
+	^ searchModeDropList
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> searchModeName [
+	"Answer a <String> representing the currently selected selection mode"
+	
+	^ self searchMode name
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> searchModes: aListOfSearches [
+
+	searchModeDropList items: aListOfSearches
+]
+
+{ #category : 'accessing' }
+StFinderSearchBar >> searchText [
+	"Answer a <String> with the current text to search"
+
+	^ searchInput text
+]
+
+{ #category : 'initialization' }
+StFinderSearchBar >> updatePlaceHolder: modeType [
+	
+	searchInput placeholder: modeType name
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> updatePreview: aStFinderSelectorSearch [ 
+	"Private - Search mode changed, update the valid search options for the selected aStFinderSelectorSearch"
+
+	owner updatePreview: aStFinderSelectorSearch
+
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> updateSearch: aString [
+
+	(StFinderSettings searchAsYouType and: [ aString size >= 3 ])
+		ifTrue: [ self searchBy: aString ]
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> updateSearchModes [
+
+	searchModeDropList items: self owner model availableSearches
+]
+
+{ #category : 'updating - widgets' }
+StFinderSearchBar >> updateSearchOptions: aStFinderSelectorSearch [ 
+	"Private - Search mode changed, update the valid search options for the selected aStFinderSelectorSearch"
+
+	owner updateSearchOptions: aStFinderSelectorSearch validSearchOptions
+
+]
+
+{ #category : 'events' }
+StFinderSearchBar >> whenSearchModeChangedDo: aOneArgumentBlock [
+	"aOneArgumentBlock gets the new search mode passed as the argument."
+
+	searchModeDropList whenSelectedItemChangedDo: aOneArgumentBlock
+]
+
+{ #category : 'events' }
+StFinderSearchBar >> whenSubmitSearchDo: aOneArgumentBlock [
+	"aOneArgumentBlock gets the search text passed as the argument."
+
+	searchInput whenSubmitDo: aOneArgumentBlock
+]

--- a/src/NewTools-Finder/StFinderSearchEnded.class.st
+++ b/src/NewTools-Finder/StFinderSearchEnded.class.st
@@ -1,0 +1,53 @@
+"
+A SearchEnded is an announcement raised when a search has ended.
+"
+Class {
+	#name : 'StFinderSearchEnded',
+	#superclass : 'Announcement',
+	#instVars : [
+		'results',
+		'time'
+	],
+	#category : 'NewTools-Finder-Announcement',
+	#package : 'NewTools-Finder',
+	#tag : 'Announcement'
+}
+
+{ #category : 'accessing' }
+StFinderSearchEnded class >> results: anObject [
+
+	^ self new results: anObject; yourself
+]
+
+{ #category : 'accessing' }
+StFinderSearchEnded class >> results: anObject time: aTime [
+
+	^ self new 
+		results: anObject; 
+		time: aTime;
+		yourself
+]
+
+{ #category : 'accessing' }
+StFinderSearchEnded >> results [
+
+	^ results
+]
+
+{ #category : 'accessing' }
+StFinderSearchEnded >> results: anObject [
+
+	results := anObject
+]
+
+{ #category : 'accessing' }
+StFinderSearchEnded >> time [
+
+	^ time
+]
+
+{ #category : 'accessing' }
+StFinderSearchEnded >> time: aTimeInMs [
+
+	time := aTimeInMs 
+]

--- a/src/NewTools-Finder/StFinderSearchOptions.class.st
+++ b/src/NewTools-Finder/StFinderSearchOptions.class.st
@@ -1,0 +1,166 @@
+"
+I am a widget for the ̀Finder̀ tool. I contain all widgets regarding the search options.
+
+### Matching regular expressions
+
+The ""Match Regular Expression"" checkbox and the ""Match Exact"" checkboxes in the search bar are mutually exclusive. This means that only one of them can be selected at a time. The reason behind this is that both checkboxes serve different purposes and using them simultaneously could lead to contradictory results.
+
+- The ""Match Regular Expression"" checkbox allows users to enter a regular expression (regex) in the search bar. Regex is a powerful tool for pattern matching in strings. For example, if you want to find all words that start with `a`, you could use the regex `^a`.
+- On the other hand, the ""Match Exact"" checkbox would cause the search to return only those entries that exactly match the search string.
+
+If both options were allowed to be selected at the same time, it would create confusion and potentially incorrect results. For instance, if a user enters '^a' in the search bar with the ""Match Exact"" checkbox selected, the system would try to find entries that exactly match the regex ^a, which doesn't make sense.
+
+Therefore, to avoid such situations, it's best to keep these two checkboxes mutually exclusive.
+
+### Matching case 
+
+The ""Match Case"" checkbox in a search bar is NOT mutually exclusive with either the ""Match Regular Expression"" or the ""Match Exact"" checkboxes. These checkboxes can be selected together without causing contradictory results. 
+
+- The ""Match Regular Expression"" checkbox allows users to enter a regular expression (regex) in the search bar. The ""Match Case"" checkbox modifies this behavior by making the regex case-sensitive, meaning it distinguishes between uppercase and lowercase letters. So, if you use a regex that includes a case-specific pattern, selecting the ""Match Case"" checkbox will ensure that the search results match that specific case.
+-  Similarly, the ""Match Exact"" checkbox causes the search to return only those entries that exactly match the search string. The ""Match Case"" checkbox can be used alongside this to control whether the exact match is case-sensitive. If the ""Match Case"" checkbox is selected, the search will look for an exact match including case. If it's not selected, the search will ignore case.
+
+So, the ""Match Case"" checkbox can be used with either the ""Match Regular Expression"" or the ""Match Exact"" checkbox, depending on whether you want to perform a case-sensitive search with a regex or an exact string.
+
+
+"
+Class {
+	#name : 'StFinderSearchOptions',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'regexpCheckBox',
+		'exactCheckBox',
+		'caseCheckBox'
+	],
+	#category : 'NewTools-Finder-Widgets',
+	#package : 'NewTools-Finder',
+	#tag : 'Widgets'
+}
+
+{ #category : 'initialization' }
+StFinderSearchOptions >> activateAll [
+	"Deactivate all the receiver's search options"
+
+	regexpCheckBox enabled: true.
+	exactCheckBox enabled: true.
+	caseCheckBox enabled: true.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> caseCheckBox [
+
+	^ caseCheckBox
+]
+
+{ #category : 'initialization' }
+StFinderSearchOptions >> deactivateAll [
+	"Deactivate all the receiver's search options"
+
+	regexpCheckBox enabled: false.
+	exactCheckBox enabled: false.
+	caseCheckBox enabled: false.
+]
+
+{ #category : 'layout' }
+StFinderSearchOptions >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		spacing: 2;
+		add: regexpCheckBox width: 70;
+		add: exactCheckBox width: 70;
+		add: caseCheckBox width: 70;
+		yourself
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> disableExact [
+
+	exactCheckBox enabled: false.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> disableRegex [
+
+	regexpCheckBox enabled: false.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> enableExact [
+
+	exactCheckBox enabled: true.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> enableRegex [
+
+	regexpCheckBox enabled: true.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> exactCheckBox [
+
+	^ exactCheckBox
+]
+
+{ #category : 'initialization' }
+StFinderSearchOptions >> initializePresenters [
+
+	regexpCheckBox := self newCheckBox 
+		label: 'Regexp';
+		help: 'Use regular expression';
+		yourself.
+		
+	exactCheckBox := self newCheckBox 
+		label: 'Exact';
+		help: 'Use exact match';
+		yourself.
+		
+	caseCheckBox := self newCheckBox 
+		label: 'Case';
+		help: 'Use match case';
+		yourself
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> regexpCheckBox [
+
+	^ regexpCheckBox
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenCaseActivatedDo: aBlock [
+
+	caseCheckBox whenActivatedDo: aBlock.
+
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenCaseDeactivatedDo: aBlock [
+
+	caseCheckBox whenDeactivatedDo: aBlock.
+
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenExactActivatedDo: aBlock [
+
+	exactCheckBox whenActivatedDo: aBlock.
+
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenExactDeactivatedDo: aBlock [
+
+	exactCheckBox whenDeactivatedDo: aBlock.
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenRegexActivatedDo: aBlock [
+
+	regexpCheckBox whenActivatedDo: aBlock
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenRegexDeactivatedDo: aBlock [
+
+	regexpCheckBox whenDeactivatedDo: aBlock
+]

--- a/src/NewTools-Finder/StFinderSearchStarted.class.st
+++ b/src/NewTools-Finder/StFinderSearchStarted.class.st
@@ -1,0 +1,10 @@
+"
+A SearchStarted is an announcement raised when a a new search has been started.
+"
+Class {
+	#name : 'StFinderSearchStarted',
+	#superclass : 'Announcement',
+	#category : 'NewTools-Finder-Announcement',
+	#package : 'NewTools-Finder',
+	#tag : 'Announcement'
+}

--- a/src/NewTools-Finder/StFinderSearchTypesChanged.class.st
+++ b/src/NewTools-Finder/StFinderSearchTypesChanged.class.st
@@ -1,0 +1,11 @@
+"
+A SearchTypesChanged is an announcement raised when a new search has been added or
+removed from the available searches.
+"
+Class {
+	#name : 'StFinderSearchTypesChanged',
+	#superclass : 'ValueChanged',
+	#category : 'NewTools-Finder-Announcement',
+	#package : 'NewTools-Finder',
+	#tag : 'Announcement'
+}

--- a/src/NewTools-Finder/StFinderSelectAllCommand.class.st
+++ b/src/NewTools-Finder/StFinderSelectAllCommand.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'StFinderSelectAllCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderSelectAllCommand class >> defaultDescription [
+
+	^ 'Command to select all result on the Finder settings.'
+]
+
+{ #category : 'initialization' }
+StFinderSelectAllCommand class >> defaultIconName [
+
+	^ #checkedBox
+]
+
+{ #category : 'default' }
+StFinderSelectAllCommand class >> defaultName [
+
+	^ 'Select All'
+]
+
+{ #category : 'initialization' }
+StFinderSelectAllCommand class >> defaultShortcut [
+
+	^ $f meta, $a meta
+]
+
+{ #category : 'testing' }
+StFinderSelectAllCommand >> canBeExecuted [ 
+
+	^ super canBeExecuted and: [ self selectedItems ~= self resultTreeItems size ]
+]
+
+{ #category : 'executing' }
+StFinderSelectAllCommand >> execute [
+	"Select all result items"
+
+	self context selectedResults: self resultTreeItems.
+	self resultTree selectItems: self resultTreeItems.
+
+]

--- a/src/NewTools-Finder/StFinderSelectNoneCommand.class.st
+++ b/src/NewTools-Finder/StFinderSelectNoneCommand.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'StFinderSelectNoneCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderSelectNoneCommand class >> defaultDescription [
+
+	^ 'Unselect all results'
+]
+
+{ #category : 'initialization' }
+StFinderSelectNoneCommand class >> defaultIconName [
+
+	^ #checkboxUnselected
+]
+
+{ #category : 'default' }
+StFinderSelectNoneCommand class >> defaultName [
+
+	^ 'Select None'
+]
+
+{ #category : 'initialization' }
+StFinderSelectNoneCommand class >> defaultShortcut [
+
+	^ $f meta, $m meta
+]
+
+{ #category : 'testing' }
+StFinderSelectNoneCommand >> canBeExecuted [ 
+
+	^ super canBeExecuted and: [ self selectedItems ~= 0 ]
+]
+
+{ #category : 'executing' }
+StFinderSelectNoneCommand >> execute [
+	"Unselect all result items"
+
+	self context selectedResults: Set empty.
+	self resultTree unselectAll
+]

--- a/src/NewTools-Finder/StFinderSelectorResult.class.st
+++ b/src/NewTools-Finder/StFinderSelectorResult.class.st
@@ -1,0 +1,172 @@
+"
+I represent a selector as a ̀FinderResult̀.
+"
+Class {
+	#name : 'StFinderSelectorResult',
+	#superclass : 'StFinderResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderSelectorResult class >> matches: anObject [ 
+
+	^ false
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> browseAction [
+
+	self hasBrowseAction ifFalse: [ ^ self ].
+
+	self browser
+		openOnClass: self parent content
+		selector: self content
+]
+
+{ #category : 'copying' }
+StFinderSelectorResult >> copyTo: aWriteStream [ 
+
+	aWriteStream << self content
+]
+
+{ #category : 'displaying' }
+StFinderSelectorResult >> displayIcon [
+
+	^ self iconNamed: #book
+]
+
+{ #category : 'private' }
+StFinderSelectorResult >> forFinderPreview: aSpCodePresenter [ 
+
+	self parent
+		ifNil: [ 
+			aSpCodePresenter 
+				beForScripting;
+				text: 'Please select a method implementation expanding the selected item' ]
+		ifNotNil: [ 
+			self 
+				displaySource: self getCompiledMethod
+				in: aSpCodePresenter ]
+]
+
+{ #category : 'accessing' }
+StFinderSelectorResult >> getCompiledMethod [
+	"Answer a <CompiledMethod> representing the currently found content"
+
+	^ self parent getCompiledMethodFrom: self
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasBrowseAction [
+
+	^ self hasClassParent
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasClassParent [
+
+	^ self parent notNil and: [ self parent isClassResult ]
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasHierarchyAction [
+
+	^ self hasClassParent
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasImplementersAction [
+
+	^ true
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasInheritanceAction [
+
+	^ self hasClassParent
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasSendersAction [
+
+	^ true
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> hasVersionsAction [
+
+	^ self parent notNil and: [ self parent isClassResult ]
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> hierarchyAction [
+
+	self hasHierarchyAction ifFalse: [ ^ self ].
+
+	self navigation
+		browseHierarchy: self parent content
+		selector: self content
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> implementersAction [
+
+	self navigation browseAllImplementorsOf: self selectorToBrowse.
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> inheritanceAction [
+
+	self hasInheritanceAction ifFalse: [ ^ self ].
+
+	self navigation
+		methodHierarchyBrowserForClass: self parent content
+		selector: self content
+]
+
+{ #category : 'testing' }
+StFinderSelectorResult >> isSelectorResult [
+
+	^ true
+]
+
+{ #category : 'private' }
+StFinderSelectorResult >> selectItemIn: aSpTreePresenter [ 
+
+	| pathIndexCollection selectionPathAtItem |
+	pathIndexCollection := aSpTreePresenter pathIndexOf: { self }.
+	selectionPathAtItem := pathIndexCollection , #(1).
+	aSpTreePresenter 
+		expandPath: pathIndexCollection;
+		selectPath: selectionPathAtItem scrollToSelection: true;
+		clickAtPath: selectionPathAtItem
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> selectorToBrowse [
+
+	| selectorToBrowse |
+
+	^ selectorToBrowse := content isSymbol
+		ifFalse: [ content selectorForFinder ]
+		ifTrue: [ content ].
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> sendersAction [
+
+	self navigation
+		browseSendersOf: self selectorToBrowse
+		name: 'Senders of ' , self selectorToBrowse asString
+		autoSelect: self selectorToBrowse asString
+]
+
+{ #category : 'action' }
+StFinderSelectorResult >> versionsAction [
+
+	self versionBrowser
+		browseVersionsForClass: self parent content
+		selector: self content
+]

--- a/src/NewTools-Finder/StFinderSelectorSearch.class.st
+++ b/src/NewTools-Finder/StFinderSelectorSearch.class.st
@@ -1,0 +1,113 @@
+"
+I implement a search for selectors in a given environment.
+
+I am a subclass of ̀FinderSearch̀ and am used by ̀FinderModel̀ to perform searches
+for selectors.
+
+"
+Class {
+	#name : 'StFinderSelectorSearch',
+	#superclass : 'StFinderSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'private' }
+StFinderSelectorSearch >> buildResult: aListOfMethods [
+
+	| results |
+	results := OrderedCollection new.
+
+	aListOfMethods do: [ :method |
+		| foundResult |
+
+		foundResult := StFinderResult newFor: method.
+		results
+			detect: [ :elem | elem content = method selector ]
+			ifFound: [ :elem | elem addChild: foundResult ]
+			ifNone: [
+				| newResult |
+				newResult := StFinderSelectorResult new
+					             content: method selector;
+					             addChild: foundResult;
+					             yourself.
+				results add: newResult ] ].
+
+	^ results
+]
+
+{ #category : 'information' }
+StFinderSelectorSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Selectors'
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchByRegexCaseInsensitive: aString in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	| regex |
+	regex := aString asRegexIgnoringCase.
+	^ self buildResult: 
+		(self 
+			searchMethods: [ :method | regex search: method selector ] 
+			in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchByRegexCaseSensitive: aString in: aRBBrowserEnvironment [ 
+	"Perform a search given aString representing a regular expression in aRBBrowserEnvironment."
+
+	| regex |
+	regex := aString asRegex.
+	^ self 
+		buildResult: (self 
+			searchMethods: [ :method | regex search: method selector ] 
+			in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchByStringExactInsensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method selector asLowercase = aString asLowercase ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchByStringExactSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method selector = aString ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchByStringSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method selector includesSubstring: aString caseSensitive: true ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSelectorSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method selector includesSubstring: aString caseSensitive: false ] 
+		in: anEnvironment)
+]
+
+{ #category : 'private' }
+StFinderSelectorSearch >> searchMethods: aSelectBlock in: anEnvironment [
+
+	^ OrderedCollection streamContents: [ :stream |
+		  anEnvironment classesAndTraitsDo: [ :class |
+			  class methodsDo: [ :method |
+				  (aSelectBlock value: method) ifTrue: [ stream nextPut: method ] ].
+			  class classSide methodsDo: [ :method |
+				  (aSelectBlock value: method) ifTrue: [ stream nextPut: method ] ] ] ]
+]

--- a/src/NewTools-Finder/StFinderSendersCommand.class.st
+++ b/src/NewTools-Finder/StFinderSendersCommand.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'StFinderSendersCommand',
+	#superclass : 'StFinderCommand',
+	#category : 'NewTools-Finder-Commands',
+	#package : 'NewTools-Finder',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StFinderSendersCommand class >> defaultDescription [
+
+	^ 'Browse selection senders'
+]
+
+{ #category : 'initialization' }
+StFinderSendersCommand class >> defaultIconName [
+
+	^ #smallFind
+]
+
+{ #category : 'default' }
+StFinderSendersCommand class >> defaultName [
+
+	^ 'Senders'
+]
+
+{ #category : 'initialization' }
+StFinderSendersCommand class >> defaultShortcut [
+
+	^ $n meta
+]
+
+{ #category : 'testing' }
+StFinderSendersCommand >> canBeExecuted [ 
+
+	^ self resultTree selectedItems size = 1
+		and: [ self selectedItem isSelectorResult ]
+]
+
+{ #category : 'executing' }
+StFinderSendersCommand >> execute [
+	"Browse the selection senders"
+
+	self selectedItem sendersAction.
+
+]

--- a/src/NewTools-Finder/StFinderSettings.class.st
+++ b/src/NewTools-Finder/StFinderSettings.class.st
@@ -1,0 +1,217 @@
+"
+Implements global settings for the Finder tool.
+
+See class side for details.
+"
+Class {
+	#name : 'StFinderSettings',
+	#superclass : 'Object',
+	#classVars : [
+		'EvaluationTimeout',
+		'ExcludeTests',
+		'ExpandResults',
+		'IgnoreComments',
+		'LogErrorFile',
+		'LogErrorsToFile',
+		'LogErrorsToTranscript',
+		'SearchAsYouType',
+		'UseCompletion'
+	],
+	#category : 'NewTools-Finder-Core',
+	#package : 'NewTools-Finder',
+	#tag : 'Core'
+}
+
+{ #category : 'system settings' }
+StFinderSettings class >> evaluationTimeout [
+	"Modified by settings Finder: self classSide >> #evaluationTimeoutOn:"
+
+	^ EvaluationTimeout
+		ifNil: [ EvaluationTimeout := 5000 ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> evaluationTimeout: aNumber [
+	"Modified by settings Finder: self classSide >> #evaluationTimeoutOn:"
+
+	EvaluationTimeout := aNumber
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> evaluationTimeoutOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #evaluationTimeout)
+		parent: #finder;
+		default: 500;
+		label: 'Evaluation timeout';
+		description: 'Maximum timeout delay for individual calls in Examples search. Expects an integer giving the number of miliseconds';
+		target: self
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> excludeTests [
+	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
+
+	^ ExcludeTests
+		ifNil: [ ExcludeTests := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> expandResults [
+	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
+
+	^ ExpandResults
+		ifNil: [ ExpandResults := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> expandResults: aBoolean [ 
+
+	ExpandResults := aBoolean
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> expandResultsOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #expandResults)
+		parent: #finder;
+		default: false;
+		label: 'Expand all results by default';
+		description: 'All results with children will be expanded if true';
+		target: self
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> groupSettingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder group: #finder)
+		label: 'Finder';
+		description: '';
+		parent: #tools
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> ignoreComments [
+	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
+
+	^ IgnoreComments
+		ifNil: [ IgnoreComments := true ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorFile [
+	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
+
+	^ LogErrorFile
+		ifNil: [ LogErrorFile := '' ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorFileReference [
+	"Answer a <FileReference> used to log evaluation errors"
+
+	^ self logErrorFile asFileReference
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToFile [
+	"Answer <true> if the receiver should log errors to a file"
+
+	^ LogErrorsToFile 
+		ifNil: [ LogErrorFile := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToFile: aBoolean [ 
+
+	LogErrorFile := aBoolean 
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToFileOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #logErrorsToFile)
+		parent: #finder;
+		default: false;
+		label: 'Log errors to file';
+		description: 'Log evaluation errors in the examples search to a file';
+		target: self
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToTranscript [
+	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
+
+	^ LogErrorsToTranscript
+		ifNil: [ LogErrorsToTranscript := true ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToTranscript: aBoolean [ 
+
+	LogErrorsToTranscript := aBoolean
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> logErrorsToTranscriptOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #logErrorsToTranscript)
+		parent: #finder;
+		default: true;
+		label: 'Log errors to Transcript';
+		description: 'Log evaluation errors in the examples search to the Transcript';
+		target: self
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> searchAsYouType [
+	"Modified by settings Finder: self classSide >> #searchAsYouTypeOn:"
+
+	^ SearchAsYouType
+		ifNil: [ SearchAsYouType := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> searchAsYouType: aBoolean [
+	"Modified by settings Finder: self classSide >> #searchAsYouTypeOn:"
+
+	SearchAsYouType := aBoolean
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> searchAsYouTypeOn: aBuilder [
+	<systemsettings>
+	
+	(aBuilder setting: #searchAsYouType)
+		parent: #finder;
+		default: false;
+		label: 'Search as you type';
+		description: 'Present results as you type';
+		target: self
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> useCompletion [
+	"Modified by settings Finder: self classSide >> #useCompletionOn:"
+
+	^ UseCompletion
+		ifNil: [ UseCompletion := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> useCompletion: aBoolean [ 
+
+	UseCompletion := aBoolean
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> useCompletionOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #useCompletion)
+		parent: #finder;
+		default: false;
+		label: 'Use completion';
+		description: 'Enable or disable autocompletion in finder text field as you type';
+		target: self
+]

--- a/src/NewTools-Finder/StFinderSourceSearch.class.st
+++ b/src/NewTools-Finder/StFinderSourceSearch.class.st
@@ -1,0 +1,77 @@
+"
+I implement a search for in the source in a given environment.
+
+I am a subclass of ̀StFinderSelectorSearch̀ and am used by ̀StFinderModel̀ to perform searches
+for selectors.
+
+"
+Class {
+	#name : 'StFinderSourceSearch',
+	#superclass : 'StFinderSelectorSearch',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'information' }
+StFinderSourceSearch >> name [
+	"Returns the name of the search."
+
+	^ 'Source'
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchByRegexCaseInsensitive: aString in: anEnvironment [
+	"Perform a search given aRegex in anEnvironment."
+
+	| regex |
+	regex := aString asRegexIgnoringCase.
+	^ self buildResult: (self
+			   searchMethods: [ :method | regex search: method sourceCode ]
+			   in: anEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchByRegexCaseSensitive: aString in: aRBBrowserEnvironment [ 
+	"Perform a search given aString representing a regular expression in aRBBrowserEnvironment."
+
+	| regex |
+	regex := aString asRegex.
+	^ self 
+		buildResult: (self 
+			searchMethods: [ :method | regex search: method sourceCode ] 
+			in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchByStringExactInsensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method sourceCode asLowercase = aString asLowercase ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchByStringExactSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method sourceCode = aString ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchByStringSensitiveCase: aString in: aRBBrowserEnvironment [ 
+
+	^ self buildResult: (self 
+		searchMethods: [ :method | method sourceCode includesSubstring: aString caseSensitive: true ] 
+		in: aRBBrowserEnvironment)
+]
+
+{ #category : 'searching' }
+StFinderSourceSearch >> searchBySubstring: aString in: anEnvironment [
+	"Perform a search given aString in anEnvironment."
+
+	^ self buildResult: (self
+	   searchMethods: [ :method | method sourceCode includesSubstring: aString caseSensitive: false ]
+	   in: anEnvironment)
+]

--- a/src/NewTools-Finder/StFinderTraitResult.class.st
+++ b/src/NewTools-Finder/StFinderTraitResult.class.st
@@ -1,0 +1,43 @@
+"
+I represent a class as a ̀FinderResult̀.
+"
+Class {
+	#name : 'StFinderTraitResult',
+	#superclass : 'StFinderClassResult',
+	#category : 'NewTools-Finder-Result',
+	#package : 'NewTools-Finder',
+	#tag : 'Result'
+}
+
+{ #category : 'testing' }
+StFinderTraitResult class >> matches: aCompiledMethod [ 
+	"Answer <true> if aCompiledMethod comes from a trait"
+	
+	^ aCompiledMethod methodClass isTrait
+]
+
+{ #category : 'accessing' }
+StFinderTraitResult >> content: aCompiledMethod [
+
+	content := aCompiledMethod traitSource
+		ifNil: [ aCompiledMethod methodClass ]
+		ifNotNil: [ aCompiledMethod traitSource ]
+
+]
+
+{ #category : 'displaying' }
+StFinderTraitResult >> displayIcon [
+
+	^ self iconNamed: #trait
+]
+
+{ #category : 'action' }
+StFinderTraitResult >> forFinderPreview: aSpCodePresenter [
+
+	^ self parent
+		  ifNotNil: [ self displaySource: self getCompiledMethod in: aSpCodePresenter ]
+		  ifNil: [
+			  aSpCodePresenter
+				  beForScripting;
+				  text: self content definitionString ]
+]

--- a/src/NewTools-Finder/StMethodFinder.class.st
+++ b/src/NewTools-Finder/StMethodFinder.class.st
@@ -1,0 +1,30 @@
+"
+Extends `MethodFinder` to add support for search examples with:
+
+- Timeout evaluation
+- Logging
+
+"
+Class {
+	#name : 'StMethodFinder',
+	#superclass : 'MethodFinder',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'public access' }
+StMethodFinder >> findMethodsByExampleInput: inputCollection andExpectedResult: expectedResult timeout: anInteger [
+	"Search for methods which giving each elements of input returns the corresponding elements of outputs."
+	
+	^ (self possibleSolutionsForInput: inputCollection) asSet select: [ :send |
+		  send 
+			resultIn: (expectedResult evaluateWithTimeOut: anInteger)
+			timeout: anInteger ]
+]
+
+{ #category : 'public access' }
+StMethodFinder >> methodFinderSendClass [
+
+	^ StMethodFinderSend
+]

--- a/src/NewTools-Finder/StMethodFinderSend.class.st
+++ b/src/NewTools-Finder/StMethodFinderSend.class.st
@@ -1,0 +1,216 @@
+"
+Extends `MethodFinderSend` to support Finder UI operations for searching examples.
+
+- Timeout execution.
+- Logging errors.
+
+"
+Class {
+	#name : 'StMethodFinderSend',
+	#superclass : 'MethodFinderSend',
+	#category : 'NewTools-Finder-Search',
+	#package : 'NewTools-Finder',
+	#tag : 'Search'
+}
+
+{ #category : 'comparing' }
+StMethodFinderSend >> = aStMethodFinderSend [
+
+	^ self species == aStMethodFinderSend species
+		and: [ receiver == aStMethodFinderSend receiver
+		and: [ selector == aStMethodFinderSend selector
+		and: [ arguments = aStMethodFinderSend arguments ] ] ]
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> children [
+	^ Array empty
+]
+
+{ #category : 'copying' }
+StMethodFinderSend >> copyTo: aWriteStream [ 
+
+	aWriteStream << self selector
+]
+
+{ #category : 'comparing' }
+StMethodFinderSend >> debug [
+
+	| process suspendedContext debugSession |
+	
+	process := [ receiver perform: selector withArguments: arguments ] newProcess.
+	suspendedContext := process suspendedContext.
+	
+	debugSession := (OupsDebugRequest newForContext: suspendedContext)
+		process: process;
+		label: 'debug it';
+		submit;
+		debugSession.
+	3 timesRepeat: [ debugSession stepInto ]
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> displayIcon [
+
+	^ self iconNamed: #page
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> evaluateWithTimeOut: anInteger [ 
+
+	| runner result |
+
+	runner := TKTLocalProcessTaskRunner new.
+	runner 
+		schedule: [ 
+			result := [ self evaluate ] onErrorDo: [ : e | self handleError: e ] ] asTask
+		timeout: anInteger milliSeconds.
+	^ result
+
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> forFinderPreview: aSpCodePresenter [ 
+
+	self flag: #toRemove.
+	aSpCodePresenter 
+		beForScripting;
+		text: self previewText
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> handleError: e [
+
+	StFinderSettings logErrorsToTranscript
+		ifTrue: [ (self logInfo: e) traceCr ].
+	StFinderSettings logErrorsToFile
+		ifTrue: [ StFinderSettings logErrorFileReference 
+			writeStreamDo: [ : stream | stream nextPutAll: (self logInfo: e) ] ].
+
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasBrowseAction [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StMethodFinderSend >> hasChildren [
+
+	^ false
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasHierarchyAction [
+
+	^ false
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasImplementersAction [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasInheritanceAction [
+
+	^ false
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasSendersAction [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> hasVersionsAction [
+
+	^ false
+]
+
+{ #category : 'comparing' }
+StMethodFinderSend >> hash [
+
+	^ receiver hash bitXor: selector hash
+
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> implementersAction [
+
+	SystemNavigation default browseAllImplementorsOf: self selector
+]
+
+{ #category : 'testing' }
+StMethodFinderSend >> isClassResult [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StMethodFinderSend >> isSelectorResult [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> logInfo: e [
+	"Answer a <String> representing the error e to be logged"
+	
+	^ String streamContents: [ : stream |
+		stream
+			<< e class name;
+			<< '[';
+			<< e messageText;
+			<< ']';
+			space.
+			self printOn: stream ]
+]
+
+{ #category : 'testing' }
+StMethodFinderSend >> matches: aString [ 
+
+	^ false
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> previewText [
+
+	self flag: #toRemove.
+	^ StFinderPresenter methodFinderExplanation
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> profile [
+
+	self shouldBeImplemented
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> resultIn: expectedResult timeout: anInteger [
+
+	[ [ ^ expectedResult = (self evaluateWithTimeOut: anInteger) ]
+		onErrorDo: [ :anError | ^ false ] ]
+			on: Deprecation
+			do: [ :depr | ^ false ]
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> selectorForFinder [
+	"Answer a <Symbol> with the receiver's selector for the Finder tool"
+
+	^ self selector
+]
+
+{ #category : 'accessing' }
+StMethodFinderSend >> sendersAction [
+
+	self flag: #review. "StFinderSelectorResult>>sendersAction"
+	SystemNavigation default
+		browseSendersOf: self selector
+		name: 'Senders of ' , self selector
+		autoSelect: self selector
+]

--- a/src/NewTools-Finder/package.st
+++ b/src/NewTools-Finder/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Finder' }


### PR DESCRIPTION
This PR contains the new implementation of the Finder based in Spec 2. It is a first version which could be greatly improved by receiving feedback from the community once integrated.

This PR __does NOT__ remove the old Finder. That would be pushed by another PR.

The work in this PR started in the repository https://github.com/n1toxyz/NewTools-Finder (thanks to @n1toxyz !).
Then it was re-taken and completed in https://github.com/pharo-spec/NewTools-Finder/tree/main

Most of the look and feel is the same of the Morphic based Finder tool, however it includes new features and the model it is cleaner, allowing to add new types of searches in a straightforward way.

# Features

- Includes new features and settings to control the behavior of the searches.
  - Expand all the results by default
  - Log evaluation errors for Example searches to Transcript
  - Log evaluation errors for Example searches to a file.
  - Use completion (disabled because completion is not working correctly in Pharo 12 for now).
- Includes auto-selection of the first item if matches exactly with the entered search input.
- Example searches run with a timeout.
- Search as you type (like Spotter) is included (after typing the first 3 characters by default), however not enabled in the default setting for now.
- Search using different strategies
  - Substring search (default option)
  - Regex for regular expressions
  - Exact for matching exactly was typed.
  - Case, which can be combined or not. A complete explanation of the possible combinations can be found in the class comment of `StFinderSearchOptions`.
- Commands (contextual menus) for:
  - Debug it (enabled when it makes sense: selection of methods)
  - Profile it (enabled when it makes sense: selection of methods)
  - Browse
  - References
  - Senders
  - Implementors
  - Expand all items
  - Collapse all items
  - Select all items
  - Unselect all
  - Copy the current selection
- Includes a new search type (Packages) which wasn't available in the old Finder.

# Known bugs and limitations

- In the UI, the first items returned from the first search do not include their children, meaning that they do not include the expand arrow at the left of each children, although each child node in the model contains it. Hitting __Enter__ a second time will draw the left arrows to expand the node.
- Tests for source code search are still missing. Some tests could have been implemented Parametrized Test Matrix.
- Time out for example searches needs more testing.
- Searching in comments are ignored currently.
- Searching some pragmas needs more testing.

