### PR TITLE
Add pre-filling the name text presenter in file dialogs

### DIFF
--- a/src/NewTools-FileBrowser-Tests/StSaveFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StSaveFilePresenterTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'StSaveFilePresenterTest',
+	#superclass : 'StFilePresenterTest',
+	#category : 'NewTools-FileBrowser-Tests-UI',
+	#package : 'NewTools-FileBrowser-Tests',
+	#tag : 'UI'
+}
+
+{ #category : 'accessing' }
+StSaveFilePresenterTest >> dialogClass [
+
+	^ StSaveFilePresenter
+]
+
+{ #category : 'tests' }
+StSaveFilePresenterTest >> testSetNameText [
+
+	| preFillDocName |
+	
+	preFillDocName := 'mydocument.doc'.
+	dialog nameText: preFillDocName.
+	self
+		assert: dialog nameText
+		equals: preFillDocName
+]
+
+{ #category : 'tests' }
+StSaveFilePresenterTest >> testWhenChangeDirectoryShouldFilesListContainsHisChildren [
+	| newDirectory |
+	newDirectory := (root / 'dir') asFileReference.
+	dialog defaultFolder: newDirectory.
+	self
+		assert: (dialog fileReferenceTable items includesAll: newDirectory children)
+]

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -291,6 +291,19 @@ StFileDialogPresenter >> isolate [
 	
 ]
 
+{ #category : 'accessing - ui' }
+StFileDialogPresenter >> nameText [
+	"Answer a <String> with the text in the name presenter used to display the currently selected file/directory or a manually entered name"
+	
+	^ fileNavigationSystem nameText text.
+]
+
+{ #category : 'accessing' }
+StFileDialogPresenter >> nameText: aString [ 
+
+	fileNavigationSystem nameText: aString
+]
+
 { #category : 'api - customization' }
 StFileDialogPresenter >> okAction: aOneArgBlock [
 	okAction := aOneArgBlock

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -179,10 +179,11 @@ StFileNavigationSystemPresenter >> defaultPreviewer [
 StFileNavigationSystemPresenter >> fileNameLayout [
 
 	^ SpBoxLayout newLeftToRight
-				vAlignCenter;
-				add: nameText;
-				add: filtersDropList expand: false;
-				yourself
+		spacing: 2;	
+		vAlignCenter;
+		add: nameText;
+		add: filtersDropList expand: false;
+		yourself
 ]
 
 { #category : 'accessing' }
@@ -194,11 +195,6 @@ StFileNavigationSystemPresenter >> fileReferenceTable [
 StFileNavigationSystemPresenter >> filesListAction [
 
 	| previewProcess |
-
-	fileReferenceTable
-		transmitTo: nameText
-		transform: [ :selectedItem | 
-			selectedItem ifNotNil: [ selectedItem basename ] ifNil: [ '' ] ].
 
 	fileReferenceTable whenActivatedDo: [ :selectedItem | 
 		previewProcess ifNotNil: [ 
@@ -264,6 +260,8 @@ StFileNavigationSystemPresenter >> initializeFilesTable [
 		beResizable;
 		columns: StFileBrowserAbstractColumn columns;
 		sortingBlock: self defaultFileSortBlock;
+		whenSelectedItemChangedDo: [ : selectedItem | 
+			selectedItem ifNotNil: [ self nameText: selectedItem basename ] ];		
 		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'StFileBrowserNavigationMenu' ]
 ]
 
@@ -324,6 +322,13 @@ StFileNavigationSystemPresenter >> initializePresenters [
 { #category : 'accessing' }
 StFileNavigationSystemPresenter >> nameText [
 	^ nameText
+]
+
+{ #category : 'accessing' }
+StFileNavigationSystemPresenter >> nameText: aString [
+	"Set the receive's name text to aString. This is displayed in a text presenter to display the currently selected file, or the name of a new file to be saved"
+	
+	nameText text: aString.
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
This PR enables to preset the "name text" presenter text, which is useful for example to suggest a new file name in Save File dialogs. It also preserves the feature of updating the text when a directory or file is changed in the file navigation table.

Add tests.﻿

Usage example:
```smalltalk
StSaveFilePresenter new
		title: 'Save Microdown document';
		nameText: 'mydocument.' , anExtension asString;
		extensions: { anExtension }; 
		openModal.
```