### PR TITLE
Change superclass of StDebuggerTest from TestCase to SpBaseTest

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'StDebuggerTest',
-	#superclass : 'TestCase',
+	#superclass : 'SpBaseTest',
 	#instVars : [
 		'session',
 		'debugger',


### PR DESCRIPTION
In [build 2](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-16449/2/) for [Pharo pull request #16449](https://github.com/pharo-project/pharo/pull/16449), `#testUpdateExtensionSubscription` on StDebuggerTest failed on Linux, but not on Windows or macOS. I didn’t really investigate, but I’m guessing the cause is use of different processes as discussed in Pharo issues [#12502](https://github.com/pharo-project/pharo/issues/12502) and [#16041](https://github.com/pharo-project/pharo/issues/16041), so this pull request changes the superclass of StDebuggerTest from TestCase to SpBaseTest.