### PR TITLE
Adapt #getVolumeInfo:into:size: for StWin32Info to strict FFI

### DIFF
--- a/src/NewTools-FileBrowser/StWin32Info.class.st
+++ b/src/NewTools-FileBrowser/StWin32Info.class.st
@@ -29,5 +29,5 @@ StWin32Info class >> getVolumeInfo: driveLetter [
 { #category : 'private-ffi' }
 StWin32Info class >> getVolumeInfo: volumeName into: lpBuffer size: nSize [
 	"Primitive to obtain an environment variable using windows Wide Strings"
-	^ self ffiCall: #(uint GetVolumeInformationW (Win32WideString volumeName, Win32WideString lpBuffer, ulong nSize, nil, nil, nil, nil, 0)) module: #kernel32
+	^ self ffiCall: #(uint GetVolumeInformationW (Win32WideString volumeName, Win32WideString lpBuffer, ulong nSize, ulong* nil, ulong* nil, ulong* nil, Win32WideString nil, ulong 0)) module: #kernel32
 ]


### PR DESCRIPTION
This pull request adapts `#getVolumeInfo:into:size:` for StWin32Info to the changes of [Pharo pull request #15683](https://github.com/pharo-project/pharo/pull/15683). For reference, see Microsoft’s documentation on [‘GetVolumeInformationW’](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw) and [‘Windows Data Types’](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types).