### PR TITLE
Add missing methods in Finder

### DIFF
--- a/src/NewTools-Finder/StFinderClassResult.class.st
+++ b/src/NewTools-Finder/StFinderClassResult.class.st
@@ -93,6 +93,12 @@ StFinderClassResult >> hasSelectorParent [
 	^ self parent isNotNil and: [ self parent isSelectorResult ]
 ]
 
+{ #category : 'testing' }
+StFinderClassResult >> isClassResult [
+
+	^ true
+]
+
 { #category : 'action' }
 StFinderClassResult >> referencesAction [
 

--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -346,6 +346,8 @@ StFinderPresenter >> initializeResultTree [
 		beMultipleSelection;
 		display: [ :result | result displayString ];
 		displayIcon: [ :result | result displayIcon ];
+		bindKeyCombination: $b meta toAction: [ self resultTree selectedItem browseAction ];
+		bindKeyCombination: $r meta toAction: [ self resultTree selectedItem referencesAction ];
 		contextMenu: [ (self rootCommandsGroup / 'StFinderSelContextualMenu') beRoot asMenuPresenter ].
 ]
 
@@ -547,7 +549,7 @@ StFinderPresenter >> updateResultsWith: results time: time [
 		roots: results;
 		children: [ :result | result children ].
 	self updateResultsBehavior.
-	resultStatusBar pushMessage: (self updateStatusBarTextFrom: results time: time)
+	resultStatusBar pushMessage: (self updateStatusBarTextFrom: results time: time).
 ]
 
 { #category : 'updating - widgets' }

--- a/src/NewTools-Finder/StMethodFinderSend.class.st
+++ b/src/NewTools-Finder/StMethodFinderSend.class.st
@@ -62,8 +62,7 @@ StMethodFinderSend >> evaluateWithTimeOut: anInteger [
 
 	runner := TKTLocalProcessTaskRunner new.
 	runner 
-		schedule: [ 
-			result := [ self evaluate ] onErrorDo: [ : e | self handleError: e ] ] asTask
+		schedule: [ result := [ self evaluate ] onErrorDo: [ : e | self handleError: e ] ] asTask
 		timeout: anInteger milliSeconds.
 	^ result
 


### PR DESCRIPTION
This is a small PR for the new Finder to add a missing method preventing to browse the selected item in the results list.

- Add missing #isClassResult method.
- Add key bindings to result tree.
