### PR TITLE
Showing CMD character in OSX in Spotter

### DIFF
--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -79,10 +79,11 @@ StPharoApplication >> newIconProvider [
 
 { #category : 'private - running' }
 StPharoApplication >> resetBackend [
-
 	| backendName |
 	
-	backendName := backend ifNil: [ self class defaultBackendName ] ifNotNil: [ backend name ].
+	backendName := backend 
+		ifNil: [ self class defaultBackendName ] 
+		ifNotNil: [ backend name ].
 	self useBackend: backendName.
 ]
 

--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -77,6 +77,15 @@ StPharoApplication >> newIconProvider [
 	^ StPharoDefaultIconProvider new
 ]
 
+{ #category : 'private - running' }
+StPharoApplication >> resetBackend [
+
+	| backendName |
+	
+	backendName := backend ifNil: [ self class defaultBackendName ] ifNotNil: [ backend name ].
+	self useBackend: backendName.
+]
+
 { #category : 'initialization' }
 StPharoApplication >> resetConfiguration [
 	
@@ -104,7 +113,8 @@ StPharoApplication >> start [
 { #category : 'system startup' }
 StPharoApplication >> startUp: resuming [
 
-	self resetConfiguration
+	self resetConfiguration.
+	self resetBackend.
 ]
 
 { #category : 'settings' }

--- a/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
+++ b/src/NewTools-Spotter/StSpotterHeaderPresenter.class.st
@@ -102,6 +102,7 @@ StSpotterHeaderPresenter >> initializePresenters [
 	self addStyle: 'stSpotterHeader'.
 	amountLabelPresenter addStyle: 'dim'.
 	helpLabelPresenter addStyle: 'dim'.
+	helpLabelPresenter addStyle: 'shortcut'.
 	diveButtonPresenter image: (self application iconNamed: #smallForward).
 	diveButtonPresenter eventHandler
 		whenMouseDownDo: [ :event | 


### PR DESCRIPTION
- The StPharoApplication should reset the backend when starting the image.
- The Spotter help should have the "shortcut" class to correct show the CMD character
Fix partially Pharo #14700