### PR TITLE
Array>>#displayString should be part of Kernel and not an override from NewTools

### DIFF
--- a/src/NewTools-Inspector-Extensions/Array.extension.st
+++ b/src/NewTools-Inspector-Extensions/Array.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'Array' }
-
-{ #category : '*NewTools-Inspector-Extensions' }
-Array >> displayString [
-
-	^ super displayString contractTo: 200
-]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/16050

Should be merged together with https://github.com/pharo-project/pharo/pull/16069