### PR TITLE
Avoid class side super initialize

### DIFF
--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -118,7 +118,7 @@ StFileNavigationSystemPresenter class >> example [
 { #category : 'class initialization' }
 StFileNavigationSystemPresenter class >> initialize [
 
-	super initialize.
+	self initializeBookmarks.
 	Previewer := self defaultPreviewer
 ]
 


### PR DESCRIPTION
Fix a leftover in the FileBrowser PR, reported in #657 
