### PR TITLE
Bug fix: Context menu item ‘Revert to selected version’ in recent versions of a method does not revert

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -26,6 +26,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Gtk';
 			"Basic tools (inherited from Spec)"
 			package: 'NewTools-MethodBrowsers' with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];
+			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
 			package: 'NewTools-KeymapBrowser';
 			"inspector"
 			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Inspector-Extensions' ) ];

--- a/src/NewTools-MethodBrowsers-Tests/StVersionBrowserPresenter.extension.st
+++ b/src/NewTools-MethodBrowsers-Tests/StVersionBrowserPresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'StVersionBrowserPresenter' }
+
+{ #category : '*NewTools-MethodBrowsers-Tests' }
+StVersionBrowserPresenter >> selectIndex: index [
+
+	messageList selectIndex: index
+]

--- a/src/NewTools-MethodBrowsers-Tests/StVersionBrowserPresenterTest.class.st
+++ b/src/NewTools-MethodBrowsers-Tests/StVersionBrowserPresenterTest.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'StVersionBrowserPresenterTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'class',
+		'factory'
+	],
+	#category : 'NewTools-MethodBrowsers-Tests',
+	#package : 'NewTools-MethodBrowsers-Tests'
+}
+
+{ #category : 'running' }
+StVersionBrowserPresenterTest >> setUp [
+	super setUp.
+	factory := ClassFactoryForTestCase new.
+	class := factory newClass
+
+]
+
+{ #category : 'running' }
+StVersionBrowserPresenterTest >> tearDown [
+	factory cleanUp.
+	super tearDown
+]
+
+{ #category : 'running' }
+StVersionBrowserPresenterTest >> testRevertOldMethod [ 
+	| browser |
+	class compile: 'm
+	^1'.
+	self assert: class new m equals: 1.
+	class compile: 'm
+	^2'.
+	self assert: class new m equals: 2.
+	browser := StVersionBrowserPresenter on: class >> #m.
+	browser selectIndex: browser changeList size.
+	browser doRevert.
+	self assert: class new m equals: 1.
+	
+	
+]

--- a/src/NewTools-MethodBrowsers-Tests/package.st
+++ b/src/NewTools-MethodBrowsers-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-MethodBrowsers-Tests' }

--- a/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
@@ -296,7 +296,7 @@ StVersionBrowserPresenter >> newMessageList [
 StVersionBrowserPresenter >> newMessageToolbar [
 		
 	^ (self instantiate: StMethodHistoryToolbarPresenter on: rgMethod)
-		whenRevertDo: [ self revert: self selectedMessage ];
+		whenRevertDo: [ self doRevert ];
 		yourself
 ]
 

--- a/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
@@ -345,6 +345,12 @@ StVersionBrowserPresenter >> revert: aChangeRecord [
 		selectIndex: 1
 ]
 
+{ #category : 'test support' }
+StVersionBrowserPresenter >> selectIndex: index [
+
+	messageList selectIndex: index
+]
+
 { #category : 'private' }
 StVersionBrowserPresenter >> selectItem: item [
 

--- a/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
@@ -197,7 +197,7 @@ StVersionBrowserPresenter >> doCompareToOtherVersion [
 
 { #category : 'actions' }
 StVersionBrowserPresenter >> doRevert [
-
+	self revert: self selectedMessage
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
@@ -345,12 +345,6 @@ StVersionBrowserPresenter >> revert: aChangeRecord [
 		selectIndex: 1
 ]
 
-{ #category : 'test support' }
-StVersionBrowserPresenter >> selectIndex: index [
-
-	messageList selectIndex: index
-]
-
 { #category : 'private' }
 StVersionBrowserPresenter >> selectItem: item [
 


### PR DESCRIPTION
Fix for issue [16045 raised in Pharo](https://github.com/pharo-project/pharo/issues/16045).
In method version browser, revert context menu should actually revert method version.