### PR TITLE
Fix Preview Settings Browser: does not open when a custom setting is used

### DIFF
--- a/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
@@ -45,8 +45,11 @@ StSettingsApplication >> iconMap [
 
 { #category : 'accessing' }
 StSettingsApplication >> iconMapAt: aString [ 
+	"Answer a <Symbol> specifying an icon name. Defaults to a generic icon if the application does not provide one"
 
-	^ self iconMap at: aString
+	^ self iconMap 
+		at: aString
+		ifAbsent: [ #info ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This PR provides a default icon for Spec applications which does not provide a category item in the new settings browser. It fixes the bug reported in https://github.com/pharo-project/pharo/issues/16399
