### PR TITLE
ProfilerUI: Added a warning when trying to compile and the variables are not declared

### DIFF
--- a/src/NewTools-ProfilerUI/StProfilerModel.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerModel.class.st
@@ -159,15 +159,21 @@ StProfilerModel >> profileBlock: aBlock [
 { #category : 'api' }
 StProfilerModel >> profileCode: someCode notifying: requestor [
 
-	| compiledMethod |
+	| compiledMethod compiler |
 	self resetProfiler.
-
-	compiledMethod := Smalltalk compiler
-		                  source: (self doItSourceCodeFrom: someCode);
-		                  requestor: requestor;
-		                  isScripting: true;
-		                  failBlock: [ ^ self ];
-		                  compile.
+	compiler := Smalltalk compiler
+		            source: (self doItSourceCodeFrom: someCode);
+		            requestor: requestor;
+		            isScripting: true;
+		            permitUndeclared: true;
+		            failBlock: [ ^ self ];
+		            yourself.
+	compiledMethod := [ compiler compile ]
+		                  on: OCUndeclaredVariableWarning
+		                  do: [
+			                  SpPresenter new alert:
+				                  'They are undeclared variables!'.
+			                  ^ self ].
 	compiledMethod valueWithReceiver: self
 ]
 


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/16330
As the code we are compiling doesn't belong to any class, the compiler cannot change the definition of the code.
A workaround that we found is showing a warning to the user when that happens.
A more complete solution can be to implement a binding mechanism like in the Playground, but that needs more discussion.