### PR TITLE
[P12][Backport] fix `#needRequestorScope` of StDebuggerContextInteractionModel so that its bindings can be used when evaluating code in the debugger

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -100,6 +100,12 @@ StDebuggerContextInteractionModel >> isScripting [
 	^context belongsToDoIt
 ]
 
+{ #category : 'testing' }
+StDebuggerContextInteractionModel >> needRequestorScope [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StDebuggerContextInteractionModel >> object [
 


### PR DESCRIPTION
Backport of #762 to Pharo 12