### PR TITLE
Update New Finder log errors to Transcript setting

### DIFF
--- a/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderExampleTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'StFinderExampleTest',
 	#superclass : 'StFinderTest',
+	#instVars : [
+		'previousLogSetting'
+	],
 	#category : 'NewTools-Finder-Tests-Core',
 	#package : 'NewTools-Finder-Tests',
 	#tag : 'Core'
@@ -10,9 +13,21 @@ Class {
 StFinderExampleTest >> setUp [
 
 	super setUp.
+
+	"Avoid polluting the CI output during tests"
+	previousLogSetting := StFinderSettings logErrorsToTranscript.
+	StFinderSettings logErrorsToTranscript: false.
+
 	presenterModel currentSearch: StFinderExampleSearch new.
 	self openInstance.
 	
+]
+
+{ #category : 'running' }
+StFinderExampleTest >> tearDown [
+
+	StFinderSettings logErrorsToTranscript: previousLogSetting.
+	super tearDown.
 ]
 
 { #category : 'running' }

--- a/src/NewTools-Finder/StFinderSettings.class.st
+++ b/src/NewTools-Finder/StFinderSettings.class.st
@@ -144,7 +144,7 @@ StFinderSettings class >> logErrorsToTranscript [
 	"Modified by settings Finder: self classSide >> #logErrorsToTranscriptOn:"
 
 	^ LogErrorsToTranscript
-		ifNil: [ LogErrorsToTranscript := true ]
+		ifNil: [ LogErrorsToTranscript := false ]
 ]
 
 { #category : 'system settings' }
@@ -158,7 +158,7 @@ StFinderSettings class >> logErrorsToTranscriptOn: aBuilder [
 	<systemsettings>
 	(aBuilder setting: #logErrorsToTranscript)
 		parent: #finder;
-		default: true;
+		default: false;
 		label: 'Log errors to Transcript';
 		description: 'Log evaluation errors in the examples search to the Transcript';
 		target: self


### PR DESCRIPTION
This PR changes the default in logErrorsToTranscript setting, so we do not pollute output by default.
Also execute the Example tests without logging to transcript so the CI isn't polluted.