### PR TITLE
Remove references to SystemAnnouncer singleton

### DIFF
--- a/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
@@ -479,10 +479,10 @@ StCritiqueBrowserPresenter >> reapplyThisRule [
 
 { #category : 'system annoucements' }
 StCritiqueBrowserPresenter >> registerToAnnouncements [
-	
+
 	self unregisterFromAnnouncements.
-	
-	SystemAnnouncer uniqueInstance weak
+
+	self class codeChangeAnnouncer weak
 		when: ClassAdded send: #handleClassAdded: to: self;
 		when: ClassModifiedClassDefinition send: #handleClassModified: to: self;
 		when: ClassRemoved send: #handleClassRemoved: to: self;
@@ -645,7 +645,7 @@ StCritiqueBrowserPresenter >> toolbarModel [
 { #category : 'system annoucements' }
 StCritiqueBrowserPresenter >> unregisterFromAnnouncements [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Core/StPharoApplication.class.st
+++ b/src/NewTools-Core/StPharoApplication.class.st
@@ -65,10 +65,7 @@ StPharoApplication >> initialize [
 StPharoApplication >> initializeConfiguration [
 
 	self resetConfiguration.
-	SystemAnnouncer uniqueInstance weak 
-		when: UIThemeChanged 
-		send: #resetConfiguration
-		to: self
+	self class codeSupportAnnouncer weak when: UIThemeChanged send: #resetConfiguration to: self
 ]
 
 { #category : 'private - factory' }

--- a/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
@@ -93,14 +93,13 @@ DebugPointBrowserPresenter >> defaultLayout [
 ]
 
 { #category : 'initialization' }
-DebugPointBrowserPresenter >> initialize [ 
+DebugPointBrowserPresenter >> initialize [
 
 	super initialize.
-	SystemAnnouncer uniqueInstance weak when: DebugPointAdded send: #updateTable to: self.
-	SystemAnnouncer uniqueInstance weak when: DebugPointRemoved send: #updateTable to: self.
-	SystemAnnouncer uniqueInstance weak when: DebugPointChanged send: #updateEditor to: self.
-		
-	
+	self class codeSupportAnnouncer weak
+		when: DebugPointAdded send: #updateTable to: self;
+		when: DebugPointRemoved send: #updateTable to: self;
+		when: DebugPointChanged send: #updateEditor to: self
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltCache.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltCache.class.st
@@ -102,7 +102,8 @@ StHaltCache >> buildCacheForMethod: aCompiledMethod [
 
 { #category : 'notifying' }
 StHaltCache >> cacheChanged [
-	SystemAnnouncer uniqueInstance announce: StHaltCacheChanged
+
+	self class codeSupportAnnouncer announce: StHaltCacheChanged
 ]
 
 { #category : 'cache' }
@@ -161,14 +162,17 @@ StHaltCache >> refreshCache [
 
 { #category : 'system subscription' }
 StHaltCache >> registerSubscriptions [
-	SystemAnnouncer uniqueInstance weak when: MethodModified send: #methodChanged: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #methodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodAdded send: #methodAdded: to: self
+
+	self class codeChangeAnnouncer weak
+		when: MethodModified send: #methodChanged: to: self;
+		when: MethodRemoved send: #methodRemoved: to: self;
+		when: MethodAdded send: #methodAdded: to: self
 ]
 
 { #category : 'system subscription' }
 StHaltCache >> removeSubscriptions [
-	SystemAnnouncer uniqueInstance unsubscribe: self
+
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Debugger-Breakpoints-Tools/StHaltCacheTest.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StHaltCacheTest.class.st
@@ -31,28 +31,31 @@ StHaltCacheTest >> testAddingHaltToMethod [
 
 { #category : 'tests - cache initialization' }
 StHaltCacheTest >> testCacheActivation [
+
 	cache removeSubscriptions.
 	cache := StHaltCache new.
 	cache isActive: true.
 	self assert: cache isActive.
-	self assert: (SystemAnnouncer uniqueInstance hasSubscriber: cache) 
+	self assert: (self class codeChangeAnnouncer hasSubscriber: cache)
 ]
 
 { #category : 'tests - cache initialization' }
 StHaltCacheTest >> testCacheDectivation [
+
 	cache removeSubscriptions.
 	cache := StHaltCache new.
 	cache isActive: true.
-	self assert: (SystemAnnouncer uniqueInstance hasSubscriber: cache).
+	self assert: (self class codeChangeAnnouncer hasSubscriber: cache).
 	cache isActive: false.
-	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: cache) 
+	self deny: (self class codeChangeAnnouncer hasSubscriber: cache)
 ]
 
 { #category : 'tests - cache initialization' }
 StHaltCacheTest >> testInitialActivation [
+
 	cache := StHaltCache new.
 	self deny: cache isActive.
-	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: cache) 
+	self deny: (self class codeChangeAnnouncer hasSubscriber: cache)
 ]
 
 { #category : 'tests - cache building' }

--- a/src/NewTools-Debugger-Breakpoints-Tools/StObjectBreakpointInspection.class.st
+++ b/src/NewTools-Debugger-Breakpoints-Tools/StObjectBreakpointInspection.class.st
@@ -154,19 +154,21 @@ StObjectBreakpointInspection >> initialize [
 
 { #category : 'initialization' }
 StObjectBreakpointInspection >> initializePresenters [
+
 	self buildSourceCode.
 	self buildHaltAndBreakpointTable.
 	self configureSourceCodeUpdate.
 	self buildTableData.
-	SystemAnnouncer uniqueInstance weak when: StHaltCacheChanged send: #buildTableData to: self.
-	SystemAnnouncer uniqueInstance weak when: BreakpointAdded send: #buildTableData to: self
+	self class codeSupportAnnouncer weak
+		when: StHaltCacheChanged send: #buildTableData to: self;
+		when: BreakpointAdded send: #buildTableData to: self
 ]
 
 { #category : 'initialization' }
 StObjectBreakpointInspection >> initializeWindow: aWindowPresenter [
+
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter
-		whenClosedDo: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
+	aWindowPresenter whenClosedDo: [ self unsubscribeFromCacheChanges ]
 ]
 
 { #category : 'breakpoints' }
@@ -197,7 +199,8 @@ StObjectBreakpointInspection >> methodsWithBreakpoints [
 
 { #category : 'system subscription' }
 StObjectBreakpointInspection >> unsubscribeFromCacheChanges [
-	SystemAnnouncer uniqueInstance unsubscribe: self
+
+	self class codeSupportAnnouncer unsubscribe: self
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -99,10 +99,8 @@ StDebuggerTest >> setUp [
 StDebuggerTest >> subscriptionsForStDebuggerExtensionActivationToggle [
 
 	| subscriptions |
-	subscriptions := SystemAnnouncer uniqueInstance subscriptions
-		                 subscriptions.
-	^ subscriptions asOrderedCollection select: [ :s | 
-		  s announcementClass = StDebuggerExtensionActivationToggle ]
+	subscriptions := self class codeSupportAnnouncer subscriptions subscriptions.
+	^ subscriptions asOrderedCollection select: [ :s | s announcementClass = StDebuggerExtensionActivationToggle ]
 ]
 
 { #category : 'running' }
@@ -215,9 +213,8 @@ StDebuggerTest >> testClose [
 	"We trigger the closing from the presenter instead of the debugger itself,
 	because the window is not really open so the debugger will not close through debugger close."
 	windowPresenter windowClosed.
-	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: debugger).
-	self deny:
-		(actionModel hasSubscriber: debugger)
+	self deny: (self class codeSupportAnnouncer hasSubscriber: debugger).
+	self deny: (actionModel hasSubscriber: debugger)
 ]
 
 { #category : 'tests - code pane' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -134,8 +134,7 @@ StDebugger class >> configureLayout [
 StDebugger class >> configureLayout: aSymbol [
 
 	self layoutConfigurator selectedLayout: aSymbol.
-	SystemAnnouncer uniqueInstance announce:
-		StDebuggerLayoutChangedAnnouncement new
+	self codeSupportAnnouncer announce: StDebuggerLayoutChangedAnnouncement new
 ]
 
 { #category : 'instance creation' }
@@ -1301,19 +1300,13 @@ StDebugger >> subscribeToActionModel [
 { #category : 'subscription' }
 StDebugger >> susbcribeToExtensionToggleAnnouncement [
 
-	SystemAnnouncer uniqueInstance weak
-		when: StDebuggerExtensionActivationToggle
-		send: #updateExtensionsFromAnnouncement:
-		to: self
+	self class codeSupportAnnouncer weak when: StDebuggerExtensionActivationToggle send: #updateExtensionsFromAnnouncement: to: self
 ]
 
 { #category : 'subscription' }
 StDebugger >> susbcribeToLayoutChangesAnnouncement [
 
-	SystemAnnouncer uniqueInstance weak
-		when: StDebuggerLayoutChangedAnnouncement
-		send: #updateLayout
-		to: self
+	self class codeSupportAnnouncer weak when: StDebuggerLayoutChangedAnnouncement send: #updateLayout to: self
 ]
 
 { #category : 'accessing - presenters' }
@@ -1344,7 +1337,7 @@ StDebugger >> unsubscribeFromActionModel [
 { #category : 'subscription' }
 StDebugger >> unsubscribeFromSystemAnnouncer [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self class codeSupportAnnouncer unsubscribe: self
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -503,10 +503,7 @@ StDebuggerActionModel >> stepThrough: aContext [
 { #category : 'system subscription' }
 StDebuggerActionModel >> subscribeToMethodAddedAnnouncement [
 
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAdded
-		send: #updateAfterMethodAdded
-		to: self
+	self class codeChangeAnnouncer weak when: MethodAdded send: #updateAfterMethodAdded to: self
 ]
 
 { #category : 'accessing' }
@@ -523,7 +520,7 @@ StDebuggerActionModel >> unsubscribe: anEventListener [
 { #category : 'system subscription' }
 StDebuggerActionModel >> unsubscribeFromSystemAnnouncer [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Debugger/TStDebuggerExtension.trait.st
+++ b/src/NewTools-Debugger/TStDebuggerExtension.trait.st
@@ -48,11 +48,9 @@ TStDebuggerExtension classSide >> showInDebugger [
 { #category : 'debugger extension' }
 TStDebuggerExtension classSide >> showInDebugger: aBoolean [
 
-	self showInDebugger = aBoolean ifTrue: [ "The activated state hasn't changed. So we don't announce an extension toggle"
-		^ self ].
+	self showInDebugger = aBoolean ifTrue: [ "The activated state hasn't changed. So we don't announce an extension toggle" ^ self ].
 	showDebuggerExtension := aBoolean.
-	SystemAnnouncer uniqueInstance announce:
-		(StDebuggerExtensionActivationToggle debuggerExtensionClass: self)
+	self class codeSupportAnnouncer announce: (StDebuggerExtensionActivationToggle debuggerExtensionClass: self)
 ]
 
 { #category : 'visiting' }

--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -472,7 +472,7 @@ StMessageBrowser >> refreshingBlock: aBlock [
 { #category : 'announcements - registration' }
 StMessageBrowser >> registerToAnnouncements [
 
-	SystemAnnouncer uniqueInstance weak		
+	self class codeChangeAnnouncer weak
 		when: MethodAdded send: #methodAdded: to: self;
 		when: MethodModified send: #methodModified: to: self;
 		when: MethodRemoved send: #methodRemoved: to: self;
@@ -647,6 +647,6 @@ StMessageBrowser >> whenSelectedItemChanged: aBlock [
 
 { #category : 'private' }
 StMessageBrowser >> windowIsClosing [
-	
-	SystemAnnouncer uniqueInstance unsubscribe: self
+
+	self class codeChangeAnnouncer unsubscribe: self
 ]


### PR DESCRIPTION
This change removes the references to `SystemAnnouncer uniqueInstance` to use either #codeChangeAnnouncer or #codeSupportAnnouncer depending on the cases.