### PR TITLE
[P12][P13] fix `#needRequestorScope` of `StDebuggerContextInteractionModel` so that its bindings can be used when evaluating code in the debugger

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -100,6 +100,12 @@ StDebuggerContextInteractionModel >> isScripting [
 	^context belongsToDoIt
 ]
 
+{ #category : 'testing' }
+StDebuggerContextInteractionModel >> needRequestorScope [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StDebuggerContextInteractionModel >> object [
 


### PR DESCRIPTION
Currently, `StDebuggerContextInteractionModel >> #needRequestorScope` returns false, which prevents the debugger from using the bindings of its interaction model when evaluating code.

It should return `true`.

[For more details, see discussion here](https://github.com/pharo-spec/Spec/issues/1506)

This should be merged to Pharo13 AND Pharo12