### PR TITLE
Updated text to new shortcut

### DIFF
--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -99,7 +99,7 @@ StPlaygroundPresenter class >> menuCommandOn: aBuilder [
 		parent: #InputOutput;
 		action: [ Smalltalk tools openWorkspace ];
 		order: 1;
-		keyText: 'o, w';
+		keyText: 'o, p';
 		help: 'A window used as a scratchpad area where fragments of Pharo code can be entered, stored, edited, and evaluated.';
 		iconName: #workspace
 ]


### PR DESCRIPTION
Now the Playground's shortcut is `O + P` but the text was using O + W. This updates to the new Shortcut.

Before:
<img width="343" alt="image" src="https://github.com/pharo-spec/NewTools/assets/33934979/6fc752d4-049a-404a-8a8d-96135d7e5de0">

Now:
<img width="340" alt="image" src="https://github.com/pharo-spec/NewTools/assets/33934979/cbfa4057-9543-4fd2-be89-da31a60d9a84">
