### PR TITLE
Changed StFinderTest superclass to SpBaseTest

### DIFF
--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'StFinderTest',
-	#superclass : 'TestCase',
+	#superclass : 'SpBaseTest',
 	#instVars : [
 		'presenter',
 		'presenterModel'


### PR DESCRIPTION
As reported in https://github.com/pharo-project/pharo/issues/16041 to avoid problems during concurrent accessing of morphs from within the CL handler and Morphic UI processes. Fix suggested by @Rinzwind