### PR TITLE
Deprecate asFileName and re-write senders

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -82,6 +82,10 @@ BaselineOfNewTools >> baseline: spec [
 			"Fuel"
 			package: 'NewTools-Debugger-Fuel';
 			package: 'NewTools-Debugger-Fuel-Tests' with: [ spec requires: #( 'NewTools-Debugger-Fuel' ) ];
+			"Utils"
+			package: 'NewTools-Fuel';
+			package: 'NewTools-Fuel-Tests' with: [ spec requires: #( 'NewTools-Fuel' ) ];
+			
      		"Rewriter Tools"
 			package: 'NewTools-RewriterTools-Backend';
 			package: 'NewTools-RewriterTools' with: [ spec requires: #('NewTools-RewriterTools-Backend') ];
@@ -123,7 +127,10 @@ BaselineOfNewTools >> baseline: spec [
 				    	'NewTools-Debugger-Breakpoints-Tools'
 				    	'NewTools-Debugger-Tests' 
 					 	'NewTools-Debugger-Fuel'
-				    	'NewTools-Debugger-Fuel-Tests' 
+				    	'NewTools-Debugger-Fuel-Tests'
+					
+						'NewTools-Fuel'
+						'NewTools-Fuel-Test'
 					 	'NewTools-Utils'
 						'NewTools-DebugPointsBrowser'
 						'NewTools-ObjectCentricDebugPoints' );
@@ -172,6 +179,10 @@ BaselineOfNewTools >> baseline: spec [
 			group: 'SettingsBrowser' with: #(
 						'NewTools-SettingsBrowser'
 						'NewTools-SettingsBrowser-Tests');
+			"Utilities"
+			group: 'Utils' with: #(
+				'NewTools-Fuel'
+				'NewTools-Fuel-Tests');
 
 			group: 'default' with: #( 
 						'Playground' 
@@ -187,7 +198,8 @@ BaselineOfNewTools >> baseline: spec [
 						'FileBrowser'
 						'Finder'
 						'Profiler'
-						'SettingsBrowser' ) ]
+						'SettingsBrowser'
+						'Utils' ) ]
 ]
 
 { #category : 'external projects' }

--- a/src/NewTools-Fuel-Tests/FLFuelOutTest.class.st
+++ b/src/NewTools-Fuel-Tests/FLFuelOutTest.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : 'FLFuelOutTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'fileName'
+	],
+	#category : 'NewTools-Fuel-Tests',
+	#package : 'NewTools-Fuel-Tests'
+}
+
+{ #category : 'running' }
+FLFuelOutTest >> tearDown [
+
+	fileName ifNotNil: [ : f | f asFileReference ensureDelete ].
+	super tearDown.
+]
+
+{ #category : 'tests' }
+FLFuelOutTest >> testFuelOutWriteArrayFile [
+
+	| targetObject |
+
+	FileLocator imageDirectory isWritable
+		ifFalse: [ ^ self skip ].
+	targetObject := { 1 . 2 .  3 } fuelOut.
+	fileName := targetObject printString , '.fuel'.
+	self assert: fileName asFileReference exists 
+]
+
+{ #category : 'tests' }
+FLFuelOutTest >> testFuelOutWriteFile [
+
+	| targetObject |
+	
+	FileLocator imageDirectory isWritable
+		ifFalse: [ ^ self skip ].
+	targetObject := Object new fuelOut.
+	fileName := targetObject printString , '.fuel'.
+	self assert: fileName asFileReference exists.
+]
+
+{ #category : 'tests' }
+FLFuelOutTest >> testFuelOutWriteFileVersioned [
+
+	| firstTargetObject firstTargetObjectFile secondTargetObject |
+
+	FileLocator imageDirectory isWritable
+		ifFalse: [ ^ self skip ].	
+
+	(firstTargetObjectFile := 'an Object.fuel' asFileReference) exists
+		ifTrue: [ firstTargetObjectFile ensureDelete ].
+	firstTargetObject := Object new fuelOut.
+	fileName := firstTargetObjectFile nextVersion basename.
+		
+	secondTargetObject := Object new fuelOut.
+	
+	self assert: fileName asFileReference exists.
+
+	firstTargetObjectFile ensureDelete.
+]
+
+{ #category : 'tests' }
+FLFuelOutTest >> testFuelOutWriteFileWithFileSystemDelimiters [
+
+	FileLocator imageDirectory isWritable
+		ifFalse: [ ^ self skip ].
+
+	self 
+		should: [ '/this/is/a/file/path.txt' fuelOut ] 
+		raise: FileDoesNotExistException
+		description: 'Users of #fuelOut should ensure a valid printString implementation to serialize the file name'
+
+]

--- a/src/NewTools-Fuel-Tests/package.st
+++ b/src/NewTools-Fuel-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Fuel-Tests' }

--- a/src/NewTools-Fuel/Object.extension.st
+++ b/src/NewTools-Fuel/Object.extension.st
@@ -1,8 +1,10 @@
 Extension { #name : 'Object' }
 
-{ #category : '*NewTools-Utils-Fuel' }
+{ #category : '*NewTools-Fuel' }
 Object >> fuelOut [
+
 	| target |
-	target := FileLocator imageDirectory / self printString asFileName, 'fuel'.
+
+	target := FileLocator imageDirectory / (self printString , '.fuel').
 	self serializeToFileNamed: target nextVersion fullName
 ]

--- a/src/NewTools-Fuel/package.st
+++ b/src/NewTools-Fuel/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Fuel' }


### PR DESCRIPTION
Port this fix to Pharo 13 (re-work from #694).
Update baseline: Two new packages will contain miscellaneous utilities. 
Move #fuelOut outside the NewTools-Utils (package NewTools-Utils belongs to the Debugger group). 
