### PR TITLE
Refactor various ‘worldMenu’ registration methods to use #iconName: instead of #icon:

### DIFF
--- a/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
@@ -41,7 +41,7 @@ StCritiqueBrowserPresenter class >> critiquesBrowserMenuOn: aBuilder [
 		order: 2;
 		parent: #Browsing;
 		help: 'To manage rule checks.';
-		icon: self icon
+		iconName: self iconName
 ]
 
 { #category : 'layout' }
@@ -72,7 +72,13 @@ StCritiqueBrowserPresenter class >> icon [
 
 	"Answer an icon for the receiver."
 
-	^ self iconNamed: #error
+	^ self iconNamed: self iconName
+]
+
+{ #category : 'icons' }
+StCritiqueBrowserPresenter class >> iconName [
+
+	^ #error
 ]
 
 { #category : 'instance creation' }

--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -101,7 +101,7 @@ StPlaygroundPresenter class >> menuCommandOn: aBuilder [
 		order: 1;
 		keyText: 'o, w';
 		help: 'A window used as a scratchpad area where fragments of Pharo code can be entered, stored, edited, and evaluated.';
-		icon: (self iconNamed: #workspace)
+		iconName: #workspace
 ]
 
 { #category : 'instance creation' }

--- a/src/NewTools-ProfilerUI/StProfilerPresenter.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerPresenter.class.st
@@ -29,7 +29,7 @@ StProfilerPresenter class >> menuCommandOn: aBuilder [
 	(aBuilder item: #'Profiler')
 		parent: #Profiling;
 		order: 1;
-		icon: (self iconNamed: #smallProfile);
+		iconName: #smallProfile;
 		help: 'Profile the execution of a piece of code using different profilers, and navigate into the result.';
 		action: [self new open]
 ]

--- a/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
@@ -42,7 +42,7 @@ StRewriterExpressionFinderPresenter class >> menuCommandOn: aBuilder [
 		action: [ self new open ];
 		order: 31;
 		parent: #Tools;
-		icon: self icon;
+		iconName: self iconName;
 		help: self descriptionText
 ]
 

--- a/src/NewTools-RewriterTools/StRewriterMatchToolPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterMatchToolPresenter.class.st
@@ -58,7 +58,7 @@ StRewriterMatchToolPresenter class >> menuCommandOn: aBuilder [
 		order: 32;
 		parent: #Tools;
 		help: self descriptionText;
-		icon: self icon
+		iconName: self iconName
 ]
 
 { #category : 'specs' }

--- a/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
@@ -57,7 +57,7 @@ StRewriterRuleEditorPresenter class >> menuCommandOn: aBuilder [
 		order: 30;
 		parent: #Tools;
 		help: self descriptionText;
-		icon: self icon
+		iconName: self iconName
 ]
 
 { #category : 'specs' }

--- a/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
@@ -24,7 +24,7 @@ StSettingsApplication class >> menuSettingsBrowserCommandOn: aBuilder [
 		parent: #Tools;
 		label: 'New Settings Browser';
 		action: [ self new run ];
-		icon: (self iconNamed: self taskbarIconName);
+		iconName: self taskbarIconName;
 		help: 'New Settings Browser';
 		order: 100		
 ]


### PR DESCRIPTION
This pull request refactors various ‘worldMenu’ registration methods to use `#iconName:` instead of `#icon:` for setting the menu item’s icon.

This is related to (but does not depend on) [Pharo pull request #16201](https://github.com/pharo-project/pharo/pull/16201), in which `#iconName:` on PragmaMenuAndShortcutRegistration is changed to use the FormSet for the icon.