### PR TITLE
Fix title display in File Presenter windows

### DIFF
--- a/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
@@ -54,6 +54,15 @@ StOpenFilePresenterTest >> testSelectFile [
 ]
 
 { #category : 'tests' }
+StOpenFilePresenterTest >> testSetTitle [
+
+	dialog title: 'test set title'.
+	self
+		assertCollection: dialog title
+		equals: 'test set title'.
+]
+
+{ #category : 'tests' }
 StOpenFilePresenterTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
 	| newDirectory |
 	newDirectory := (root / 'dir') asFileReference.

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -5,10 +5,12 @@ General file system presenter, which replaces the older FileList tool.
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
 		'fileNavigationSystem',
-		'bookmarksTreeTable'
+		'bookmarksTreeTable',
+		'title'
 	],
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
@@ -192,7 +194,7 @@ StFileSystemPresenter >> setInitialExtentTo: aSpWindowPresenter [
 { #category : 'initialization' }
 StFileSystemPresenter >> setTitleTo: aSpWindowPresenter [
 
-	aSpWindowPresenter title: self initialTitle
+	aSpWindowPresenter title: self title
 
 ]
 
@@ -204,9 +206,16 @@ StFileSystemPresenter >> setWindowIconTo: aSpWindowPresenter [
 ]
 
 { #category : 'accessing' }
-StFileSystemPresenter >> title: aString [ 
+StFileSystemPresenter >> title [
 
-	self withWindowDo: [ : w | w title: aString ]
+	^ title
+		ifNil: [ title := self initialTitle ]
+]
+
+{ #category : 'accessing' }
+StFileSystemPresenter >> title: aString [
+
+	title := aString.
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -5,7 +5,6 @@ General file system presenter, which replaces the older FileList tool.
 Class {
 	#name : 'StFileSystemPresenter',
 	#superclass : 'StFileBrowserAbstractPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'treeNavigationSystem',
 		'fileNavigationSystem',

--- a/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
@@ -50,7 +50,7 @@ StOpenDirectoryPresenter >> initialTitle [
 	^ 'Select Directory To Open'
 ]
 
-{ #category : 'actions' }
+{ #category : 'accessing' }
 StOpenDirectoryPresenter >> selectedEntry [
 
 	super selectedEntry ifNotNil: [ :fileReference | 


### PR DESCRIPTION
This PR enables to set the title of the file system presenters, as reported in https://github.com/pharo-project/pharo/pull/16084 by @demarey
