### PR TITLE
Fix issue when opening custom scope on calypso

### DIFF
--- a/src/NewTools-Scopes-Editor/ScopesPresenter.class.st
+++ b/src/NewTools-Scopes-Editor/ScopesPresenter.class.st
@@ -300,7 +300,7 @@ ScopesPresenter >> openOnCalypso: aClassOrPackage [
 
 	| scope |
 	
-	scope := ClyScopedSystemEnvironment currentImage
+	scope := ClyScopedSystemEnvironment currentImage copy
 		         scope: aClassOrPackage;
 		         yourself.
 

--- a/src/NewTools-Scopes/RBBrowserEnvironmentWrapper.extension.st
+++ b/src/NewTools-Scopes/RBBrowserEnvironmentWrapper.extension.st
@@ -13,6 +13,7 @@ RBBrowserEnvironmentWrapper >> isNotEmpty [
 
 { #category : '*NewTools-Scopes' }
 RBBrowserEnvironmentWrapper >> packagesDo: aBlock [
+
 	self packages do: [ :each | aBlock value: each ]
 ]
 


### PR DESCRIPTION
Currently user created Scopes (i.e. custom scopes) cannot be browsed in Calypso.
This PR fixes issues related to this functionality.

This is necessary for the proper functioning of [PR#16771 in Pharo repo](https://github.com/pharo-project/pharo/pull/16771)