### PR TITLE
ExpressionFinder - matches browser now knows the method that is showing

### DIFF
--- a/src/NewTools-RewriterTools/StRewriterOccurrencesBrowserPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterOccurrencesBrowserPresenter.class.st
@@ -30,9 +30,13 @@ StRewriterOccurrencesBrowserPresenter class >> title [
 { #category : 'initialization' }
 StRewriterOccurrencesBrowserPresenter >> connectPresenters [
 
-	listPresenter whenSelectedDo: [ :selectedItem |
-		codePresenter text: selectedItem sourceAnchor entity sourceCode.
-		codePresenter selectionInterval: selectedItem sourceAnchor interval ]
+	listPresenter whenSelectedDo: [ :aReReplaceNodeCritique |
+		| compiledMethod |
+		compiledMethod := aReReplaceNodeCritique sourceAnchor entity.
+		codePresenter
+			text: compiledMethod sourceCode;
+			selectionInterval: aReReplaceNodeCritique sourceAnchor interval;
+			beForMethod: compiledMethod ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Improved the UI of the matches browser for the expression finder.
Done in the pharo spring with @uNouss

Before it was like this:
![image](https://github.com/pharo-spec/NewTools/assets/33934979/a4fc4ffe-d31f-4760-bcd2-49f3373f4b44)

Now it's like this:
<img width="1027" alt="Capture d’écran 2024-02-23 à 12 11 05" src="https://github.com/pharo-spec/NewTools/assets/33934979/5eba1b2e-a813-4ae3-a5cf-b76849260e74">
