### PR TITLE
Revert "Use taskbar icon name for inspector and playground"

### DIFF
--- a/src/NewTools-Inspector/StInspectorPresenter.class.st
+++ b/src/NewTools-Inspector/StInspectorPresenter.class.st
@@ -324,12 +324,6 @@ StInspectorPresenter >> stopProcessing [
 	StInspectorRefreshService uniqueInstance unregister: self
 ]
 
-{ #category : 'initialization' }
-StInspectorPresenter >> taskbarIconName [
-	
-	^ #smallInspectIt
-]
-
 { #category : 'private - updating' }
 StInspectorPresenter >> updateList [
 
@@ -344,6 +338,12 @@ StInspectorPresenter >> updateTitle [
 	self isRoot ifFalse: [ ^ self ].
 	self withWindowDo: [ :window | 
 		window title: self title ].
+]
+
+{ #category : 'initialization' }
+StInspectorPresenter >> windowIcon [
+	
+	^ self application iconNamed: #smallInspectIt
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
@@ -379,12 +379,6 @@ StPlaygroundPagePresenter >> showLineNumbers: aBoolean [
 	toggleLineNumberButton label: (StShowLineNumbersCommand iconLabelFor: self showLineNumbers)
 ]
 
-{ #category : 'initialization' }
-StPlaygroundPagePresenter >> taskbarIconName [
-	
-	^ #workspace
-]
-
 { #category : 'private' }
 StPlaygroundPagePresenter >> text [
 
@@ -435,4 +429,10 @@ StPlaygroundPagePresenter >> updatePresenter [
 StPlaygroundPagePresenter >> whenActivatedDo: aBlock [
 
 	activationBlock := aBlock
+]
+
+{ #category : 'initialization' }
+StPlaygroundPagePresenter >> windowIcon [
+	
+	^ self application iconNamed: #workspace
 ]

--- a/src/NewTools-Playground/StPlaygroundPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPresenter.class.st
@@ -213,9 +213,9 @@ StPlaygroundPresenter >> stopProcessing [
 ]
 
 { #category : 'initialization' }
-StPlaygroundPresenter >> taskbarIconName [
+StPlaygroundPresenter >> windowIcon [
 	
-	^ #workspace
+	^ self application iconNamed: #workspace
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Reverts pharo-spec/NewTools#771

I will revert this PR since it breaks Pharo

```
Form(Object)>>doesNotUnderstand: #asSymbol
ThemeIcons>>iconFormSetNamed:ifNone:
ThemeIcons>>iconFormSetNamed:
TaskbarItemMorph(Object)>>iconFormSetNamed:
TaskbarItemMorph>>initializeFor:
PharoLightTheme(UITheme)>>newTaskbarButtonIn:forTask:
TaskbarTask>>taskbarButtonFor:
[:t | | button |
		button := t taskbarButtonFor: self.
		button ifNotNil: [self addMorphBack: button]] in TaskbarMorph>>updateTaskButtons in Block: [:t | | button |...
OrderedCollection>>do:
TaskbarMorph>>updateTaskButtons
TaskbarMorph>>updateTasks
[self updateBounds.
	self updateTasks] in TaskbarMorph>>ownerChanged in Block: [self updateBounds....
FullBlockClosure(BlockClosure)>>on:do:
TaskbarMorph>>ownerChanged
[:m | m ownerChanged] in WorldMorph(Morph)>>doLayoutIn: in Block: [:m | m ownerChanged]
Array(SequenceableCollection)>>do:
WorldMorph(Morph)>>doLayoutIn:
WorldMorph(Morph)>>computeFullBounds
WorldMorph(Morph)>>fullBounds
MorphicEventDispatcher>>dispatchDefault:with:
MorphicEventDispatcher>>handleMouseMove:
MouseMoveEvent>>sentTo:
[ ^ anEvent sentTo: self ] in MorphicEventDispatcher>>dispatchEvent:with: in Block: [ ^ anEvent sentTo: self ]
FullBlockClosure(BlockClosure)>>ensure:
MorphicEventDispatcher>>dispatchEvent:with:
WorldMorph(Morph)>>processEvent:using:
WorldMorph(Morph)>>processEvent:
HandMorph>>sendEvent:focus:clear:
HandMorph>>sendMouseEvent:
HandMorph>>handleEvent:
[
		(morphicWorld activeHand isNotNil and: [ anEvent hand isNotNil ]) ifTrue: [
			morphicWorld activeHand handleEvent: anEvent
		]
	] in OSWindowMorphicEventHandler>>dispatchMorphicEvent: in Block: [...
WorldState>>runStepMethodsIn:
WorldMorph>>runStepMethods
WorldState>>doOneCycleFor:
WorldMorph>>doOneCycleNow
WorldMorph>>doOneCycle
[
		| extraWorldsToDraw |
		extraWorldsToDraw := ExtraWorldListMutex critical: [
			                     self extraWorldList ].
		extraWorldsToDraw do: [ :world | world doOneCycle ].

		(self currentWorld isNotNil and: [
			 (extraWorldsToDraw includes: self currentWorld) not ]) ifTrue: [
			self currentWorld doOneCycle ] ] in WorldMorph class>>doOneCycle in Block: [...
FullBlockClosure(BlockClosure)>>ensure:
WorldState class>>doDrawCycleWith:
WorldMorph class>>doOneCycle
MorphicRenderLoop>>doOneCycle
MorphicRenderLoop>>doOneCycleWhile:
[ MorphicRenderLoop new doOneCycleWhile: [ true ] ] in MorphicUIManager>>spawnNewProcess in Block: [ MorphicRenderLoop new doOneCycleWhile: [ tru[..]
[self value.
			"IMPORTANT: Do not step over next line of code. See method comments for details"
			Processor terminateRealActive] in FullBlockClosure(BlockClosure)>>newProcess in Block: [self value....

```