### PR TITLE
Fix function signature in #getVolumeInfo:into:size: for StWin32Info

### DIFF
--- a/src/NewTools-FileBrowser/StWin32Info.class.st
+++ b/src/NewTools-FileBrowser/StWin32Info.class.st
@@ -29,5 +29,5 @@ StWin32Info class >> getVolumeInfo: driveLetter [
 { #category : 'private-ffi' }
 StWin32Info class >> getVolumeInfo: volumeName into: lpBuffer size: nSize [
 	"Primitive to obtain an environment variable using windows Wide Strings"
-	^ self ffiCall: #(uint GetVolumeInformationW (Win32WideString volumeName, Win32WideString lpBuffer, ulong nSize, ulong* nil, ulong* nil, ulong* nil, Win32WideString nil, ulong 0)) module: #kernel32
+	^ self ffiCall: #(uint GetVolumeInformationW (Win32WideString volumeName, Win32WideString lpBuffer, ulong nSize, void* 0, void* 0, void* 0, Win32WideString 0, ulong 0)) module: #kernel32
 ]


### PR DESCRIPTION
This pull request fixes mistakes made in the function signature in `#getVolumeInfo:into:size:` for StWin32Info in pull request #729.