### PR TITLE
Align suffixes of FileBrowser

### DIFF
--- a/src/NewTools-Compression-Utils/ZipArchive.extension.st
+++ b/src/NewTools-Compression-Utils/ZipArchive.extension.st
@@ -8,7 +8,7 @@ ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
 		"
 	| directory |
 
-	directory := (StOpenDirectoryDialog new
+	directory := (StOpenDirectoryPresenter new
 		currentDirectory: FileSystem workingDirectory;
 		openModal) ifNil: [ ^ self ].
 

--- a/src/NewTools-FileBrowser-Tests/StFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StFilePresenterTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'StFileDialogTest',
+	#name : 'StFilePresenterTest',
 	#superclass : 'StFileBrowserTestCase',
 	#instVars : [
 		'dialog',
@@ -11,17 +11,17 @@ Class {
 }
 
 { #category : 'testing' }
-StFileDialogTest class >> isAbstract [
-	^ self = StFileDialogTest
+StFilePresenterTest class >> isAbstract [
+	^ self = StFilePresenterTest
 ]
 
 { #category : 'accessing' }
-StFileDialogTest >> dialogClass [
+StFilePresenterTest >> dialogClass [
 	^ self subclassResponsibility
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> fileListAllMustBeFilterByPNGFIlter [
+StFilePresenterTest >> fileListAllMustBeFilterByPNGFIlter [
 	self
 		assert:
 			(dialog fileReferenceTable items
@@ -31,14 +31,14 @@ StFileDialogTest >> fileListAllMustBeFilterByPNGFIlter [
 ]
 
 { #category : 'running' }
-StFileDialogTest >> setUp [
+StFilePresenterTest >> setUp [
 
 	super setUp.
 	(dialog := self dialogClass owner: fileSystemPresenter on: fileSystemModel) defaultFolder: root
 ]
 
 { #category : 'running' }
-StFileDialogTest >> tearDown [
+StFilePresenterTest >> tearDown [
 
 	dialog class initialize.
 	window ifNotNil: [ : w | w delete ].
@@ -46,19 +46,19 @@ StFileDialogTest >> tearDown [
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testIsRootDirectory [
+StFilePresenterTest >> testIsRootDirectory [
 	self assert: (dialog isRootDirectory: FileLocator root)
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testIsRootDirectoryWindowsDrive [
+StFilePresenterTest >> testIsRootDirectoryWindowsDrive [
 	OSPlatform current isWindows
 		ifFalse: [ ^ self ].
 	self assert: (dialog isRootDirectory: FileLocator C)
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testOpen [
+StFilePresenterTest >> testOpen [
 
 	"will it even open?"
 
@@ -66,7 +66,7 @@ StFileDialogTest >> testOpen [
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testOpenFolder [
+StFilePresenterTest >> testOpenFolder [
 	window := dialog open.
 	self assert: dialog currentDirectory equals: root.
 	dialog showDirectory: root / 'dir'.
@@ -74,7 +74,7 @@ StFileDialogTest >> testOpenFolder [
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testWhenAddACollectionOfBookmarkToCustomBookmarkShouldBeAddedToBookmarkTreeTable [
+StFilePresenterTest >> testWhenAddACollectionOfBookmarkToCustomBookmarkShouldBeAddedToBookmarkTreeTable [
 	| aCollectionOfBookmark |
 
 	aCollectionOfBookmark := {
@@ -93,9 +93,9 @@ StFileDialogTest >> testWhenAddACollectionOfBookmarkToCustomBookmarkShouldBeAdde
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testWhenAddingBookmarkOnDefaultBookmarksShouldBeAddToAllInstance [
+StFilePresenterTest >> testWhenAddingBookmarkOnDefaultBookmarksShouldBeAddToAllInstance [
 	| anOtherInstance addCommand |
-	anOtherInstance := StOpenDirectoryDialog new.
+	anOtherInstance := StOpenDirectoryPresenter new.
 	self
 		assertCollection: anOtherInstance bookmarks
 		hasSameElements: dialog bookmarks.
@@ -113,14 +113,14 @@ StFileDialogTest >> testWhenAddingBookmarkOnDefaultBookmarksShouldBeAddToAllInst
 ]
 
 { #category : 'tests' }
-StFileDialogTest >> testWhenAddingBookmarkOnIsolateBookmarksShouldBeAddToAllInstance [
+StFilePresenterTest >> testWhenAddingBookmarkOnIsolateBookmarksShouldBeAddToAllInstance [
 	| anOtherInstance addCommand |
 	dialog isolate.
 	addCommand := StFileBrowserAddBookmarkCommand new.
 	addCommand context: dialog fileNavigationSystem.
 	dialog fileReferenceTable selectIndex: ((dialog fileReferenceTable items collect: #basename) indexOf: 'dir'). 
 	addCommand execute.
-	anOtherInstance := StOpenDirectoryDialog new.
+	anOtherInstance := StOpenDirectoryPresenter new.
 	self 
 		assert: anOtherInstance bookmarks 
 		equals: dialog bookmarks.

--- a/src/NewTools-FileBrowser-Tests/StOpenDirectoryPresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenDirectoryPresenterTest.class.st
@@ -1,26 +1,26 @@
 Class {
-	#name : 'StOpenDirectoryDialogTest',
-	#superclass : 'StFileDialogTest',
+	#name : 'StOpenDirectoryPresenterTest',
+	#superclass : 'StFilePresenterTest',
 	#category : 'NewTools-FileBrowser-Tests-UI',
 	#package : 'NewTools-FileBrowser-Tests',
 	#tag : 'UI'
 }
 
 { #category : 'accessing' }
-StOpenDirectoryDialogTest >> dialogClass [
+StOpenDirectoryPresenterTest >> dialogClass [
 
-	^ StOpenDirectoryDialog
+	^ StOpenDirectoryPresenter
 ]
 
 { #category : 'tests' }
-StOpenDirectoryDialogTest >> testDefaultDirectory [
+StOpenDirectoryPresenterTest >> testDefaultDirectory [
 	self assert: dialog selectedEntry equals: root.
 	dialog defaultFolder: root / 'dir'.
 	self assert: dialog selectedEntry equals: root / 'dir'
 ]
 
 { #category : 'tests' }
-StOpenDirectoryDialogTest >> testSelectDirectory [
+StOpenDirectoryPresenterTest >> testSelectDirectory [
 
 	| selectedDirectory |
 	dialog okAction: [ :dir | selectedDirectory := dir ].
@@ -37,7 +37,7 @@ StOpenDirectoryDialogTest >> testSelectDirectory [
 ]
 
 { #category : 'tests' }
-StOpenDirectoryDialogTest >> testSelectNonexistingDirectory [
+StOpenDirectoryPresenterTest >> testSelectNonexistingDirectory [
 
 	self
 		should: [ dialog defaultFolder: root / 'idontexist' ]
@@ -46,7 +46,7 @@ StOpenDirectoryDialogTest >> testSelectNonexistingDirectory [
 ]
 
 { #category : 'tests' }
-StOpenDirectoryDialogTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
+StOpenDirectoryPresenterTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
 	| newDirectory |
 	newDirectory := (root / 'dir') asFileReference.
 	dialog defaultFolder: newDirectory.

--- a/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
@@ -1,19 +1,19 @@
 Class {
-	#name : 'StOpenFileDialogTest',
-	#superclass : 'StFileDialogTest',
+	#name : 'StOpenFilePresenterTest',
+	#superclass : 'StFilePresenterTest',
 	#category : 'NewTools-FileBrowser-Tests-UI',
 	#package : 'NewTools-FileBrowser-Tests',
 	#tag : 'UI'
 }
 
 { #category : 'accessing' }
-StOpenFileDialogTest >> dialogClass [
+StOpenFilePresenterTest >> dialogClass [
 
-	^ StOpenFileDialog
+	^ StOpenFilePresenter
 ]
 
 { #category : 'tests' }
-StOpenFileDialogTest >> testExtensions [
+StOpenFilePresenterTest >> testExtensions [
 
 	dialog extensions: #( ext ) named: 'Ext files'.
 	self
@@ -27,7 +27,7 @@ StOpenFileDialogTest >> testExtensions [
 ]
 
 { #category : 'tests' }
-StOpenFileDialogTest >> testMultipleExtensions [
+StOpenFilePresenterTest >> testMultipleExtensions [
 
 	dialog extensions: #( image changes sources ) named: 'Src files'.
 	self
@@ -41,7 +41,7 @@ StOpenFileDialogTest >> testMultipleExtensions [
 ]
 
 { #category : 'tests' }
-StOpenFileDialogTest >> testSelectFile [
+StOpenFilePresenterTest >> testSelectFile [
 
 	| selectedFile |
 	dialog okAction: [ :file | selectedFile := file ].
@@ -54,7 +54,7 @@ StOpenFileDialogTest >> testSelectFile [
 ]
 
 { #category : 'tests' }
-StOpenFileDialogTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
+StOpenFilePresenterTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
 	| newDirectory |
 	newDirectory := (root / 'dir') asFileReference.
 	dialog defaultFolder: newDirectory.

--- a/src/NewTools-FileBrowser/StMorphicUIManager.class.st
+++ b/src/NewTools-FileBrowser/StMorphicUIManager.class.st
@@ -36,7 +36,7 @@ StMorphicUIManager class >> isValidForCurrentSystemConfiguration [
 StMorphicUIManager >> chooseDirectory: label from: dir [
 	self flag: #ToDoWhenIntegration.
 	self flag: 'use chooseDirectory:path: instead of this'.
-	^ StOpenDirectoryDialog new
+	^ StOpenDirectoryPresenter new
 		defaultFolder: dir;
 		title: (label ifNil: [ 'Choose Directory' translated ]);
 		open
@@ -45,7 +45,7 @@ StMorphicUIManager >> chooseDirectory: label from: dir [
 { #category : 'ui requests' }
 StMorphicUIManager >> chooseDirectory: label path: path [
 
-	^ StOpenDirectoryDialog new
+	^ StOpenDirectoryPresenter new
 		  defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
 		  title: (label ifNil: [ 'Choose Directory' translated ]);
 		  openModal;
@@ -53,69 +53,12 @@ StMorphicUIManager >> chooseDirectory: label path: path [
 ]
 
 { #category : 'ui requests' }
-StMorphicUIManager >> chooseFileMatching: patterns label: label [
-	self deprecated: 'now you have to give a filter see NewTools-FileBrowser-Filtering'.
-	^ StOpenFileDialog new
-		title: (label ifNil: [ 'Choose File' translated ]);
-		"fileFilters: pattern  ;"
-		open
-]
-
-{ #category : 'ui requests' }
-StMorphicUIManager >> chooseFileName: title extensions: exts path: path preview: preview [
-	self
-		deprecated: 'now you have to give a filter see FileDialog-filterStrategie'.
-	^ (StOpenFileDialog new
-		title: (title ifNil: [ 'Choose File' translated ]);
-		"fileFilters: (exts ifNil: [ #() ] ifNotNil: [ :e | e collect: [ :each | '*.' , each ] ]);"
-			defaultFolder: path;
-			previewer: preview;
-		open) ifNotNil: #basename
-]
-
-{ #category : 'ui requests' }
-StMorphicUIManager >> chooseFullFileName: title extensions: exts path: path preview: preview [
-	self
-		deprecated: 'now you have to give a filter see FileDialog-filterStrategie'.
-	^ (StOpenFileDialog new
-		title: (title ifNil: [ 'Choose File' translated ]);
-		"fileFilters: (exts ifNil: [ #() ] ifNotNil: [ :e | e collect: [ :each | '*.' , each ] ]);"
-			defaultFolder: path;
-			previewer: preview;
-		open) ifNotNil: #fullName
-]
-
-{ #category : 'ui requests' }
 StMorphicUIManager >> chooseFullFileNameMatching: patterns label: title [
 	self
 		deprecated: 'now you have to give a filter see FileDialog-filterStrategie'.
-	^ StOpenFileDialog new
+	^ StOpenFilePresenter new
 		title: (title ifNil: [ 'Choose File' translated ]);
 		"fileFilters: (patterns ifNil: [ #() ] ifNotNil: [ :e | e collect: [ :each | '*.' , each ] ]);
 		"
 			open
-]
-
-{ #category : 'ui requests' }
-StMorphicUIManager >> fileOpen: title extensions: exts path: path preview: preview [
-	self
-		deprecated: 'now you have to give a filter see FileDialog-filterStrategie'.
-	^ (StOpenFileDialog new
-		title: (title ifNil: [ 'Choose File' translated ]);
-		"fileFilters: (exts ifNil: [ #() ] ifNotNil: [ :e | e collect: [ :each | '*.' , each ] ]);
-		"defaultFolder: path;
-		previewer: preview;
-		openModal) ifNotNil: #readStream
-]
-
-{ #category : 'ui requests' }
-StMorphicUIManager >> fileSave: title extensions: exts path: path [
-	self
-		deprecated: 'now you have to give a filter see FileDialog-filterStrategie'.
-	^ StSaveFileDialog new
-		title: (title ifNil: [ 'Choose File' translated ]);
-		"fileFilters: (exts ifNil: [ #() ] ifNotNil: [ :e | e collect: [ :each | '*.' , each ] ]);
-		"
-			defaultFolder: path;
-		open
 ]

--- a/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
@@ -6,52 +6,52 @@ So no files will be shown in the file/folder listings.
 see my super for more information about customization
 "
 Class {
-	#name : 'StOpenDirectoryDialog',
-	#superclass : 'StOpenFileOrDirectoryDialog',
+	#name : 'StOpenDirectoryPresenter',
+	#superclass : 'StOpenFileOrDirectoryPresenter',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
 }
 
 { #category : 'examples' }
-StOpenDirectoryDialog class >> example [
+StOpenDirectoryPresenter class >> example [
 
 	<example>
 	^ self chooseThenInspect
 ]
 
 { #category : 'examples' }
-StOpenDirectoryDialog class >> exampleModal [
+StOpenDirectoryPresenter class >> exampleModal [
 
 	<example>
 	^ self chooseModalAndInspect
 ]
 
 { #category : 'hooks' }
-StOpenDirectoryDialog class >> navigationSystemClass [
+StOpenDirectoryPresenter class >> navigationSystemClass [
 	
 	^ StDirectoryNavigationSystemPresenter 
 ]
 
 { #category : 'hooks' }
-StOpenDirectoryDialog >> allowsChooseDirectoryIfNoFilename [
+StOpenDirectoryPresenter >> allowsChooseDirectoryIfNoFilename [
 
 	^ true
 ]
 
 { #category : 'initialization' }
-StOpenDirectoryDialog >> initialExtentForWindow [
+StOpenDirectoryPresenter >> initialExtentForWindow [
 
 	^ (1050 @ 550) scaledByDisplayScaleFactor
 ]
 
 { #category : 'hooks' }
-StOpenDirectoryDialog >> initialTitle [
+StOpenDirectoryPresenter >> initialTitle [
 	^ 'Select Directory To Open'
 ]
 
 { #category : 'actions' }
-StOpenDirectoryDialog >> selectedEntry [
+StOpenDirectoryPresenter >> selectedEntry [
 
 	super selectedEntry ifNotNil: [ :fileReference | 
 		fileReference isDirectory ifTrue: [ ^ fileReference ] ].

--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
@@ -3,7 +3,7 @@ This is an abstract class to group open dialog presenter behavior.
 See subclasses for specific users.
 "
 Class {
-	#name : 'StOpenFileOrDirectoryDialog',
+	#name : 'StOpenFileOrDirectoryPresenter',
 	#superclass : 'StFileDialogPresenter',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
@@ -11,12 +11,12 @@ Class {
 }
 
 { #category : 'accessing - ui' }
-StOpenFileOrDirectoryDialog >> confirmLabel [
+StOpenFileOrDirectoryPresenter >> confirmLabel [
 
 	^ 'Open'
 ]
 
 { #category : 'hooks' }
-StOpenFileOrDirectoryDialog >> initialTitle [
+StOpenFileOrDirectoryPresenter >> initialTitle [
 	^ self subclassResponsibility
 ]

--- a/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
@@ -7,15 +7,15 @@ examples see class side method example
 
 "
 Class {
-	#name : 'StOpenFileDialog',
-	#superclass : 'StOpenFileOrDirectoryDialog',
+	#name : 'StOpenFilePresenter',
+	#superclass : 'StOpenFileOrDirectoryPresenter',
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
 	#tag : 'UI'
 }
 
 { #category : 'example' }
-StOpenFileDialog class >> complexExampleAdaptivePreviewer [
+StOpenFilePresenter class >> complexExampleAdaptivePreviewer [
 
 	<example>
 	| presenter |
@@ -46,7 +46,7 @@ StOpenFileDialog class >> complexExampleAdaptivePreviewer [
 ]
 
 { #category : 'example' }
-StOpenFileDialog class >> complexExampleTextPreviewer [
+StOpenFilePresenter class >> complexExampleTextPreviewer [
 
 	<example>
 	| presenter |
@@ -81,28 +81,28 @@ StOpenFileDialog class >> complexExampleTextPreviewer [
 ]
 
 { #category : 'examples' }
-StOpenFileDialog class >> example [
+StOpenFilePresenter class >> example [
 
 	<example>
 	^ self chooseThenInspect
 ]
 
 { #category : 'examples' }
-StOpenFileDialog class >> exampleExtensions [
+StOpenFilePresenter class >> exampleExtensions [
 
 	<example>
 	^ self extensions: #( 'image' )
 ]
 
 { #category : 'examples' }
-StOpenFileDialog class >> exampleModal [
+StOpenFilePresenter class >> exampleModal [
 
 	<example>
 	^ self chooseModalAndInspect
 ]
 
 { #category : 'example' }
-StOpenFileDialog class >> examplePreviewer [
+StOpenFilePresenter class >> examplePreviewer [
 
 	self new
 		previewer: StFileBrowserInspectPreviewer new;
@@ -110,6 +110,6 @@ StOpenFileDialog class >> examplePreviewer [
 ]
 
 { #category : 'hooks' }
-StOpenFileDialog >> initialTitle [
+StOpenFilePresenter >> initialTitle [
 	^ 'Select File To Open'
 ]

--- a/src/NewTools-FileBrowser/StSaveFilePresenter.class.st
+++ b/src/NewTools-FileBrowser/StSaveFilePresenter.class.st
@@ -2,7 +2,7 @@
 My responsibility is to provide dialog for SAVING files.
 "
 Class {
-	#name : 'StSaveFileDialog',
+	#name : 'StSaveFilePresenter',
 	#superclass : 'StFileDialogPresenter',
 	#instVars : [
 		'confirmedOverwrite'
@@ -13,34 +13,34 @@ Class {
 }
 
 { #category : 'examples' }
-StSaveFileDialog class >> example [
+StSaveFilePresenter class >> example [
 
 	<example>
 	^ self chooseThenInspect
 ]
 
 { #category : 'examples' }
-StSaveFileDialog class >> exampleExtensions [
+StSaveFilePresenter class >> exampleExtensions [
 
 	<example>
 	^ self extensions: #( 'image' )
 ]
 
 { #category : 'examples' }
-StSaveFileDialog class >> exampleModal [
+StSaveFilePresenter class >> exampleModal [
 
 	<example>
 	^ self chooseModalAndInspect
 ]
 
 { #category : 'accessing - ui' }
-StSaveFileDialog >> confirmLabel [
+StSaveFilePresenter >> confirmLabel [
 
 	^ 'Save'
 ]
 
 { #category : 'initialization' }
-StSaveFileDialog >> connectPresenters [
+StSaveFilePresenter >> connectPresenters [
 
 	| ec |
 	super connectPresenters.
@@ -51,31 +51,31 @@ StSaveFileDialog >> connectPresenters [
 ]
 
 { #category : 'accessing' }
-StSaveFileDialog >> existingFileMessage: entry [
+StSaveFilePresenter >> existingFileMessage: entry [
 
 	^ 'File named "{1}" already exists. Do you want to overwrite it?' format: { entry basename }
 ]
 
 { #category : 'initialization' }
-StSaveFileDialog >> initialExtentForWindow [ 
+StSaveFilePresenter >> initialExtentForWindow [ 
 
 	^ (1050 @ 550) scaledByDisplayScaleFactor
 ]
 
 { #category : 'hooks' }
-StSaveFileDialog >> initialTitle [
+StSaveFilePresenter >> initialTitle [
 	^ 'Save As'
 ]
 
 { #category : 'initialization' }
-StSaveFileDialog >> initializePresenters [ 
+StSaveFilePresenter >> initializePresenters [ 
 
 	super initializePresenters.
 	fileNavigationSystem layout: self rightPaneLayout
 ]
 
 { #category : 'layout' }
-StSaveFileDialog >> rightPaneLayout [
+StSaveFilePresenter >> rightPaneLayout [
 
 	^ SpBoxLayout newTopToBottom
 		add: fileNavigationSystem navigationLayout expand: false;
@@ -84,7 +84,7 @@ StSaveFileDialog >> rightPaneLayout [
 ]
 
 { #category : 'accessing' }
-StSaveFileDialog >> selectedEntry [
+StSaveFilePresenter >> selectedEntry [
 
 	| entry |
 	entry := super selectedEntry ifNil: [ ^ nil ].


### PR DESCRIPTION
Rename suffixes of the file browser to be sure that all presenters are ending with #Presenter + remove the unused deprecated methods.