### PR TITLE
Compression UI utilities

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -138,20 +138,20 @@ BaselineOfNewTools >> baseline: spec [
 						'Core' 
 						'NewTools-FlagBrowser' 
 						'NewTools-FlagBrowser-Tests' );
-			group: #development with: #( 'default' 
+			group: 'development' with: #( 'default' 
 						'NewTools-DebuggerSelector'
 				   		'NewTools-DebuggerSelector-Tests' );
-			group: #FileBrowser with: #( 
+			group: 'FileBrowser' with: #( 
 						'NewTools-FileBrowser' 
 						'NewTools-FileBrowser-Tests' );
-      			group: #RewriterTools with: #(
+      			group: 'RewriterTools' with: #(
 				    		'NewTools-RewriterTools-Backend'
 				    		'NewTools-RewriterTools'
 				    		'NewTools-RewriterTools-Backend-Tests'
 				    		'NewTools-RewriterTools-Tests' );
 			group: 'Profiler' with: #( 'NewTools-ProfilerUI' );
 			"ScopesEditor"
-			group: #ScopesEditor with: #(
+			group: 'ScopesEditor' with: #(
 						'NewTools-Scopes' 
 						'NewTools-Scopes-Editor' 
 						'NewTools-Scopes-Resources-A-Tests' 
@@ -159,11 +159,11 @@ BaselineOfNewTools >> baseline: spec [
 						'NewTools-Scopes-Resources-C-Tests' 
 						'NewTools-Scopes-Tests');
 			"Finder"
-			group: #Finder with: #(
+			group: 'Finder' with: #(
 						'NewTools-Finder'
 						'NewTools-Finder-Tests');
 			"Settings Browser"
-			group: #SettingsBrowser with: #(
+			group: 'SettingsBrowser' with: #(
 						'NewTools-SettingsBrowser'
 						'NewTools-SettingsBrowser-Tests');
 			"Compression Utilities"

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -167,7 +167,7 @@ BaselineOfNewTools >> baseline: spec [
 						'NewTools-SettingsBrowser'
 						'NewTools-SettingsBrowser-Tests');
 			"Compression Utilities"
-			group: #CompressionUtilities with: #(
+			group: 'CompressionUtilities' with: #(
 						'NewTools-Compression-Utils');
 
 			group: 'default' with: #( 

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -98,7 +98,9 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Finder-Tests' with: [ spec requires: #('NewTools-Finder') ];
 			
 			package: 'NewTools-SettingsBrowser' with: [ spec requires: #('ColorPicker') ];
-			package: 'NewTools-SettingsBrowser-Tests' with: [ spec requires: #('NewTools-SettingsBrowser') ].			
+			package: 'NewTools-SettingsBrowser-Tests' with: [ spec requires: #('NewTools-SettingsBrowser') ];
+			
+			package: 'NewTools-Compression-Utils' with: [ spec requires: #('NewTools-FileBrowser') ].			
 
 		spec
 			group: 'Core' with: #( 'NewTools-Core' 'NewTools-Morphic' );
@@ -164,6 +166,9 @@ BaselineOfNewTools >> baseline: spec [
 			group: #SettingsBrowser with: #(
 						'NewTools-SettingsBrowser'
 						'NewTools-SettingsBrowser-Tests');
+			"Compression Utilities"
+			group: #CompressionUtilities with: #(
+						'NewTools-Compression-Utils');
 
 			group: 'default' with: #( 
 						'Playground' 
@@ -179,7 +184,8 @@ BaselineOfNewTools >> baseline: spec [
 						'FileBrowser'
 						'Finder'
 						'Profiler'
-						'SettingsBrowser') ]
+						'SettingsBrowser'
+						'CompressionUtilities') ]
 ]
 
 { #category : 'external projects' }

--- a/src/NewTools-Compression-Utils/InflateStream.extension.st
+++ b/src/NewTools-Compression-Utils/InflateStream.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : 'InflateStream' }
+
+{ #category : '*NewTools-Compression-Utils' }
+InflateStream class >> openWithContents: contentsString label: titleString [
+	"Open a text viewer on contentsString and window label titleString"
+
+	SpTextPresenter new
+		text: contentsString;
+		open;
+		withWindowDo: [ : w | 
+			w 
+				title: titleString;
+				extent: 600 @ 800 ]
+]
+
+{ #category : '*NewTools-Compression-Utils' }
+InflateStream class >> viewContents: fullFileName [
+	"Open the decompressed contents of fullFileName"
+
+	| file |
+	(file := fullFileName asFileReference) binaryReadStreamDo: [ :aStream | 
+		self with: aStream do: [ :aGzStream | 
+			self 
+				openWithContents: aGzStream upToEnd 
+				label: 'Decompressed contents of: ' , file basename ] ]
+]

--- a/src/NewTools-Compression-Utils/ZipArchive.extension.st
+++ b/src/NewTools-Compression-Utils/ZipArchive.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : 'ZipArchive' }
+
+{ #category : '*NewTools-Compression-Utils' }
+ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
+	"Service method to extract all contents of a zip.
+	Example: 
+		ZipArchive extractAllIn: 'my_file.zip' 
+		"
+	| directory |
+
+	directory := (StOpenDirectoryDialog new
+		currentDirectory: FileSystem workingDirectory;
+		openModal) ifNil: [ ^ self ].
+
+	^ self new
+		readFrom: aFileReferenceOrFileName;
+		extractAllTo: directory
+]

--- a/src/NewTools-Compression-Utils/package.st
+++ b/src/NewTools-Compression-Utils/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Compression-Utils' }


### PR DESCRIPTION
Re-take of [PR](https://github.com/pharo-project/pharo/pull/16106)'s causing dependency problems in the build.
In this PR, a new package is proposed: `NewTools-Compression-Utils`.

The new package includes a couple of minimal method to add open directory dialog to Compression classes.
It also removes the UIManager dependency from Compression.

These changes were the same as the previous PR's, but does instead of using the SpApplication hook, it uses directly the new FileBrowser API.
