### PR TITLE
Use taskbar icon name for inspector and playground

### DIFF
--- a/src/NewTools-Inspector/StInspectorPresenter.class.st
+++ b/src/NewTools-Inspector/StInspectorPresenter.class.st
@@ -324,6 +324,12 @@ StInspectorPresenter >> stopProcessing [
 	StInspectorRefreshService uniqueInstance unregister: self
 ]
 
+{ #category : 'initialization' }
+StInspectorPresenter >> taskbarIconName [
+	
+	^ #smallInspectIt
+]
+
 { #category : 'private - updating' }
 StInspectorPresenter >> updateList [
 
@@ -338,12 +344,6 @@ StInspectorPresenter >> updateTitle [
 	self isRoot ifFalse: [ ^ self ].
 	self withWindowDo: [ :window | 
 		window title: self title ].
-]
-
-{ #category : 'initialization' }
-StInspectorPresenter >> windowIcon [
-	
-	^ self application iconNamed: #smallInspectIt
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
@@ -379,6 +379,12 @@ StPlaygroundPagePresenter >> showLineNumbers: aBoolean [
 	toggleLineNumberButton label: (StShowLineNumbersCommand iconLabelFor: self showLineNumbers)
 ]
 
+{ #category : 'initialization' }
+StPlaygroundPagePresenter >> taskbarIconName [
+	
+	^ #workspace
+]
+
 { #category : 'private' }
 StPlaygroundPagePresenter >> text [
 
@@ -429,10 +435,4 @@ StPlaygroundPagePresenter >> updatePresenter [
 StPlaygroundPagePresenter >> whenActivatedDo: aBlock [
 
 	activationBlock := aBlock
-]
-
-{ #category : 'initialization' }
-StPlaygroundPagePresenter >> windowIcon [
-	
-	^ self application iconNamed: #workspace
 ]

--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -213,9 +213,9 @@ StPlaygroundPresenter >> stopProcessing [
 ]
 
 { #category : 'initialization' }
-StPlaygroundPresenter >> windowIcon [
+StPlaygroundPresenter >> taskbarIconName [
 	
-	^ self application iconNamed: #workspace
+	^ #workspace
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
In the same idea of https://github.com/pharo-project/pharo/pull/16661
This PR only follow what is written in actual Pharo code. Do not using `windowIcon` (that is only use for icon in taskbar). And use `taskbarIconName` instead