### PR TITLE
Fix "Open terminal here" in new File browser

### DIFF
--- a/src/NewTools-FileBrowser/StFileBrowserOpenTerminalCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserOpenTerminalCommand.class.st
@@ -75,7 +75,7 @@ StFileBrowserOpenTerminalCommand >> openWindowsTerminalOn: aPath [
 	^ String streamContents: [ : stream |
 		stream
 			<< 'start cmd.exe /K "cd /d ';
-			<< aPath;
+			<< aPath fullName;
 			<< '"' ]
 ]
 


### PR DESCRIPTION
Fix "Open terminal here" in new File browser, as reported in https://github.com/pharo-project/pharo/issues/16393, which does not work correctly on Windows. Thanks to @astares for suggesting the code for the fix
