### PR TITLE
Fix issue while trying to display file setting items

### DIFF
--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -138,11 +138,10 @@ StPlaygroundPresenter class >> registerToolsOn: registry [
 
 { #category : 'settings' }
 StPlaygroundPresenter class >> settingsOn: aBuilder [
-<systemsettings>
+	<systemsettings>
 
-(aBuilder setting: #cacheDirectory)
+	(aBuilder setting: #cacheDirectory)
 		parent: #pharoSystem;
-		default: true;
 		type: #Directory;
 		default:  self defaultCacheDirectory;
 		target: StPlaygroundPresenter;

--- a/src/NewTools-SettingsBrowser/AbstractFileReference.extension.st
+++ b/src/NewTools-SettingsBrowser/AbstractFileReference.extension.st
@@ -12,3 +12,9 @@ AbstractFileReference >> asSettingPresenter: aSettingDeclaration [
 		value: self;
 		yourself
 ]
+
+{ #category : '*NewTools-SettingsBrowser' }
+AbstractFileReference >> asText [
+
+	^ self fullName
+]

--- a/src/NewTools-SettingsBrowser/AbstractFileReference.extension.st
+++ b/src/NewTools-SettingsBrowser/AbstractFileReference.extension.st
@@ -3,7 +3,12 @@ Extension { #name : 'AbstractFileReference' }
 { #category : '*NewTools-SettingsBrowser' }
 AbstractFileReference >> asSettingPresenter: aSettingDeclaration [ 
 
-	^ (StSettingTextPresenterItem on: aSettingDeclaration)
+	| settingPresenterClass |
+	
+	settingPresenterClass := self isDirectory 
+		ifTrue: [ StSettingDirectoryPresenterItem ]
+		ifFalse: [ StSettingFilePresenterItem ].
+	^ (settingPresenterClass on: aSettingDeclaration)
 		value: self;
 		yourself
 ]

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLineDirectorySelectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLineDirectorySelectionPresenter.class.st
@@ -1,0 +1,82 @@
+"
+Provides a Spec presenter with:
+
+- A label
+- An input text displaying a directory.
+- A button to select a directory which will update the input text when changed.
+
+"
+Class {
+	#name : 'StLabeledMultiLineDirectorySelectionPresenter',
+	#superclass : 'StLabeledMultiLinePresenter',
+	#classTraits : '{} + TraitedClass',
+	#instVars : [
+		'selectButtonPresenter'
+	],
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'examples' }
+StLabeledMultiLineDirectorySelectionPresenter class >> example [
+
+	^ (self 
+		label: 'Label Example' 
+		input: SpTextPresenter new
+		description: 'Description string') open
+
+]
+
+{ #category : 'layout' }
+StLabeledMultiLineDirectorySelectionPresenter >> buttonWidth [
+
+	^ 100
+]
+
+{ #category : 'layout' }
+StLabeledMultiLineDirectorySelectionPresenter >> defaultLayout [
+	^ SpBoxLayout newLeftToRight
+		add: labelPresenter withConstraints: [ :constraints | constraints width: self labelWidth ];
+		add:
+			(SpBoxLayout newTopToBottom
+				add: (SpBoxLayout newLeftToRight 
+					add: input withConstraints: [ :constraints | 
+						constraints 
+							width: self inputTextWidth;
+							height: self inputTextHeight ];
+					add: selectButtonPresenter withConstraints: [ :constraints | 
+						constraints width: self buttonWidth ]);
+				add: descriptionPresenter withConstraints: [ :constraints | 
+					constraints 
+						height: self inputTextHeight * 2.5 ]) width: self settingBoxWidth;
+		yourself
+]
+
+{ #category : 'initialization' }
+StLabeledMultiLineDirectorySelectionPresenter >> initializePresenters [ 
+
+	super initializePresenters.
+	selectButtonPresenter := self newButton
+		label: 'Select Directory';
+		action: [ 
+			| selectedDirectory |
+			((selectedDirectory := StOpenDirectoryPresenter new openModal) notNil and: [ selectedDirectory isDirectory ])
+				ifTrue: [ 
+					self input 
+						text: selectedDirectory fullName;
+						help: selectedDirectory fullName ] ];
+		yourself
+]
+
+{ #category : 'as yet unclassified' }
+StLabeledMultiLineDirectorySelectionPresenter >> selectButtonPresenter [
+
+	^ selectButtonPresenter
+]
+
+{ #category : 'as yet unclassified' }
+StLabeledMultiLineDirectorySelectionPresenter >> selectButtonPresenter: anObject [
+
+	selectButtonPresenter := anObject
+]

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLineDirectorySelectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLineDirectorySelectionPresenter.class.st
@@ -9,7 +9,6 @@ Provides a Spec presenter with:
 Class {
 	#name : 'StLabeledMultiLineDirectorySelectionPresenter',
 	#superclass : 'StLabeledMultiLinePresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'selectButtonPresenter'
 	],
@@ -69,13 +68,13 @@ StLabeledMultiLineDirectorySelectionPresenter >> initializePresenters [
 		yourself
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'private' }
 StLabeledMultiLineDirectorySelectionPresenter >> selectButtonPresenter [
 
 	^ selectButtonPresenter
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'private' }
 StLabeledMultiLineDirectorySelectionPresenter >> selectButtonPresenter: anObject [
 
 	selectButtonPresenter := anObject

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLineFileSelectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLineFileSelectionPresenter.class.st
@@ -1,0 +1,42 @@
+"
+Provides a Spec presenter with:
+
+- A label
+- An input text displaying a directory.
+- A button to select a directory which will update the input text when changed.
+
+"
+Class {
+	#name : 'StLabeledMultiLineFileSelectionPresenter',
+	#superclass : 'StLabeledMultiLineDirectorySelectionPresenter',
+	#classTraits : '{} + TraitedClass',
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'examples' }
+StLabeledMultiLineFileSelectionPresenter class >> example [
+
+	^ (self 
+		label: 'Label Example' 
+		input: SpTextPresenter new
+		description: 'Description string') open
+
+]
+
+{ #category : 'initialization' }
+StLabeledMultiLineFileSelectionPresenter >> initializePresenters [ 
+
+	super initializePresenters.
+	selectButtonPresenter := self newButton
+		label: 'Select File';
+		action: [ 
+			| selectedFile |
+			((selectedFile := StOpenFilePresenter new openModal) notNil and: [ selectedFile isFile ])
+				ifTrue: [ 
+					self input 
+						text: selectedFile fullName;
+						help: selectedFile fullName ] ];
+		yourself
+]

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLineFileSelectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLineFileSelectionPresenter.class.st
@@ -9,7 +9,6 @@ Provides a Spec presenter with:
 Class {
 	#name : 'StLabeledMultiLineFileSelectionPresenter',
 	#superclass : 'StLabeledMultiLineDirectorySelectionPresenter',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-SettingsBrowser-Widgets',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Widgets'

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLinePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLinePresenter.class.st
@@ -1,7 +1,6 @@
 Class {
 	#name : 'StLabeledMultiLinePresenter',
 	#superclass : 'SpLabeledPresenter',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-SettingsBrowser-Widgets',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Widgets'

--- a/src/NewTools-SettingsBrowser/StLabeledMultiLinePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StLabeledMultiLinePresenter.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : 'StLabeledMultiLinePresenter',
+	#superclass : 'SpLabeledPresenter',
+	#classTraits : '{} + TraitedClass',
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'layout' }
+StLabeledMultiLinePresenter >> defaultLayout [
+	^ SpBoxLayout newLeftToRight
+		add: labelPresenter withConstraints: [ :constraints | constraints width: self labelWidth ];
+		add:
+			(SpBoxLayout newTopToBottom
+				add: input withConstraints: [ :constraints | 
+					constraints 
+						width: self inputTextWidth;
+						height: self inputTextHeight ];
+				add: descriptionPresenter withConstraints: [ :constraints | 
+					constraints 
+						height: self inputTextHeight * 2.5 ]) width: self settingBoxWidth;
+		yourself
+]
+
+{ #category : 'accessing' }
+StLabeledMultiLinePresenter >> description: aString [
+	aString ifNil: [ ^ self ].
+	
+	descriptionPresenter := self newText
+		beWrapWord;
+		text: aString;
+		withoutEditionContextMenu;
+		withoutScrollBars;
+		addStyle: 'descriptionStyle';
+		yourself
+]
+
+{ #category : 'layout' }
+StLabeledMultiLinePresenter >> inputTextHeight [
+
+	^ self class inputTextHeight
+]
+
+{ #category : 'layout' }
+StLabeledMultiLinePresenter >> inputTextWidth [
+
+	^ 400
+]
+
+{ #category : 'accessing' }
+StLabeledMultiLinePresenter >> label: aString [
+
+	super label: aString.
+	labelPresenter help: aString.
+]
+
+{ #category : 'layout' }
+StLabeledMultiLinePresenter >> labelWidth [
+
+	^ self class labelWidth + 200
+]
+
+{ #category : 'layout' }
+StLabeledMultiLinePresenter >> settingBoxWidth [
+
+	^ 600
+]

--- a/src/NewTools-SettingsBrowser/StSettingBooleanPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingBooleanPresenterItem.class.st
@@ -1,5 +1,5 @@
 "
-Wrapper for settings containing a `Booleam` type.
+Wrapper for settings containing a `Boolean` type.
 "
 Class {
 	#name : 'StSettingBooleanPresenterItem',
@@ -12,8 +12,9 @@ Class {
 { #category : 'initialization' }
 StSettingBooleanPresenterItem >> initializePresenters [ 
 
-	super initializePresenters.
 	setterPresenter := self newCheckBox.
+	super initializePresenters.
+
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingDirectoryPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingDirectoryPresenterItem.class.st
@@ -1,0 +1,41 @@
+"
+Wrapper for settings containing a directory `FileReference` type.
+"
+Class {
+	#name : 'StSettingDirectoryPresenterItem',
+	#superclass : 'StSettingPresenterItem',
+	#classTraits : '{} + TraitedClass',
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'as yet unclassified' }
+StSettingDirectoryPresenterItem >> initializePresenters [
+
+	setterPresenter := self newTextInput 
+		beEditable;
+		placeholder: self model label;
+		yourself.
+	labeledPresenter := (self instantiate: self labeledPresenterClass on: self) 
+		label: self model label;
+		description: self model description;
+		input: self setterPresenter;
+		yourself.
+]
+
+{ #category : 'initialization' }
+StSettingDirectoryPresenterItem >> labeledPresenterClass [
+
+	^ StLabeledMultiLineDirectorySelectionPresenter
+
+]
+
+{ #category : 'as yet unclassified' }
+StSettingDirectoryPresenterItem >> value: aFileReference [ 
+	"Set the receiver's value to aString"
+
+	self setterPresenter 
+		help: aFileReference asString;
+		text: aFileReference
+]

--- a/src/NewTools-SettingsBrowser/StSettingDirectoryPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingDirectoryPresenterItem.class.st
@@ -4,13 +4,12 @@ Wrapper for settings containing a directory `FileReference` type.
 Class {
 	#name : 'StSettingDirectoryPresenterItem',
 	#superclass : 'StSettingPresenterItem',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-SettingsBrowser-Widgets',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Widgets'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'initialization' }
 StSettingDirectoryPresenterItem >> initializePresenters [
 
 	setterPresenter := self newTextInput 
@@ -31,7 +30,7 @@ StSettingDirectoryPresenterItem >> labeledPresenterClass [
 
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 StSettingDirectoryPresenterItem >> value: aFileReference [ 
 	"Set the receiver's value to aString"
 

--- a/src/NewTools-SettingsBrowser/StSettingDropListPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingDropListPresenterItem.class.st
@@ -9,12 +9,12 @@ Class {
 { #category : 'initialization' }
 StSettingDropListPresenterItem >> initializePresenters [ 
 
-	super initializePresenters.
 	setterPresenter := self newDropList
 		items: self model domainValues;
 		display: [ : item | item asString ];
 		selectIndex: self model index;
-		yourself
+		yourself.
+	super initializePresenters.
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingFilePresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingFilePresenterItem.class.st
@@ -1,0 +1,18 @@
+"
+Wrapper for settings containing a file `FileReference` type.
+"
+Class {
+	#name : 'StSettingFilePresenterItem',
+	#superclass : 'StSettingDirectoryPresenterItem',
+	#classTraits : '{} + TraitedClass',
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'initialization' }
+StSettingFilePresenterItem >> labeledPresenterClass [
+
+	^ StLabeledMultiLineFileSelectionPresenter
+
+]

--- a/src/NewTools-SettingsBrowser/StSettingFilePresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingFilePresenterItem.class.st
@@ -4,7 +4,6 @@ Wrapper for settings containing a file `FileReference` type.
 Class {
 	#name : 'StSettingFilePresenterItem',
 	#superclass : 'StSettingDirectoryPresenterItem',
-	#classTraits : '{} + TraitedClass',
 	#category : 'NewTools-SettingsBrowser-Widgets',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Widgets'

--- a/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
@@ -6,8 +6,8 @@ This presenter wraps those setting items which should present two drop lists. Fo
 Class {
 	#name : 'StSettingMultipleDropListPresenterItem',
 	#superclass : 'StSettingPresenterItem',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
-		'fontStylePresenter',
 		'colorSettingItemPresenter'
 	],
 	#category : 'NewTools-SettingsBrowser-Widgets',

--- a/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
@@ -19,17 +19,17 @@ Class {
 StSettingMultipleDropListPresenterItem >> initializePresenters [ 
 
 	| modelDefault |
-	super initializePresenters.
-	
+
 	modelDefault := self model default.
 	modelDefault color
 		ifNil: [ modelDefault color: Color transparent ].
 	colorSettingItemPresenter := modelDefault color asSettingPresenter: model.
 
-	fontStylePresenter := self newDropList 
+	setterPresenter := self newDropList 
 		items: #(#bold #italic #normal 'bold italic' );
 		selectItem: modelDefault emphasis;		
 		yourself.
+	super initializePresenters.
 ]
 
 { #category : 'accessing' }
@@ -38,6 +38,6 @@ StSettingMultipleDropListPresenterItem >> value: aSHStyleElement [
 	self flag: #delete.
 	colorSettingItemPresenter 
 		buttonColor: aSHStyleElement color.
-	fontStylePresenter selectItem: aSHStyleElement emphasis.
+	setterPresenter selectItem: aSHStyleElement emphasis.
 
 ]

--- a/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingMultipleDropListPresenterItem.class.st
@@ -6,7 +6,6 @@ This presenter wraps those setting items which should present two drop lists. Fo
 Class {
 	#name : 'StSettingMultipleDropListPresenterItem',
 	#superclass : 'StSettingPresenterItem',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'colorSettingItemPresenter'
 	],

--- a/src/NewTools-SettingsBrowser/StSettingNumberPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingNumberPresenterItem.class.st
@@ -24,8 +24,8 @@ StSettingNumberPresenterItem >> beInteger [
 { #category : 'initialization' }
 StSettingNumberPresenterItem >> initializePresenters [ 
 
-	super initializePresenters.
 	setterPresenter := self newNumberInput.
+	super initializePresenters.
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingPresenterItem.class.st
@@ -8,7 +8,6 @@ The wrapped presenter is hold in `setterPresenter` instance variable.
 Class {
 	#name : 'StSettingPresenterItem',
 	#superclass : 'SpPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'setterPresenter',
 		'model',

--- a/src/NewTools-SettingsBrowser/StSettingPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingPresenterItem.class.st
@@ -8,11 +8,11 @@ The wrapped presenter is hold in `setterPresenter` instance variable.
 Class {
 	#name : 'StSettingPresenterItem',
 	#superclass : 'SpPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
-		'labelPresenter',
 		'setterPresenter',
-		'descriptionPresenter',
-		'model'
+		'model',
+		'labeledPresenter'
 	],
 	#category : 'NewTools-SettingsBrowser-Widgets',
 	#package : 'NewTools-SettingsBrowser',
@@ -22,54 +22,28 @@ Class {
 { #category : 'layout' }
 StSettingPresenterItem >> defaultLayout [
 
-	^ SpBoxLayout newLeftToRight
-		vAlignCenter;
-		add: labelPresenter width: 300;
-		add: setterPresenter width: 200;
-		add: descriptionPresenter;
+	^ SpBoxLayout newTopToBottom
+		add: labeledPresenter;
 		yourself
-]
-
-{ #category : 'accessing' }
-StSettingPresenterItem >> descriptionPresenter [
-
-	^ descriptionPresenter
-]
-
-{ #category : 'accessing' }
-StSettingPresenterItem >> descriptionPresenter: anObject [
-
-	descriptionPresenter := anObject
 ]
 
 { #category : 'initialization' }
 StSettingPresenterItem >> initializePresenters [
 	"Set a label and description presenters as baseline for every setting"
 
-	labelPresenter := self newText 
-		withoutScrollBars;
-		propagateNaturalHeight: false;	
-		addStyle: 'descriptionStyle';
-		text: self model label.
-	descriptionPresenter := self newText 
-		withoutScrollBars;
-		propagateNaturalHeight: false;
-		text: self model description;
-		addStyle: 'descriptionStyle';
+	labeledPresenter := (self instantiate: self labeledPresenterClass on: self) 
+		label: self model label;
+		description: self model description;
+		input: self setterPresenter;
 		yourself.
 
 ]
 
-{ #category : 'accessing' }
-StSettingPresenterItem >> labelPresenter [
+{ #category : 'initialization' }
+StSettingPresenterItem >> labeledPresenterClass [
 
-	^ labelPresenter
-]
+	^ StLabeledMultiLinePresenter
 
-{ #category : 'accessing' }
-StSettingPresenterItem >> labelPresenter: anObject [
-
-	labelPresenter := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingSHStyleButtonPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingSHStyleButtonPresenterItem.class.st
@@ -27,6 +27,6 @@ StSettingSHStyleButtonPresenterItem >> buttonLabel: aString [
 { #category : 'initialization' }
 StSettingSHStyleButtonPresenterItem >> initializePresenters [ 
 
+	setterPresenter := self newButton.
 	super initializePresenters.
-	setterPresenter := self newButton
 ]

--- a/src/NewTools-SettingsBrowser/StSettingSectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingSectionPresenter.class.st
@@ -4,6 +4,7 @@ It represents a setting node Spec presenter with children (a section).
 Class {
 	#name : 'StSettingSectionPresenter',
 	#superclass : 'StSettingPresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'detailBox'
 	],

--- a/src/NewTools-SettingsBrowser/StSettingSectionPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingSectionPresenter.class.st
@@ -4,7 +4,6 @@ It represents a setting node Spec presenter with children (a section).
 Class {
 	#name : 'StSettingSectionPresenter',
 	#superclass : 'StSettingPresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'detailBox'
 	],

--- a/src/NewTools-SettingsBrowser/StSettingTextPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingTextPresenterItem.class.st
@@ -12,11 +12,11 @@ Class {
 { #category : 'initialization' }
 StSettingTextPresenterItem >> initializePresenters [ 
 
-	super initializePresenters.
 	setterPresenter := self newTextInput
 		beEditable;
 		placeholder: self model label;		
-		yourself 
+		yourself.
+	super initializePresenters.
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
@@ -36,6 +36,12 @@ StSettingsApplication class >> open [
 	self new start.
 ]
 
+{ #category : 'adding' }
+StSettingsApplication >> descriptionBackgroundColor [
+
+	^ Smalltalk ui theme lightBackgroundColor asHexString
+]
+
 { #category : 'accessing' }
 StSettingsApplication >> iconMap [
 
@@ -130,6 +136,6 @@ StSettingsApplication >> styleSheetString [
 	.settingItemStyle [ 
 		Container { #borderWidth: 5 } ],
 	.descriptionStyle [ 
-		Draw { #backgroundColor: #' , Smalltalk ui theme windowColor asHexString , ' } ]
+		Draw { #backgroundColor: #' , self descriptionBackgroundColor , ' } ]
 ]'.
 ]

--- a/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsApplication.class.st
@@ -39,7 +39,7 @@ StSettingsApplication class >> open [
 { #category : 'adding' }
 StSettingsApplication >> descriptionBackgroundColor [
 
-	^ Smalltalk ui theme lightBackgroundColor asHexString
+	^ UITheme current lightBackgroundColor asHexString
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
@@ -85,6 +85,6 @@ StSettingsMainPresenter >> initializeWindow: aWindowPresenter [
 
 	aWindowPresenter
 		title: self browserTitle;
-		initialExtent: 1000 @ 700;
+		initialExtent: 1200 @ 700;
 		centered
 ]

--- a/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
@@ -53,7 +53,7 @@ StSettingsPagePresenter >> setModel: aNode [
 { #category : 'accessing' }
 StSettingsPagePresenter >> updatePresenterTree: aStSettingNode level: anInteger [ 
 	"Private - Recursively iterate aStSettingNode children using anInteger as 'level' indicator for title styling purposes"
-	
+
 	aStSettingNode allChildren do: [ : aSettingNode | 
 		| nodePresenter |
 


### PR DESCRIPTION
This PR fixes various problems with the setting browser:

- Add two setting wrappers for selection of directory and files in the new settings browser.
- Fix layout of settings pages to avoid unnecessary scroll bars.
- Better layout and colors.
- Add missing method to display file reference names in the setting browser.
- Remove duplicated `default:` in Playground setting. 
- Fix opening of Color Picker
