### PR TITLE
Fix Undeclared reference in StClyMessageListPresenter

### DIFF
--- a/src/NewTools-MethodBrowsers/StClyMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StClyMessageListPresenter.class.st
@@ -37,7 +37,7 @@ StClyMessageListPresenter >> connectPresenters [
 { #category : 'private - actions' }
 StClyMessageListPresenter >> doRemoveMethod [
 
-	(RBRemoveMethodDriver new
+	(ReRemoveMethodDriver new
 		scopes: self scopes
 		methods: { self selectedMethod }) 
 		runRefactoring	


### PR DESCRIPTION
Fixes testUndeclared reported by ReleaseTest during CI 
RBRemoveMethodDriver -> ReRemoveMethodDriver in StClyMessageListPresenter
