### PR TITLE
Major refactoring and fixes in New File Browser

### DIFF
--- a/src/NewTools-FileBrowser-Tests/StFileDialogTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StFileDialogTest.class.st
@@ -32,6 +32,7 @@ StFileDialogTest >> fileListAllMustBeFilterByPNGFIlter [
 
 { #category : 'running' }
 StFileDialogTest >> setUp [
+
 	super setUp.
 	(dialog := self dialogClass owner: fileSystemPresenter on: fileSystemModel) defaultFolder: root
 ]
@@ -75,9 +76,12 @@ StFileDialogTest >> testOpenFolder [
 { #category : 'tests' }
 StFileDialogTest >> testWhenAddACollectionOfBookmarkToCustomBookmarkShouldBeAddedToBookmarkTreeTable [
 	| aCollectionOfBookmark |
-	aCollectionOfBookmark := {(root / 'dir') asFileReference.
-	(root / 'dir.ext') asFileReference}
-		collect: [ :eachItem | StFileBrowserBookmark name: eachItem basename location: eachItem path icon: nil ].
+
+	aCollectionOfBookmark := {
+		(root / 'dir') asFileReference.
+		(root / 'dir.ext') asFileReference }
+			collect: [ :eachItem | StFileBrowserBookmark name: eachItem basename location: eachItem path icon: nil ].
+
 	dialog bookmarks: { (StFileBrowserGroupBookmark
 				name: 'aTestBookmark'
 				collection: aCollectionOfBookmark
@@ -123,13 +127,4 @@ StFileDialogTest >> testWhenAddingBookmarkOnIsolateBookmarksShouldBeAddToAllInst
 	self
 		assert: dialog bookmarksTreeTable roots
 		equals: anOtherInstance bookmarksTreeTable roots
-]
-
-{ #category : 'tests' }
-StFileDialogTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
-	| newDirectory |
-	newDirectory := (root / 'dir') asFileReference.
-	dialog defaultFolder: newDirectory.
-	self
-		assert: (dialog fileReferenceTable items includesAll: newDirectory children)
 ]

--- a/src/NewTools-FileBrowser-Tests/StNavigationSystemTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StNavigationSystemTest.class.st
@@ -40,7 +40,7 @@ StNavigationSystemTest >> testCustomizationWhenChangeCollectionOfPreviewerShould
 
 { #category : 'tests' }
 StNavigationSystemTest >> testInitializeCurrentPathTextInputShouldSet [
-	self assert: dialog currentDirectory fullName equals: dialog currentPathTextInputPresenter entityText text 
+	self assert: dialog currentDirectory fullName equals: dialog pathBreadcrumbPresenter entityText text 
 ]
 
 { #category : 'tests' }
@@ -150,8 +150,8 @@ StNavigationSystemTest >> testWhenOpenADirectoryShouldDisplayHisChildrenFilterBy
 { #category : 'tests' }
 StNavigationSystemTest >> testWhenPathTextInputPresenterAcceptShouldChangeFileListWithTheGoodContent [
 
-	dialog currentPathTextInputPresenter pathTextChangedTo:
-		(dialog currentPathTextInputPresenter entityText text asPath / 'dir')
+	dialog pathBreadcrumbPresenter pathTextChangedTo:
+		(dialog pathBreadcrumbPresenter entityText text asPath / 'dir')
 			pathString.
 	self
 		assertCollection:

--- a/src/NewTools-FileBrowser-Tests/StOpenDirectoryDialogTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenDirectoryDialogTest.class.st
@@ -44,3 +44,13 @@ StOpenDirectoryDialogTest >> testSelectNonexistingDirectory [
 		raise: DirectoryDoesNotExist.
 	self assert: dialog currentDirectory equals: root
 ]
+
+{ #category : 'tests' }
+StOpenDirectoryDialogTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
+	| newDirectory |
+	newDirectory := (root / 'dir') asFileReference.
+	dialog defaultFolder: newDirectory.
+
+	"Since we're only displaying directories, no files should appear in the reference table"
+	self assertEmpty: dialog fileReferenceTable items
+]

--- a/src/NewTools-FileBrowser-Tests/StOpenFileDialogTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenFileDialogTest.class.st
@@ -52,3 +52,12 @@ StOpenFileDialogTest >> testSelectFile [
 	dialog confirm.
 	self assert: selectedFile equals: root / 'sth.ext'
 ]
+
+{ #category : 'tests' }
+StOpenFileDialogTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
+	| newDirectory |
+	newDirectory := (root / 'dir') asFileReference.
+	dialog defaultFolder: newDirectory.
+	self
+		assert: (dialog fileReferenceTable items includesAll: newDirectory children)
+]

--- a/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
@@ -1,7 +1,6 @@
 Class {
 	#name : 'StDirectoryNavigationSystemPresenter',
 	#superclass : 'StFileNavigationSystemPresenter',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'

--- a/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
@@ -1,6 +1,7 @@
 Class {
 	#name : 'StDirectoryNavigationSystemPresenter',
 	#superclass : 'StFileNavigationSystemPresenter',
+	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'

--- a/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryNavigationSystemPresenter.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : 'StDirectoryNavigationSystemPresenter',
+	#superclass : 'StFileNavigationSystemPresenter',
+	#category : 'NewTools-FileBrowser-UI',
+	#package : 'NewTools-FileBrowser',
+	#tag : 'UI'
+}
+
+{ #category : 'utilities' }
+StDirectoryNavigationSystemPresenter >> updateFileReferenceTable [
+	"Update the receiver's contents according to the current directory and apply configured filters"
+	
+	fileReferenceTable items: 
+		(self currentDirectory children select: [ : c |
+			c exists and: [ c isDirectory ]]).
+]

--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -4,6 +4,7 @@ Implements a basic Spec presenter to display a directory tree.
 Class {
 	#name : 'StDirectoryTreePresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'directoryTreePresenter'
 	],
@@ -87,9 +88,8 @@ StDirectoryTreePresenter >> initializePresenters [
 { #category : 'utilities' }
 StDirectoryTreePresenter >> openFolder: aFileReference [ 
 
-	model openFolder: aFileReference.
 	self owner updateWidgetWithFileReference: aFileReference.
-	self expandPath: aFileReference.
+
 ]
 
 { #category : 'accessing' }
@@ -107,9 +107,14 @@ StDirectoryTreePresenter >> shouldReparent [
 ]
 
 { #category : 'utilities' }
-StDirectoryTreePresenter >> updateFileSystemContents [
+StDirectoryTreePresenter >> updateFileDirectoryTree [
 
-	super updateFileSystemContents.
 	directoryTreePresenter roots: StFileSystemItemWrapper roots.
 	self expandPath: self currentDirectory.
+]
+
+{ #category : 'utilities' }
+StDirectoryTreePresenter >> updateWidgetWithFileReference: aFileReference [
+
+	self expandPath: aFileReference.
 ]

--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -18,7 +18,7 @@ StDirectoryTreePresenter class >> buildCommandsGroupWith: presenterInstance forR
 
 	rootCommandGroup
 		register: (
-			(CmCommandGroup named: 'StFBDirectoryContextualMenu') asSpecGroup
+			(CmCommandGroup named: 'StFileBrowserDirectoryContextualMenu') asSpecGroup
 				register: StFileBrowserNewDirectoryCommand forSpec;			
 				register: StFileBrowserRenameCommand forSpec;
 				register: StFileBrowserRemoveCommand forSpec;
@@ -82,7 +82,7 @@ StDirectoryTreePresenter >> initializePresenters [
 		roots: StFileSystemItemWrapper roots;
 		children: [ :aClass | aClass subdirectories ];
 		beResizable;
-		contextMenu: [ (self rootCommandsGroup / 'StFBDirectoryContextualMenu') beRoot asMenuPresenter ].
+		contextMenu: [ (self rootCommandsGroup / 'StFileBrowserDirectoryContextualMenu') beRoot asMenuPresenter ].
 ]
 
 { #category : 'utilities' }

--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -4,7 +4,6 @@ Implements a basic Spec presenter to display a directory tree.
 Class {
 	#name : 'StDirectoryTreePresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'directoryTreePresenter'
 	],

--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -46,6 +46,12 @@ StFileBrowserAbstractPresenter class >> lastVisitedDirectory [
 ]
 
 { #category : 'instance creation' }
+StFileBrowserAbstractPresenter class >> new [
+
+	^ self on: StFileSystemModel new
+]
+
+{ #category : 'instance creation' }
 StFileBrowserAbstractPresenter class >> open [
 
 	^ (self on: StFileSystemModel new) open
@@ -105,6 +111,16 @@ StFileBrowserAbstractPresenter >> currentDirectory [
 StFileBrowserAbstractPresenter >> currentDirectory: aFileReference [
 
 	self model currentDirectory: aFileReference.
+]
+
+{ #category : 'initialization' }
+StFileBrowserAbstractPresenter >> defaultColumns [
+
+	^ { 
+		StFileBrowserModificationDateColumn .
+		StFileBrowserSizeColumn .
+		StFileBrowserRightsColumn 
+		}
 ]
 
 { #category : 'defaults' }

--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -1,7 +1,6 @@
 Class {
 	#name : 'StFileBrowserAbstractPresenter',
 	#superclass : 'StPresenter',
-	#classTraits : 'TraitedClass',
 	#instVars : [
 		'model'
 	],

--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -15,36 +15,6 @@ Class {
 	#tag : 'UI'
 }
 
-{ #category : 'accessing' }
-StFileBrowserAbstractPresenter class >> defaultDirectory [
-	"Answer a <FileReference> with the default directory for opening the file browser and dialogs"
-
-	^ StFileBrowserSettings defaultDirectory
-]
-
-{ #category : 'class initialization' }
-StFileBrowserAbstractPresenter class >> initialize [
-
-	self initializeBookmarks.
-]
-
-{ #category : 'class initialization' }
-StFileBrowserAbstractPresenter class >> initializeBookmarks [
-
-	Bookmarks := StFileBrowserBookmark defaultBookmarks
-]
-
-{ #category : 'accessing' }
-StFileBrowserAbstractPresenter class >> lastVisitedDirectory [
-
-	(LastVisitedDirectory isNotNil and: [ 
-		 [ LastVisitedDirectory exists ]
-			 on: ResolutionRequest
-			 do: [ false ] ]) ifFalse: [ 
-		LastVisitedDirectory := self defaultDirectory ].
-	^ LastVisitedDirectory
-]
-
 { #category : 'instance creation' }
 StFileBrowserAbstractPresenter class >> new [
 
@@ -54,7 +24,7 @@ StFileBrowserAbstractPresenter class >> new [
 { #category : 'instance creation' }
 StFileBrowserAbstractPresenter class >> open [
 
-	^ (self on: StFileSystemModel new) open
+	^ self new open
 ]
 
 { #category : 'adding' }
@@ -69,15 +39,13 @@ StFileBrowserAbstractPresenter >> addBookmark: aFileReference [
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarks [
 
-	Bookmarks 
-		ifNil: [ self class initialize ].
-	^ Bookmarks
+	^ self model bookmarks 
 ]
 
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarks: aCollectionOfFDGroupBookMark [
 
-	Bookmarks := aCollectionOfFDGroupBookMark asOrderedCollection.
+	self model bookmarks: aCollectionOfFDGroupBookMark.
 	bookmarksTreeTable roots: Bookmarks 
 ]
 
@@ -97,7 +65,7 @@ StFileBrowserAbstractPresenter >> bookmarksTreeTableItems: aCollection [
 StFileBrowserAbstractPresenter >> createDirectory [
 
 	self model createDirectory.
-	self updateFileSystemContents.
+	self updateFileSystemPresenters.
 ]
 
 { #category : 'accessing' }
@@ -127,7 +95,7 @@ StFileBrowserAbstractPresenter >> defaultColumns [
 StFileBrowserAbstractPresenter >> defaultDirectory [
 	"See class side comment"
 
-	^ self class defaultDirectory.
+	^ self model defaultDirectory.
 ]
 
 { #category : 'accessing - history' }
@@ -140,14 +108,6 @@ StFileBrowserAbstractPresenter >> history [
 StFileBrowserAbstractPresenter >> history: aConfigurableHistoryIterator [ 
 
 	self model history: aConfigurableHistoryIterator.
-]
-
-{ #category : 'initialization' }
-StFileBrowserAbstractPresenter >> initialize [
-
-	super initialize.
-	(StFileBrowserSettings showAlwaysDefaultBookmarks and: [ self bookmarks isEmpty ])
-		ifTrue: [ self class initializeBookmarks ]
 ]
 
 { #category : 'initialization' }
@@ -190,7 +150,9 @@ StFileBrowserAbstractPresenter >> initializePresenters [
 
 { #category : 'accessing - history' }
 StFileBrowserAbstractPresenter >> lastVisitedDirectory [
-	^ self class lastVisitedDirectory.
+	"Answer the <FileReference> of the last visited directory"
+
+	^ self model lastVisitedDirectory
 ]
 
 { #category : 'accessing' }
@@ -211,7 +173,7 @@ StFileBrowserAbstractPresenter >> openOnLastDirectory [
 StFileBrowserAbstractPresenter >> resetBookmarks [
 	"Reset bookmarks to their defaults"
 
-	self class initializeBookmarks
+	self model resetBookmarks
 ]
 
 { #category : 'accessing - bookmarks' }
@@ -220,13 +182,7 @@ StFileBrowserAbstractPresenter >> selectedBookMark [
 ]
 
 { #category : 'accessing - model' }
-StFileBrowserAbstractPresenter >> setModelBeforeInitialization: aStFBFileSystemModel [
+StFileBrowserAbstractPresenter >> setModelBeforeInitialization: aStFileSystemModel [
 
-	model := aStFBFileSystemModel
-]
-
-{ #category : 'utilities' }
-StFileBrowserAbstractPresenter >> updateFileSystemContents [
-
-	self owner updateFileSystemContents
+	model := aStFileSystemModel
 ]

--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -30,10 +30,12 @@ StFileBrowserAbstractPresenter class >> open [
 { #category : 'adding' }
 StFileBrowserAbstractPresenter >> addBookmark: aFileReference [ 
 
-	self bookmarks add: (StFileBrowserBookmark 
-		name: aFileReference basename 
-		location: aFileReference 
-		icon: (self iconNamed: #book)).
+	self model addBookmark: aFileReference.
+	bookmarksTreeTable 
+		roots: self bookmarks;
+		expandRoots;
+		refresh.
+
 ]
 
 { #category : 'accessing - bookmarks' }
@@ -52,13 +54,6 @@ StFileBrowserAbstractPresenter >> bookmarks: aCollectionOfFDGroupBookMark [
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarksTreeTable [
 	^ bookmarksTreeTable
-]
-
-{ #category : 'accessing - bookmarks' }
-StFileBrowserAbstractPresenter >> bookmarksTreeTableItems: aCollection [
-	"Convenience method to set the receiver's bookmarks table items to aCollection"
-	
-	bookmarksTreeTable roots: aCollection
 ]
 
 { #category : 'utilities' }
@@ -185,4 +180,10 @@ StFileBrowserAbstractPresenter >> selectedBookMark [
 StFileBrowserAbstractPresenter >> setModelBeforeInitialization: aStFileSystemModel [
 
 	model := aStFileSystemModel
+]
+
+{ #category : 'utilities' }
+StFileBrowserAbstractPresenter >> updateFileSystemPresenters [
+
+	self owner updateFileSystemPresenters
 ]

--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : 'StPresenter',
 	#classTraits : 'TraitedClass',
 	#instVars : [
-		'bookmarksTreeTable',
 		'model'
 	],
 	#classVars : [
@@ -27,33 +26,30 @@ StFileBrowserAbstractPresenter class >> open [
 	^ self new open
 ]
 
-{ #category : 'adding' }
+{ #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> addBookmark: aFileReference [ 
 
-	self model addBookmark: aFileReference.
-	bookmarksTreeTable 
-		roots: self bookmarks;
-		expandRoots;
-		refresh.
+	self owner addBookmark: aFileReference.
+
 
 ]
 
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarks [
 
-	^ self model bookmarks 
+	^ self model bookmarks.
 ]
 
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarks: aCollectionOfFDGroupBookMark [
 
-	self model bookmarks: aCollectionOfFDGroupBookMark.
-	bookmarksTreeTable roots: Bookmarks 
+	self owner bookmarks: aCollectionOfFDGroupBookMark
 ]
 
 { #category : 'accessing - bookmarks' }
 StFileBrowserAbstractPresenter >> bookmarksTreeTable [
-	^ bookmarksTreeTable
+
+	^ self owner bookmarksTreeTable
 ]
 
 { #category : 'utilities' }
@@ -76,7 +72,7 @@ StFileBrowserAbstractPresenter >> currentDirectory: aFileReference [
 	self model currentDirectory: aFileReference.
 ]
 
-{ #category : 'initialization' }
+{ #category : 'defaults' }
 StFileBrowserAbstractPresenter >> defaultColumns [
 
 	^ { 
@@ -105,26 +101,6 @@ StFileBrowserAbstractPresenter >> history: aConfigurableHistoryIterator [
 	self model history: aConfigurableHistoryIterator.
 ]
 
-{ #category : 'initialization' }
-StFileBrowserAbstractPresenter >> initializeBookmarksTreeTable [
-
-	bookmarksTreeTable := self newTreeTable.
-	bookmarksTreeTable
-		hideColumnHeaders;
-		addColumn: (SpCompositeTableColumn new
-				 addColumn:
-					 (SpImageTableColumn evaluated: [ :each | each icon ])
-						 beNotExpandable;
-				 addColumn:
-					 (SpStringTableColumn evaluated: [ :groupBookMark | 
-							  groupBookMark name ]);
-				 yourself);
-		roots: self bookmarks;
-		children: #children;
-		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'Menu' ];
-		expandRoots
-]
-
 { #category : 'accessing - history' }
 StFileBrowserAbstractPresenter >> initializeHistoryIteratorWith: aDirectory [
 
@@ -134,13 +110,6 @@ StFileBrowserAbstractPresenter >> initializeHistoryIteratorWith: aDirectory [
 			ifFalse: [ self inform: 'Nothing to undo' ] ]
 		redo: [ :folder | self updateWidgetWithFileReference: folder ]).
 	self history register: aDirectory
-]
-
-{ #category : 'initialization' }
-StFileBrowserAbstractPresenter >> initializePresenters [ 
-
-	super initializePresenters.
-	self initializeBookmarksTreeTable
 ]
 
 { #category : 'accessing - history' }
@@ -157,6 +126,12 @@ StFileBrowserAbstractPresenter >> model [
 	^ model
 ]
 
+{ #category : 'hooks' }
+StFileBrowserAbstractPresenter >> navigationSystemClass [
+
+	^ self class navigationSystemClass
+]
+
 { #category : 'utilities' }
 StFileBrowserAbstractPresenter >> openOnLastDirectory [ 
 	"Answer <true> if receiver should open in the last used directory"
@@ -169,11 +144,6 @@ StFileBrowserAbstractPresenter >> resetBookmarks [
 	"Reset bookmarks to their defaults"
 
 	self model resetBookmarks
-]
-
-{ #category : 'accessing - bookmarks' }
-StFileBrowserAbstractPresenter >> selectedBookMark [
-	^ bookmarksTreeTable selection selectedItem
 ]
 
 { #category : 'accessing - model' }

--- a/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
@@ -27,6 +27,9 @@ StFileBrowserAddBookmarkCommand >> execute [
 
 	fileReference := self context selectedEntry.
 	self context addBookmark: fileReference.
+	self bookmarksTreeTable
+		roots: self context bookmarks;
+		expandRoots
 
 ]
 

--- a/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
@@ -26,7 +26,7 @@ StFileBrowserAddBookmarkCommand >> execute [
 	| fileReference |
 
 	fileReference := self context selectedEntry.
-	self context addBookmark: fileReference.
+	self contextModel addBookmark: fileReference.
 	self context bookmarksTreeTableItems: self context bookmarks
 ]
 

--- a/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAddBookmarkCommand.class.st
@@ -26,8 +26,8 @@ StFileBrowserAddBookmarkCommand >> execute [
 	| fileReference |
 
 	fileReference := self context selectedEntry.
-	self contextModel addBookmark: fileReference.
-	self context bookmarksTreeTableItems: self context bookmarks
+	self context addBookmark: fileReference.
+
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserBookmark.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserBookmark.class.st
@@ -29,7 +29,7 @@ StFileBrowserBookmark class >> defaultBookmarks [
 
 	^ OrderedCollection with:
 		  (StFileBrowserGroupBookmark
-			   name: 'Favourites'
+			   name: 'Bookmarks'
 			   collection: presets
 			   iconName: #book)
 ]

--- a/src/NewTools-FileBrowser/StFileBrowserCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserCommand.class.st
@@ -7,6 +7,12 @@ Class {
 }
 
 { #category : 'accessing' }
+StFileBrowserCommand >> contextModel [
+
+	^ self context model
+]
+
+{ #category : 'accessing' }
 StFileBrowserCommand >> iconProvider [ 
 
 	^ StFileBrowserIconCache 

--- a/src/NewTools-FileBrowser/StFileBrowserCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserCommand.class.st
@@ -7,12 +7,6 @@ Class {
 }
 
 { #category : 'accessing' }
-StFileBrowserCommand >> contextModel [
-
-	^ self context model
-]
-
-{ #category : 'accessing' }
 StFileBrowserCommand >> iconProvider [ 
 
 	^ StFileBrowserIconCache 

--- a/src/NewTools-FileBrowser/StFileBrowserCompressCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserCompressCommand.class.st
@@ -38,7 +38,7 @@ StFileBrowserCompressCommand >> execute [
 	zip addFile: self selectedEntry.
 	zip writeToFile: self selectedEntry parent / newZipName.
 	zip close.
-	self updateFileSystemContents
+	self updateFileSystemPresenters
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserRemoveBookmarkCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserRemoveBookmarkCommand.class.st
@@ -36,7 +36,9 @@ StFileBrowserRemoveBookmarkCommand >> execute [
 		tmpBookmark := tmpBookmark at: (collection at: 1).
 		collectionSize := collectionSize - 1 ].
 	tmpBookmark removeAt: (collection at: 1).
-	self bookmarksTreeTable roots: self context bookmarks
+	self bookmarksTreeTable 
+		roots: self context bookmarks;
+		expandRoots
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserRemoveCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserRemoveCommand.class.st
@@ -56,7 +56,7 @@ StFileBrowserRemoveCommand >> execute [
 		self confirmNotEmpty 
 			ifTrue: [ entryToDelete ensureDeleteAll ]
 			ifFalse: [ ^ self inform: 'Remove directory cancelled' ] ].
-	self context updateFileSystemContents
+	self context updateFileSystemPresenters
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserRenameCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserRenameCommand.class.st
@@ -47,7 +47,7 @@ StFileBrowserRenameCommand >> execute [
 	self requestNewName
 		ifNotNil: [ : newName | 
 			self selectedEntry renameTo: newName.
-			self updateFileSystemContents ]
+			self updateFileSystemPresenters ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserSelectionCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserSelectionCommand.class.st
@@ -41,10 +41,3 @@ StFileBrowserSelectionCommand >> selectedEntryName [
 
 	^ self selectedEntry name
 ]
-
-{ #category : 'utilities' }
-StFileBrowserSelectionCommand >> updateFileSystemContents [
-	"Update the receiver's file navigation table"
-
-	self context updateFileSystemContents
-]

--- a/src/NewTools-FileBrowser/StFileBrowserSelectionCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserSelectionCommand.class.st
@@ -41,3 +41,10 @@ StFileBrowserSelectionCommand >> selectedEntryName [
 
 	^ self selectedEntry name
 ]
+
+{ #category : 'utilities' }
+StFileBrowserSelectionCommand >> updateFileSystemPresenters [
+	"Update the receiver's file navigation table"
+
+	self context updateFileSystemPresenters
+]

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -45,7 +45,6 @@ StFileDialogPresenter textIcons method
 Class {
 	#name : 'StFileDialogPresenter',
 	#superclass : 'StFileSystemPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'okAction',
 		'filter'

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -336,7 +336,7 @@ StFileDialogPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 StFileDialogPresenter >> initializePresenters [
 
 	super initializePresenters.
-	fileNavigationSystem := self instantiate: StFileNavigationSystemPresenter on: model.
+	fileNavigationSystem := self instantiate: self navigationSystemClass on: model.
 	fileNavigationSystem 
 		filter: self filter;
 		columns: self defaultColumns.
@@ -362,6 +362,12 @@ StFileDialogPresenter >> isRootDirectory: aDirectory [
 StFileDialogPresenter >> isolate [
 	self bookmarks: self bookmarks copy.
 	
+]
+
+{ #category : 'hooks' }
+StFileDialogPresenter >> navigationSystemClass [
+
+	^ StFileNavigationSystemPresenter
 ]
 
 { #category : 'api - customization' }
@@ -425,6 +431,13 @@ StFileDialogPresenter >> setTitleTo: aSpWindowPresenter [
 StFileDialogPresenter >> showDirectory: aFileReference [
 
 	fileNavigationSystem currentDirectory: aFileReference
+]
+
+{ #category : 'utilities' }
+StFileDialogPresenter >> updateTreeNavigationWithFileReference: aFileReference [ 
+
+	aFileReference exists
+		ifTrue: [ treeNavigationSystem updateWidgetWithFileReference: aFileReference ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -52,7 +52,8 @@ Class {
 	#instVars : [
 		'fileNavigationSystem',
 		'okAction',
-		'filter'
+		'filter',
+		'treeNavigationSystem'
 	],
 	#classVars : [
 		'OkAction'
@@ -206,6 +207,9 @@ StFileDialogPresenter >> confirmed [
 { #category : 'initialization' }
 StFileDialogPresenter >> connectPresenters [
 
+	treeNavigationSystem
+		transmitDo: [ : selection | selection ifNotNil: [ self updateWidgetWithFileReference: selection fileReference ] ].
+
 	bookmarksTreeTable whenSelectionChangedDo: [ :selection | 
 		selection selectedItem ifNotNil: [ :selectedItem | 
 			selectedItem isComposite ifFalse: [ 
@@ -222,7 +226,11 @@ StFileDialogPresenter >> defaultLayout [
 
 	^ SpPanedLayout newLeftToRight
 		  positionOfSlider: 200;
-		  add: bookmarksTreeTable;
+		  add: (SpPanedLayout newTopToBottom
+				positionOfSlider: 450;		
+				add: treeNavigationSystem;
+				add: bookmarksTreeTable;
+				yourself);
 		  add: fileNavigationSystem;
 		  yourself
 ]
@@ -278,6 +286,17 @@ StFileDialogPresenter >> iconFor: anEntry [
 ]
 
 { #category : 'initialization' }
+StFileDialogPresenter >> initialExtentForWindow [
+
+	^ 1050 @ 750
+]
+
+{ #category : 'hooks' }
+StFileDialogPresenter >> initialTitle [
+	^ self subclassResponsibility
+]
+
+{ #category : 'initialization' }
 StFileDialogPresenter >> initialize [
 
 	super initialize.
@@ -318,15 +337,20 @@ StFileDialogPresenter >> initializePresenters [
 
 	super initializePresenters.
 	fileNavigationSystem := self instantiate: StFileNavigationSystemPresenter on: model.
-	fileNavigationSystem filter: self filter.
+	fileNavigationSystem 
+		filter: self filter;
+		columns: self defaultColumns.
+		
+	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: model.
+	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.
 ]
 
 { #category : 'initialization' }
-StFileDialogPresenter >> initializeWindow: aWindowPresenter [
+StFileDialogPresenter >> initializeWindow: aSpWindowPresenter [
 
-	aWindowPresenter
-		title: self title;
-		initialExtent: 1050 @ 750
+	self setTitleTo: aSpWindowPresenter.
+	self setInitialExtentTo: aSpWindowPresenter
+
 ]
 
 { #category : 'accessing' }
@@ -384,8 +408,29 @@ StFileDialogPresenter >> selectedEntry [
 	^ entry
 ]
 
+{ #category : 'initialization' }
+StFileDialogPresenter >> setInitialExtentTo: aSpWindowPresenter [
+	
+	aSpWindowPresenter initialExtent: self initialExtentForWindow
+]
+
+{ #category : 'initialization' }
+StFileDialogPresenter >> setTitleTo: aSpWindowPresenter [
+
+	aSpWindowPresenter title: self initialTitle
+
+]
+
 { #category : 'accessing' }
 StFileDialogPresenter >> showDirectory: aFileReference [
 
 	fileNavigationSystem currentDirectory: aFileReference
+]
+
+{ #category : 'initialization' }
+StFileDialogPresenter >> updateWidgetWithFileReference: aFileReference [
+
+	self currentDirectory: aFileReference.
+	aFileReference exists
+		ifTrue: [ fileNavigationSystem updateWidgetWithFileReference: aFileReference ]
 ]

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -2,20 +2,17 @@
 Abstract base class for different styles of opening/saving.
 Do not use this class directly, instead check subclasses to see specific uses.
 
-## Author 
+## Authors
 
-- Main Author : peteruhnak
-- Migrator Spec 1 to Spec 2 : CafeKrem (github pseudo)
-- Authors: Esteban Lorenzano, Hernán Morales Durand.
+- Initial release : peteruhnak
+- Migration Spec 1 to Spec 2 : CafeKrem (github pseudo)
+- Enhacements and fixes: Esteban Lorenzano, Hernán Morales Durand.
 
 ## Examples
 
 ```smalltalk
-StFBFileDialogPresenter fullExample
-```
-
-```smalltalk
-FDOpenFileDialog open
+""To open an 'Open File' dialog:""
+StOpenFileDialog open.
 ```
 
 ## Customization
@@ -27,7 +24,7 @@ This class defines methods to customize your File Dialog Presenters
 - `defaultFolder: aPath` Used to open a fileDialog on a aPath, this path must exist and be a directory
 
 ```smalltalk
-(StFBOpenFileDialog new defaultFolder: '/home/cdutriez/' asFileReference) open 
+(StOpenFileDialog new defaultFolder: '/usr/bin/' asFileReference) open 
 ```
 
 - `filtersCustomization: aCollection` Used to define a set of Filter (choose one or more among `StFBAbstractPredicate` or create a new  predicate)
@@ -35,25 +32,23 @@ This class defines methods to customize your File Dialog Presenters
 There is always a default filter (`filterNothing`)
 
 ```smalltalk		
-(StFBOpenFileDialog new filtersCustomization: { StFBJPGAndPNGPredicate new }) open
+(StOpenFileDialog new filtersCustomization: { StJPGAndPNGPredicate new }) open
 ```
-
 	
 ## Icons
 
 If you want to add icons you just have to create a method with pragma <icons> and this method have to return an array of association 
 
-FDFileDialogPresenter textIcons method 
+StFileDialogPresenter textIcons method 
 
 "
 Class {
 	#name : 'StFileDialogPresenter',
-	#superclass : 'StFileBrowserAbstractPresenter',
+	#superclass : 'StFileSystemPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
-		'fileNavigationSystem',
 		'okAction',
-		'filter',
-		'treeNavigationSystem'
+		'filter'
 	],
 	#classVars : [
 		'OkAction'
@@ -69,15 +64,6 @@ StFileDialogPresenter class >> allIcons [
 	^ (Pragma allNamed: 'icons' in: StFileDialogPresenter class)
 		flatCollect:
 			[ :pragma | pragma methodClass instanceSide perform: pragma methodSelector ]
-]
-
-{ #category : 'commander2' }
-StFileDialogPresenter class >> buildCommandsGroupWith: presenter forRoot: rootCommandGroup [
-	rootCommandGroup
-		register:
-			((CmCommandGroup named: 'Menu') asSpecGroup
-				register: StFileBrowserRemoveBookmarkCommand forSpec;
-				yourself)
 ]
 
 { #category : 'examples' }
@@ -150,12 +136,6 @@ StFileDialogPresenter class >> initialize [
 
 ]
 
-{ #category : 'instance creation' }
-StFileDialogPresenter class >> new [
-
-	^ self on: StFileSystemModel new
-]
-
 { #category : 'icons' }
 StFileDialogPresenter class >> textIcons [
 	<icons>
@@ -183,7 +163,8 @@ StFileDialogPresenter >> cancelled [
 
 { #category : 'api - customization' }
 StFileDialogPresenter >> columns: aCollectionOfColumns [
-	fileNavigationSystem columns: aCollectionOfColumns 
+
+	self fileNavigationSystem columns: aCollectionOfColumns 
 ]
 
 { #category : 'actions' }
@@ -204,35 +185,9 @@ StFileDialogPresenter >> confirmed [
 	okAction cull: self selectedEntry
 ]
 
-{ #category : 'initialization' }
-StFileDialogPresenter >> connectPresenters [
-
-	treeNavigationSystem
-		transmitDo: [ : selection | selection ifNotNil: [ self updateWidgetWithFileReference: selection fileReference ] ].
-
-	bookmarksTreeTable whenSelectionChangedDo: [ :selection | 
-		selection selectedItem ifNotNil: [ :selectedItem | 
-			selectedItem isComposite ifFalse: [ 
-				fileNavigationSystem openFolder: selectedItem location ] ] ]
-]
-
 { #category : 'api - customization' }
 StFileDialogPresenter >> defaultFolder: aPath [
-	fileNavigationSystem defaultFolder: aPath
-]
-
-{ #category : 'layout' }
-StFileDialogPresenter >> defaultLayout [
-
-	^ SpPanedLayout newLeftToRight
-		  positionOfSlider: 200;
-		  add: (SpPanedLayout newTopToBottom
-				positionOfSlider: 450;		
-				add: treeNavigationSystem;
-				add: bookmarksTreeTable;
-				yourself);
-		  add: fileNavigationSystem;
-		  yourself
+	self fileNavigationSystem defaultFolder: aPath
 ]
 
 { #category : 'accessing' }
@@ -251,13 +206,8 @@ StFileDialogPresenter >> extensions: aCollectionOfExtensions named: aString [
 ]
 
 { #category : 'accessing' }
-StFileDialogPresenter >> fileNavigationSystem [
-	^ fileNavigationSystem
-]
-
-{ #category : 'accessing' }
 StFileDialogPresenter >> fileReferenceTable [
-	^ fileNavigationSystem fileReferenceTable
+	^ self fileNavigationSystem fileReferenceTable
 ]
 
 { #category : 'accessing' }
@@ -270,7 +220,7 @@ StFileDialogPresenter >> filter [
 StFileDialogPresenter >> filter: aStFBFilter [
 
 	filter := aStFBFilter.
-	fileNavigationSystem ifNotNil: [ fileNavigationSystem filter: filter ]
+	self fileNavigationSystem ifNotNil: [ self fileNavigationSystem filter: filter ]
 ]
 
 { #category : 'utilities' }
@@ -288,10 +238,10 @@ StFileDialogPresenter >> iconFor: anEntry [
 { #category : 'initialization' }
 StFileDialogPresenter >> initialExtentForWindow [
 
-	^ 1050 @ 750
+	^ (1050 @ 750) scaledByDisplayScaleFactor
 ]
 
-{ #category : 'hooks' }
+{ #category : 'initialization' }
 StFileDialogPresenter >> initialTitle [
 	^ self subclassResponsibility
 ]
@@ -310,8 +260,8 @@ StFileDialogPresenter >> initializeConfirmButton: aButton [
 	self allowsChooseDirectoryIfNoFilename ifTrue: [ ^ self ].
 	buttonEnableBlock := [ :newText | 
 	                     aButton enabled: newText trimmed isNotEmpty ].
-	fileNavigationSystem nameText whenTextChangedDo: buttonEnableBlock.
-	buttonEnableBlock value: fileNavigationSystem nameText text
+	self fileNavigationSystem nameText whenTextChangedDo: buttonEnableBlock.
+	buttonEnableBlock value: self fileNavigationSystem nameText text
 ]
 
 { #category : 'initialization' }
@@ -332,27 +282,6 @@ StFileDialogPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 	self initializeConfirmButton: confirmButton
 ]
 
-{ #category : 'initialization' }
-StFileDialogPresenter >> initializePresenters [
-
-	super initializePresenters.
-	fileNavigationSystem := self instantiate: self navigationSystemClass on: model.
-	fileNavigationSystem 
-		filter: self filter;
-		columns: self defaultColumns.
-		
-	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: model.
-	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.
-]
-
-{ #category : 'initialization' }
-StFileDialogPresenter >> initializeWindow: aSpWindowPresenter [
-
-	self setTitleTo: aSpWindowPresenter.
-	self setInitialExtentTo: aSpWindowPresenter
-
-]
-
 { #category : 'accessing' }
 StFileDialogPresenter >> isRootDirectory: aDirectory [
 	^ aDirectory isRoot or: [ OSPlatform current isWindows and: [ aDirectory parent isRoot ] ]
@@ -362,12 +291,6 @@ StFileDialogPresenter >> isRootDirectory: aDirectory [
 StFileDialogPresenter >> isolate [
 	self bookmarks: self bookmarks copy.
 	
-]
-
-{ #category : 'hooks' }
-StFileDialogPresenter >> navigationSystemClass [
-
-	^ StFileNavigationSystemPresenter
 ]
 
 { #category : 'api - customization' }
@@ -390,23 +313,23 @@ StFileDialogPresenter >> openModal [
 
 { #category : 'api - customization' }
 StFileDialogPresenter >> previewer: aPreviewer [ 
-	fileNavigationSystem previewer: aPreviewer
+	self fileNavigationSystem previewer: aPreviewer
 ]
 
 { #category : 'utilities' }
 StFileDialogPresenter >> selectFile: aFile [
 
-	fileNavigationSystem selectedEntry = aFile ifFalse: [ 
-		fileNavigationSystem fileReferenceTable selectIndex:
-			(fileNavigationSystem fileReferenceTable items indexOf: aFile) ].
-	fileNavigationSystem nameText text: aFile basename
+	self fileNavigationSystem selectedEntry = aFile ifFalse: [ 
+		self fileNavigationSystem fileReferenceTable selectIndex:
+			(self fileNavigationSystem fileReferenceTable items indexOf: aFile) ].
+	self fileNavigationSystem nameText text: aFile basename
 ]
 
 { #category : 'accessing' }
 StFileDialogPresenter >> selectedEntry [
 
 	| entry |
-	entry := fileNavigationSystem selectedEntry.
+	entry := self fileNavigationSystem selectedEntry.
 	(self allowsChooseDirectoryIfNoFilename not and: [ 
 		 entry exists and: [ entry isDirectory ] ]) ifTrue: [ 
 		self inform: 'Only files could be selected (no directories)'.
@@ -414,30 +337,10 @@ StFileDialogPresenter >> selectedEntry [
 	^ entry
 ]
 
-{ #category : 'initialization' }
-StFileDialogPresenter >> setInitialExtentTo: aSpWindowPresenter [
-	
-	aSpWindowPresenter initialExtent: self initialExtentForWindow
-]
-
-{ #category : 'initialization' }
-StFileDialogPresenter >> setTitleTo: aSpWindowPresenter [
-
-	aSpWindowPresenter title: self initialTitle
-
-]
-
 { #category : 'accessing' }
 StFileDialogPresenter >> showDirectory: aFileReference [
 
-	fileNavigationSystem currentDirectory: aFileReference
-]
-
-{ #category : 'utilities' }
-StFileDialogPresenter >> updateTreeNavigationWithFileReference: aFileReference [ 
-
-	aFileReference exists
-		ifTrue: [ treeNavigationSystem updateWidgetWithFileReference: aFileReference ]
+	self fileNavigationSystem currentDirectory: aFileReference
 ]
 
 { #category : 'initialization' }
@@ -445,5 +348,5 @@ StFileDialogPresenter >> updateWidgetWithFileReference: aFileReference [
 
 	self currentDirectory: aFileReference.
 	aFileReference exists
-		ifTrue: [ fileNavigationSystem updateWidgetWithFileReference: aFileReference ]
+		ifTrue: [ self fileNavigationSystem updateWidgetWithFileReference: aFileReference ]
 ]

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -1,55 +1,43 @@
 "
-I'm use by thez fileDialog
+This Spec presenter provides:
 
-my job is to navigate across file 
+* An history of visited folder.
+* A text input use to jump to the write path.
+* A drop list use to filter the content of the fileReferenceTable
+* A text presenter to show a preview of the currently selected file.
 
-I provide:
-* an history of visited folder
-* a textInput use to jump to the write path
-* a dropList use to filter the content of the fileReferenceTable
-* a TextPresenter to show the selectedFile 
+## Example
 
-CUSTOMIZATION
--------------
+To open a navigation presenter for PNG files, evaluate:
 
-look at the protocol 'api-customization'
+```smalltalk
+StFileNavigationSystemPresenter example.
+```
 
-column: aCollectionOfColumn
-===========================
+## Customization
 
-	to use it you have to give a collection of son of FDAbstractFileReferenceColumn for more information on how to create see documentation of FDAbstractFileReferenceColumn
+You can customize how this presenter is displayed, with methods listed at the protocol 'api-customization'. These are some examples:
 
-defaultFoler: aFileReference
-============================
-
-	nothing to say 
-
-filtersCustomization: aCollectionOfFilter
-=========================================
-
-	more documentation see FDAbstractPredicate documentation
-
-previewer: aPreviewer
-=====================
-
-	more documentation see FDAbstractPreviewer documentation
+* `column: aCollectionOfColumn` : Give a `Collection` of any subclass of `StFileBrowserAbstractColumn`.
+* `defaultFoler: aFileReference`
+* `filtersCustomization: aCollectionOfFilter` : See `StFileBrowserAbstractFilter` on tge avaiable filters and how to instantiate them.
+* `previewer: aPreviewer` : See `StFileBrowserAbstractPreviewer` to check the available previewers.
 	
-IV
---
+## Instance variables
 
-currentPathTextInputPresenter : <SpTextInputFieldPresenter> It's use to display the current path and there are same feature like in window 
-nameLabel : <SpLabelPresenter>
-nameText: <SpTextInputFieldPresenter> , use to show the name of the selected item of fileReferenceTable
-filtersDropList <SpDropList> , use to display all the filter
-readPointerHistoryParcour <DoubleLink> , use for the navigationSystem
-currentDirectory , <FileReference> into there is the currentDirectory 
-hiddenFilter <FDAbstractPredicate> there is a NullFilter or an hiddenFilter
-columns <FDAbstractFileReferenceColumn> it's a collection of Column use by FileReferenceTable
-previewer <FDAbstractPreviewer> 
-nextButton <SpButton> use for the navigationSystem 
-previousButton <SpButton> use for the navigationSystem
-notebookPreviewer <SpNoteBook> use by the preview system
-fileReferenceTable <SpTablePresenter> it's display children of the current directory
+* currentPathTextInputPresenter : <SpTextInputFieldPresenter> It's use to display the current path and there are same feature like in window 
+* nameLabel : <SpLabelPresenter>
+* nameText: <SpTextInputFieldPresenter> , use to show the name of the selected item of fileReferenceTable
+* filtersDropList <SpDropList> , use to display all the filter
+* readPointerHistoryParcour <DoubleLink> , use for the navigationSystem
+* currentDirectory , <FileReference> into there is the currentDirectory 
+* hiddenFilter <FDAbstractPredicate> there is a NullFilter or an hiddenFilter
+* columns <FDAbstractFileReferenceColumn> it's a collection of Column use by FileReferenceTable
+* previewer <FDAbstractPreviewer> 
+* nextButton <SpButton> use for the navigationSystem 
+* previousButton <SpButton> use for the navigationSystem
+* notebookPreviewer <SpNoteBook> use by the preview system
+* fileReferenceTable <SpTablePresenter> it's display children of the current directory
 "
 Class {
 	#name : 'StFileNavigationSystemPresenter',
@@ -267,6 +255,7 @@ StFileNavigationSystemPresenter >> initialize [
 { #category : 'initialization' }
 StFileNavigationSystemPresenter >> initializeFilesTable [
 
+	fileReferenceTable := self newTable.
 	fileReferenceTable
 		beResizable;
 		columns: StFileBrowserAbstractColumn columns;
@@ -306,7 +295,6 @@ StFileNavigationSystemPresenter >> initializePresenters [
 
 	super initializePresenters.
 	notebookPreviewer := self instantiate: StNoteBookPreviewerPresenter.
-	fileReferenceTable := self newTable.
 	currentPathTextInputPresenter := self instantiate: StPathBreadcrumbPresenter on: self model.
 	nameText := self newTextInput.
 	filtersDropList := self newDropList.

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -42,7 +42,6 @@ You can customize how this presenter is displayed, with methods listed at the pr
 Class {
 	#name : 'StFileNavigationSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'nameText',
 		'filtersDropList',

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -67,7 +67,7 @@ Class {
 StFileNavigationSystemPresenter class >> buildCommandsGroupWith: presenter forRoot: rootCommandGroup [
 	rootCommandGroup
 		register:
-			((CmCommandGroup named: 'StFBNavigationMenu') asSpecGroup
+			((CmCommandGroup named: 'StFileBrowserNavigationMenu') asSpecGroup
 				register: StFileBrowserNewDirectoryCommand forSpec;
 				register: StFileBrowserCopyBasenameCommand forSpec;
 				register: StFileBrowserCopyFullnameCommand forSpec;				
@@ -258,7 +258,7 @@ StFileNavigationSystemPresenter >> initializeFilesTable [
 			a isDirectory & b isDirectory not or: [ 
 					a isDirectory = b isDirectory and: [ 
 							a basename asLowercase < b basename asLowercase ] ] ];
-		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'StFBNavigationMenu' ]
+		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'StFileBrowserNavigationMenu' ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -42,8 +42,8 @@ You can customize how this presenter is displayed, with methods listed at the pr
 Class {
 	#name : 'StFileNavigationSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
-		'currentPathTextInputPresenter',
 		'nameText',
 		'filtersDropList',
 		'filter',
@@ -52,7 +52,8 @@ Class {
 		'previousButton',
 		'notebookPreviewer',
 		'fileReferenceTable',
-		'configButton'
+		'configButton',
+		'pathBreadcrumbPresenter'
 	],
 	#classVars : [
 		'Previewer'
@@ -106,7 +107,6 @@ StFileNavigationSystemPresenter class >> example [
 { #category : 'class initialization' }
 StFileNavigationSystemPresenter class >> initialize [
 
-	self initializeBookmarks.
 	Previewer := self defaultPreviewer
 ]
 
@@ -142,11 +142,6 @@ StFileNavigationSystemPresenter >> connectPresenters [
 	self configButtonAction.
 ]
 
-{ #category : 'accessing' }
-StFileNavigationSystemPresenter >> currentPathTextInputPresenter [
-	^ currentPathTextInputPresenter
-]
-
 { #category : 'api - customization' }
 StFileNavigationSystemPresenter >> defaultFolder: aFileReference [
 	self updateWidgetWithFileReference: aFileReference.
@@ -161,7 +156,7 @@ StFileNavigationSystemPresenter >> defaultLayout [
 				vAlignCenter;
 				add: previousButton expand: false;
 				add: nextButton expand: false;
-				add: currentPathTextInputPresenter;
+				add: pathBreadcrumbPresenter;
 			   addLast: configButton;				
 				yourself)
 			 expand: false;
@@ -241,7 +236,7 @@ StFileNavigationSystemPresenter >> filtersDropList [
 
 { #category : 'actions' }
 StFileNavigationSystemPresenter >> filtersDropListAction [
-	filtersDropList whenSelectionChangedDo: [ self updateFileSystemContents ]
+	filtersDropList whenSelectionChangedDo: [ self updateFileReferenceTable ]
 ]
 
 { #category : 'initialization' }
@@ -295,7 +290,7 @@ StFileNavigationSystemPresenter >> initializePresenters [
 
 	super initializePresenters.
 	notebookPreviewer := self instantiate: StNoteBookPreviewerPresenter.
-	currentPathTextInputPresenter := self instantiate: StPathBreadcrumbPresenter on: self model.
+	pathBreadcrumbPresenter := self instantiate: StPathBreadcrumbPresenter on: self model.
 	nameText := self newTextInput.
 	filtersDropList := self newDropList.
 	configButton := self newButton
@@ -357,7 +352,13 @@ StFileNavigationSystemPresenter >> openFolder: aFileReference [
 
 	self updateWidgetWithFileReference: aFileReference.
 	model openFolder: aFileReference.
+	self owner updateTreeNavigationWithFileReference: aFileReference.
 
+]
+
+{ #category : 'accessing' }
+StFileNavigationSystemPresenter >> pathBreadcrumbPresenter [
+	^ pathBreadcrumbPresenter
 ]
 
 { #category : 'accessing' }
@@ -397,8 +398,9 @@ StFileNavigationSystemPresenter >> shouldReparent [
 ]
 
 { #category : 'utilities' }
-StFileNavigationSystemPresenter >> updateFileSystemContents [
-
+StFileNavigationSystemPresenter >> updateFileReferenceTable [
+	"Update the receiver's contents according to the current directory and apply configured filters"
+	
 	fileReferenceTable items:
 		((filtersDropList selectedItem ifNil: [ filter ]) applyOn:
 			 (self currentDirectory children select: #exists)).
@@ -406,8 +408,9 @@ StFileNavigationSystemPresenter >> updateFileSystemContents [
 
 { #category : 'utilities' }
 StFileNavigationSystemPresenter >> updateWidgetWithFileReference: aFileReference [
+	"A file reference was selected in the receiver or one of its subpresenters, update the file reference table and current directory"
 
 	self currentDirectory: aFileReference.
-	self updateFileSystemContents.
-	currentPathTextInputPresenter currentDirectory: self currentDirectory
+	self updateFileReferenceTable.
+	pathBreadcrumbPresenter currentDirectory: self currentDirectory
 ]

--- a/src/NewTools-FileBrowser/StFileSystemModel.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemModel.class.st
@@ -1,3 +1,12 @@
+"
+It provides the following file system services to UI:
+
+- History
+- Default directory (global variable).
+- Last visited directory (global variable).
+- Directory opening and creation.
+- Bookmarks
+"
 Class {
 	#name : 'StFileSystemModel',
 	#superclass : 'StPresenter',
@@ -6,6 +15,7 @@ Class {
 		'history'
 	],
 	#classVars : [
+		'Bookmarks',
 		'LastVisitedDirectory'
 	],
 	#category : 'NewTools-FileBrowser-UI',
@@ -15,8 +25,40 @@ Class {
 
 { #category : 'defaults' }
 StFileSystemModel class >> defaultDirectory [
+	"Answer a <FileReference> with the default directory for opening the file browser and dialogs"
 
 	^ StFileBrowserSettings defaultDirectory
+]
+
+{ #category : 'initialization' }
+StFileSystemModel class >> initializeBookmarks [
+
+	Bookmarks := StFileBrowserBookmark defaultBookmarks
+]
+
+{ #category : 'defaults' }
+StFileSystemModel class >> lastVisitedDirectory [
+
+	(LastVisitedDirectory isNotNil and: [ 
+		 [ LastVisitedDirectory exists ]
+			 on: ResolutionRequest
+			 do: [ false ] ]) ifFalse: [ 
+		LastVisitedDirectory := self defaultDirectory ].
+	^ LastVisitedDirectory
+]
+
+{ #category : 'accessing' }
+StFileSystemModel >> bookmarks [
+
+	Bookmarks 
+		ifNil: [ self class initializeBookmarks ].
+	^ Bookmarks
+]
+
+{ #category : 'accessing' }
+StFileSystemModel >> bookmarks: aCollectionOfGroupBookMark [
+
+	Bookmarks := aCollectionOfGroupBookMark asOrderedCollection
 ]
 
 { #category : 'utilities' }
@@ -26,20 +68,20 @@ StFileSystemModel >> createDirectory [
 
 { #category : 'utilities' }
 StFileSystemModel >> createDirectory: initialName [
+
 	| name path |
-	name := (UIManager default
-		request: 'Folder name'
-		initialAnswer: initialName
-		title: 'Create New Folder') ifNil: [ ^ self ].
-	path := currentDirectory / name.
-	path exists
-		ifFalse: [ (currentDirectory / name) ensureCreateDirectory.
+	
+	(name := self requestUserDirectory: initialName) isEmptyOrNil 
+		ifTrue: [ ^ self ].
+	(path := currentDirectory / name) exists
+		ifFalse: [ 
+			(currentDirectory / name) ensureCreateDirectory.
 			self openFolder: currentDirectory.
 			^ self ].
 	path isDirectory
-		ifTrue: [ UIManager default alert: 'A folder with that name already exists.' ].
+		ifTrue: [ self application alert: 'A folder with that name already exists.' ].
 	path isFile
-		ifTrue: [ UIManager default alert: 'A file with that name already exists.' ].
+		ifTrue: [ self application alert: 'A file with that name already exists.' ].
 	self createDirectory: name
 ]
 
@@ -73,8 +115,42 @@ StFileSystemModel >> history: aConfigurableHistoryIterator [
 	history := aConfigurableHistoryIterator
 ]
 
+{ #category : 'initialization' }
+StFileSystemModel >> initialize [
+
+	super initialize.
+	(StFileBrowserSettings showAlwaysDefaultBookmarks and: [ self bookmarks isEmpty ])
+		ifTrue: [ self class initializeBookmarks ]
+]
+
+{ #category : 'accessing' }
+StFileSystemModel >> lastVisitedDirectory [
+	"Answer the <FileReference> of the last visited directory"
+
+	^ self class lastVisitedDirectory
+]
+
 { #category : 'utilities' }
 StFileSystemModel >> openFolder: aFileReference [
 
 	self history register: self currentDirectory.
+]
+
+{ #category : 'utilities' }
+StFileSystemModel >> requestUserDirectory: initialName [
+
+	| answer |
+	answer := [ self
+		request: 'Folder name'
+		initialAnswer: initialName
+		title: 'Create New Folder' ]
+	on: SpCancelledInteractionError
+	do: [ : ex | self inform: 'Cancelled'. nil ].
+	^ answer
+]
+
+{ #category : 'initialization' }
+StFileSystemModel >> resetBookmarks [ 
+
+	self bookmarks: nil.
 ]

--- a/src/NewTools-FileBrowser/StFileSystemModel.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemModel.class.st
@@ -47,6 +47,15 @@ StFileSystemModel class >> lastVisitedDirectory [
 	^ LastVisitedDirectory
 ]
 
+{ #category : 'adding' }
+StFileSystemModel >> addBookmark: aFileReference [ 
+
+	self bookmarks add: (StFileBrowserBookmark 
+		name: aFileReference basename 
+		location: aFileReference 
+		icon: (self iconNamed: #book)).
+]
+
 { #category : 'accessing' }
 StFileSystemModel >> bookmarks [
 

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -13,7 +13,6 @@ StFileSystemPresenter open.
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
 		'fileNavigationSystem',

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -1,19 +1,10 @@
 "
-It provides a File System Spec-based presenter, which replaces the old FileList tool.
-
-## Example
-
-To open a default File System Browser, evaluate:
-
-```smalltalk
-StFileSystemPresenter open.
-```
+General file system presenter, which replaces the older FileList tool.
 
 "
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
 		'fileNavigationSystem',

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -13,14 +13,27 @@ StFileSystemPresenter open.
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
-		'fileNavigationSystem'
+		'fileNavigationSystem',
+		'bookmarksTreeTable',
+		'navigationSystemClass'
 	],
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
 }
+
+{ #category : 'commands' }
+StFileSystemPresenter class >> buildCommandsGroupWith: presenter forRoot: rootCommandGroup [
+
+	rootCommandGroup
+		register:
+			((CmCommandGroup named: 'StFileBrowserBookmarksMenu') asSpecGroup
+				register: StFileBrowserRemoveBookmarkCommand forSpec;
+				yourself)
+]
 
 { #category : 'defaults' }
 StFileSystemPresenter class >> lastVisitedDirectory [
@@ -29,8 +42,14 @@ StFileSystemPresenter class >> lastVisitedDirectory [
 		 [ LastVisitedDirectory exists ]
 			 on: ResolutionRequest
 			 do: [ false ] ]) ifFalse: [ 
-		LastVisitedDirectory := self defaultDirectory ].
+		LastVisitedDirectory := StFileBrowserSettings defaultDirectory ].
 	^ LastVisitedDirectory 
+]
+
+{ #category : 'hooks' }
+StFileSystemPresenter class >> navigationSystemClass [
+
+	^ StFileNavigationSystemPresenter
 ]
 
 { #category : 'instance creation' }
@@ -40,11 +59,44 @@ StFileSystemPresenter class >> open [
 	^ self new open
 ]
 
+{ #category : 'accessing - bookmarks' }
+StFileSystemPresenter >> addBookmark: aFileReference [ 
+
+	self model addBookmark: aFileReference.
+	bookmarksTreeTable 
+		roots: self bookmarks;
+		expandRoots;
+		refresh.
+
+]
+
+{ #category : 'accessing - bookmarks' }
+StFileSystemPresenter >> bookmarks: aCollectionOfFDGroupBookMark [
+
+	bookmarksTreeTable roots: Bookmarks 
+]
+
+{ #category : 'accessing - bookmarks' }
+StFileSystemPresenter >> bookmarksTreeTable [
+	"Answer a <SpTreeTablePresenter> used to display the receiver's bookmarks"
+
+	^ bookmarksTreeTable
+]
+
 { #category : 'initialization' }
 StFileSystemPresenter >> connectPresenters [ 
+	"Here we check that the window is displayed. 
+	If it's not, that means this is a first opening so it should preserve the path selected by the user (through openOnLastDirectory preference, or defaultRoot: message send) and not to transmit the directory selection"
 
 	treeNavigationSystem
-		transmitDo: [ : selection | selection ifNotNil: [ self updateWidgetWithFileReference: selection fileReference ] ].
+		transmitDo: [ : selection | 
+			(self isDisplayed and: [ selection notNil ])
+				ifTrue: [ self updateWidgetWithFileReference: selection fileReference ] ].
+			
+	bookmarksTreeTable whenSelectionChangedDo: [ :selection | 
+		selection selectedItem ifNotNil: [ :selectedItem | 
+			selectedItem isComposite ifFalse: [ 
+				self fileNavigationSystem openFolder: selectedItem location ] ] ]
 
 ]
 
@@ -53,7 +105,11 @@ StFileSystemPresenter >> defaultLayout [
 
 	^ SpPanedLayout newLeftToRight
 			positionOfSlider: 0.2;
-			add: treeNavigationSystem;
+			add: (SpPanedLayout newTopToBottom
+				positionOfSlider: 300;		
+				add: treeNavigationSystem;
+				add: bookmarksTreeTable;
+				yourself);			
 			add: fileNavigationSystem;
 			yourself
 ]
@@ -65,6 +121,11 @@ StFileSystemPresenter >> expandPath: aFileReference [
 	treeNavigationSystem expandPath: aFileReference
 ]
 
+{ #category : 'accessing' }
+StFileSystemPresenter >> fileNavigationSystem [
+	^ fileNavigationSystem
+]
+
 { #category : 'initialization' }
 StFileSystemPresenter >> initialExtentForWindow [
 
@@ -72,15 +133,43 @@ StFileSystemPresenter >> initialExtentForWindow [
 ]
 
 { #category : 'initialization' }
+StFileSystemPresenter >> initialTitle [
+
+	^ 'File Browser'
+
+]
+
+{ #category : 'initialization' }
+StFileSystemPresenter >> initializeBookmarksTreeTable [
+
+	bookmarksTreeTable := self newTreeTable.
+	bookmarksTreeTable
+		hideColumnHeaders;
+		addColumn: (SpCompositeTableColumn new
+				 addColumn:
+					 (SpImageTableColumn evaluated: [ :each | each icon ])
+						 beNotExpandable;
+				 addColumn:
+					 (SpStringTableColumn evaluated: [ :groupBookMark | 
+							  groupBookMark name ]);
+				 yourself);
+		roots: self bookmarks;
+		children: #children;
+		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'StFileBrowserBookmarksMenu' ];
+		expandRoots
+]
+
+{ #category : 'initialization' }
 StFileSystemPresenter >> initializePresenters [
 
-	fileNavigationSystem := self instantiate: StFileNavigationSystemPresenter on: self model.
+	fileNavigationSystem := self instantiate: self navigationSystemClass on: self model.
 	fileNavigationSystem columns: self defaultColumns.
-	fileNavigationSystem fileReferenceTable beMultipleSelection.
+	fileNavigationSystem nameText disable.
 
 	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: self model.
 	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.	
 
+	self initializeBookmarksTreeTable.
 ]
 
 { #category : 'initialization' }
@@ -111,7 +200,7 @@ StFileSystemPresenter >> setInitialExtentTo: aSpWindowPresenter [
 { #category : 'initialization' }
 StFileSystemPresenter >> setTitleTo: aSpWindowPresenter [
 
-	aSpWindowPresenter title: 'File Browser'
+	aSpWindowPresenter title: self initialTitle
 
 ]
 
@@ -120,6 +209,11 @@ StFileSystemPresenter >> setWindowIconTo: aSpWindowPresenter [
 	
 	aSpWindowPresenter	windowIcon: (self iconNamed: #open).
 
+]
+
+{ #category : 'accessing' }
+StFileSystemPresenter >> treeNavigationSystem [
+	^ treeNavigationSystem
 ]
 
 { #category : 'utilities' }
@@ -134,13 +228,11 @@ StFileSystemPresenter >> updateFileSystemPresenters [
 { #category : 'utilities' }
 StFileSystemPresenter >> updateTreeNavigationWithFileReference: aFileReference [ 
 
-	aFileReference exists
-		ifTrue: [ treeNavigationSystem updateWidgetWithFileReference: aFileReference ]
+	treeNavigationSystem updateWidgetWithFileReference: aFileReference
 ]
 
 { #category : 'utilities' }
 StFileSystemPresenter >> updateWidgetWithFileReference: aFileReference [ 
 
-	aFileReference exists
-		ifTrue: [ fileNavigationSystem updateWidgetWithFileReference: aFileReference ]
+	fileNavigationSystem updateWidgetWithFileReference: aFileReference
 ]

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -129,11 +129,19 @@ StFileSystemPresenter >> setWindowIconTo: aSpWindowPresenter [
 ]
 
 { #category : 'utilities' }
-StFileSystemPresenter >> updateFileSystemContents [
+StFileSystemPresenter >> updateFileSystemPresenters [
 
-	fileNavigationSystem updateFileSystemContents.
+	fileNavigationSystem updateFileReferenceTable.
+	treeNavigationSystem updateFileDirectoryTree.
 
 
+]
+
+{ #category : 'utilities' }
+StFileSystemPresenter >> updateTreeNavigationWithFileReference: aFileReference [ 
+
+	aFileReference exists
+		ifTrue: [ treeNavigationSystem updateWidgetWithFileReference: aFileReference ]
 ]
 
 { #category : 'utilities' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -73,7 +73,7 @@ StFileSystemPresenter >> addBookmark: aFileReference [
 { #category : 'accessing - bookmarks' }
 StFileSystemPresenter >> bookmarks: aCollectionOfFDGroupBookMark [
 
-	bookmarksTreeTable roots: Bookmarks 
+	bookmarksTreeTable roots: aCollectionOfFDGroupBookMark 
 ]
 
 { #category : 'accessing - bookmarks' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -1,5 +1,13 @@
 "
-General file system presenter, which replaces the older FileList tool.
+It provides a File System Spec-based presenter, which replaces the old FileList tool.
+
+## Example
+
+To open a default File System Browser, evaluate:
+
+```smalltalk
+StFileSystemPresenter open.
+```
 
 "
 Class {
@@ -23,6 +31,13 @@ StFileSystemPresenter class >> lastVisitedDirectory [
 			 do: [ false ] ]) ifFalse: [ 
 		LastVisitedDirectory := self defaultDirectory ].
 	^ LastVisitedDirectory 
+]
+
+{ #category : 'instance creation' }
+StFileSystemPresenter class >> open [ 
+	<script>
+
+	^ self new open
 ]
 
 { #category : 'initialization' }
@@ -65,14 +80,12 @@ StFileSystemPresenter >> initialExtentForWindow [
 { #category : 'initialization' }
 StFileSystemPresenter >> initializePresenters [
 
-	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: self model.
 	fileNavigationSystem := self instantiate: StFileNavigationSystemPresenter on: self model.
-	fileNavigationSystem 
-		columns: { 
-			StFileBrowserModificationDateColumn .
-			StFileBrowserSizeColumn .
-			StFileBrowserRightsColumn }.
-	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.
+	fileNavigationSystem columns: self defaultColumns.
+	fileNavigationSystem fileReferenceTable beMultipleSelection.
+
+	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: self model.
+	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.	
 
 ]
 

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -46,12 +46,6 @@ StFileSystemPresenter >> connectPresenters [
 	treeNavigationSystem
 		transmitDo: [ : selection | selection ifNotNil: [ self updateWidgetWithFileReference: selection fileReference ] ].
 
-	fileNavigationSystem := self instantiate: StFileNavigationSystemPresenter on: self model.
-	fileNavigationSystem 
-		columns: { 
-			StFileBrowserModificationDateColumn .
-			StFileBrowserSizeColumn .
-			StFileBrowserRightsColumn }
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -13,11 +13,11 @@ StFileSystemPresenter open.
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
 		'fileNavigationSystem',
-		'bookmarksTreeTable',
-		'navigationSystemClass'
+		'bookmarksTreeTable'
 	],
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',

--- a/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
@@ -3,7 +3,7 @@ My responsibility is to provide dialog for selecting Directories.
 
 So no files will be shown in the file/folder listings.
 
-See superclass for more information about customization.
+see my super for more information about customization
 "
 Class {
 	#name : 'StOpenDirectoryDialog',
@@ -37,6 +37,12 @@ StOpenDirectoryDialog >> allowsChooseDirectoryIfNoFilename [
 { #category : 'hooks' }
 StOpenDirectoryDialog >> initialTitle [
 	^ 'Select Directory To Open'
+]
+
+{ #category : 'hooks' }
+StOpenDirectoryDialog >> navigationSystemClass [
+	
+	^ StDirectoryNavigationSystemPresenter 
 ]
 
 { #category : 'actions' }

--- a/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
@@ -8,7 +8,6 @@ see my super for more information about customization
 Class {
 	#name : 'StOpenDirectoryDialog',
 	#superclass : 'StOpenFileOrDirectoryDialog',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'

--- a/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
@@ -29,6 +29,12 @@ StOpenDirectoryDialog class >> exampleModal [
 ]
 
 { #category : 'hooks' }
+StOpenDirectoryDialog class >> navigationSystemClass [
+	
+	^ StDirectoryNavigationSystemPresenter 
+]
+
+{ #category : 'hooks' }
 StOpenDirectoryDialog >> allowsChooseDirectoryIfNoFilename [
 
 	^ true
@@ -37,12 +43,6 @@ StOpenDirectoryDialog >> allowsChooseDirectoryIfNoFilename [
 { #category : 'hooks' }
 StOpenDirectoryDialog >> initialTitle [
 	^ 'Select Directory To Open'
-]
-
-{ #category : 'hooks' }
-StOpenDirectoryDialog >> navigationSystemClass [
-	
-	^ StDirectoryNavigationSystemPresenter 
 ]
 
 { #category : 'actions' }

--- a/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryDialog.class.st
@@ -3,11 +3,12 @@ My responsibility is to provide dialog for selecting Directories.
 
 So no files will be shown in the file/folder listings.
 
-see my super for more information about customization
+See superclass for more information about customization.
 "
 Class {
 	#name : 'StOpenDirectoryDialog',
 	#superclass : 'StOpenFileOrDirectoryDialog',
+	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
@@ -33,7 +34,7 @@ StOpenDirectoryDialog >> allowsChooseDirectoryIfNoFilename [
 	^ true
 ]
 
-{ #category : 'accessing - ui' }
+{ #category : 'hooks' }
 StOpenDirectoryDialog >> initialTitle [
 	^ 'Select Directory To Open'
 ]

--- a/src/NewTools-FileBrowser/StOpenFileDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileDialog.class.st
@@ -9,7 +9,6 @@ examples see class side method example
 Class {
 	#name : 'StOpenFileDialog',
 	#superclass : 'StOpenFileOrDirectoryDialog',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'

--- a/src/NewTools-FileBrowser/StOpenFileDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileDialog.class.st
@@ -9,6 +9,7 @@ examples see class side method example
 Class {
 	#name : 'StOpenFileDialog',
 	#superclass : 'StOpenFileOrDirectoryDialog',
+	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
@@ -78,7 +79,7 @@ StOpenFileDialog class >> examplePreviewer [
 		open
 ]
 
-{ #category : 'accessing - ui' }
+{ #category : 'hooks' }
 StOpenFileDialog >> initialTitle [
 	^ 'Select File To Open'
 ]

--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryDialog.class.st
@@ -5,7 +5,6 @@ See subclasses for specific users.
 Class {
 	#name : 'StOpenFileOrDirectoryDialog',
 	#superclass : 'StFileDialogPresenter',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'

--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryDialog.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryDialog.class.st
@@ -5,6 +5,7 @@ See subclasses for specific users.
 Class {
 	#name : 'StOpenFileOrDirectoryDialog',
 	#superclass : 'StFileDialogPresenter',
+	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
@@ -19,11 +20,4 @@ StOpenFileOrDirectoryDialog >> confirmLabel [
 { #category : 'hooks' }
 StOpenFileOrDirectoryDialog >> initialTitle [
 	^ self subclassResponsibility
-]
-
-{ #category : 'initialization' }
-StOpenFileOrDirectoryDialog >> initializePresenters [
-
-	super initializePresenters.
-	fileNavigationSystem nameText disable
 ]

--- a/src/NewTools-FileBrowser/StPathBreadcrumbPresenter.class.st
+++ b/src/NewTools-FileBrowser/StPathBreadcrumbPresenter.class.st
@@ -74,8 +74,6 @@ StPathBreadcrumbPresenter >> currentDirectory: aFileReference [
 
 	textInput text: aFileReference fullName.
 	path file: aFileReference.
-	self owner ifNotNil: [ :fileNavigation | 
-		fileNavigation currentDirectory: aFileReference asAbsolute ].
 	self needRebuild: false.
 	self build
 ]

--- a/src/NewTools-FileBrowser/StSaveFileDialog.class.st
+++ b/src/NewTools-FileBrowser/StSaveFileDialog.class.st
@@ -47,7 +47,7 @@ StSaveFileDialog >> connectPresenters [
 	super connectPresenters.
 	(ec := EntryCompletion new)
 		dataSourceBlock: [ :text | 
-			fileNavigationSystem currentDirectory children collect: #basename ];
+			self fileNavigationSystem currentDirectory children collect: #basename ];
 		filterBlock: [ :opt :text | opt beginsWith: text ]
 ]
 

--- a/src/NewTools-FileBrowser/StSaveFileDialog.class.st
+++ b/src/NewTools-FileBrowser/StSaveFileDialog.class.st
@@ -4,6 +4,7 @@ My responsibility is to provide dialog for SAVING files.
 Class {
 	#name : 'StSaveFileDialog',
 	#superclass : 'StFileDialogPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'confirmedOverwrite'
 	],
@@ -50,7 +51,13 @@ StSaveFileDialog >> connectPresenters [
 		filterBlock: [ :opt :text | opt beginsWith: text ]
 ]
 
-{ #category : 'accessing - ui' }
+{ #category : 'accessing' }
+StSaveFileDialog >> existingFileMessage: entry [
+
+	^ 'File named "{1}" already exists. Do you want to overwrite it?' format: { entry basename }
+]
+
+{ #category : 'hooks' }
 StSaveFileDialog >> initialTitle [
 	^ 'Save As'
 ]
@@ -63,9 +70,7 @@ StSaveFileDialog >> selectedEntry [
 	entry := filter addExtensionTo: entry.
 	entry exists ifFalse: [ ^ entry ].
 	entry = confirmedOverwrite ifTrue: [ ^ entry ].
-	(UIManager default proceed:
-		 ('File named "{1}" already exists. Do you want to overwrite it?' 
-			  format: { entry basename })) ifTrue: [ 
-		^ confirmedOverwrite := entry ].
+	(self application confirm: (self existingFileMessage: entry))
+		ifTrue: [ ^ confirmedOverwrite := entry ].
 	^ nil
 ]

--- a/src/NewTools-FileBrowser/StSaveFileDialog.class.st
+++ b/src/NewTools-FileBrowser/StSaveFileDialog.class.st
@@ -4,7 +4,6 @@ My responsibility is to provide dialog for SAVING files.
 Class {
 	#name : 'StSaveFileDialog',
 	#superclass : 'StFileDialogPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'confirmedOverwrite'
 	],


### PR DESCRIPTION
This PR includes features and major refactorings to the File Browser, including:

- Display bookmarks in FileBrowser and Dialogs.
- Refresh bookmarks when adding or removing.
- When the directory dialog is opened, only directories are shown.
- A lot of duplicated code were removed.
- Better names for methods and instance variables.
- Fixed a test
