### PR TITLE
File Browser: Add "disable preview"

### DIFF
--- a/src/NewTools-FileBrowser/StFileBrowserSettings.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserSettings.class.st
@@ -12,6 +12,7 @@ Class {
 		'OpenOnLastDirectory',
 		'ShowAlwaysDefaultBookmarks',
 		'ShowHiddenFiles',
+		'ShowPreview',
 		'WindowsTerminalProgram'
 	],
 	#category : 'NewTools-FileBrowser-UI',
@@ -175,6 +176,33 @@ StFileBrowserSettings class >> showHiddenFilesOn: aBuilder [
 		label: 'Show hidden files and folders';
 		description: 'If enabled, shows the hidden files and folders in the file browser.';
 		target: self
+]
+
+{ #category : 'accessing' }
+StFileBrowserSettings class >> showPreview [
+
+	^ ShowPreview
+		ifNil: [ ShowPreview := true ]
+]
+
+{ #category : 'accessing' }
+StFileBrowserSettings class >> showPreview: aBoolean [
+	"Set if File Browsers should display a preview presenter"
+
+	 ShowPreview := aBoolean 
+]
+
+{ #category : 'settings' }
+StFileBrowserSettings class >> showPreviewOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder setting: #showPreview)
+		parent: #fileBrowser;
+		default: true;
+		label: 'Enable preview';
+		description: 'File Browser will show a preview file presenter by default';
+		target: self
+
 ]
 
 { #category : 'settings' }

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -53,7 +53,8 @@ Class {
 		'fileReferenceTable',
 		'configButton',
 		'pathBreadcrumbPresenter',
-		'newFolderButton'
+		'newFolderButton',
+		'showPreview'
 	],
 	#category : 'NewTools-FileBrowser-UI',
 	#package : 'NewTools-FileBrowser',
@@ -160,19 +161,34 @@ StFileNavigationSystemPresenter >> defaultFolder: aFileReference [
 { #category : 'layout' }
 StFileNavigationSystemPresenter >> defaultLayout [
 
+	| filesLayout |
+	filesLayout := self showPreview
+		               ifTrue: [
+			               SpPanedLayout newTopToBottom
+				               add: self topPaneLayout;
+				               add: notebookPreviewer;
+				               yourself ]
+		               ifFalse: [
+			               SpBoxLayout newTopToBottom
+				               add: self topPaneLayout;
+				               yourself ].
 	^ SpBoxLayout newTopToBottom
-		add: self navigationLayout expand: false;
-		add: (SpPanedLayout newTopToBottom
-				add: self topPaneLayout;
-				add: notebookPreviewer;
-				yourself);
-		yourself
+		  add: self navigationLayout expand: false;
+		  add: filesLayout;
+		  yourself
 ]
 
 { #category : 'defaults' }
 StFileNavigationSystemPresenter >> defaultPreviewer [
 
 	^ StFileBrowserAdaptiveContentPreviewer new
+]
+
+{ #category : 'layout' }
+StFileNavigationSystemPresenter >> defaultShowPreview [
+	"The default value is managed by the global file browser settings"
+
+	^ StFileBrowserSettings showPreview
 ]
 
 { #category : 'layout' }
@@ -430,6 +446,21 @@ StFileNavigationSystemPresenter >> shouldReparent [
 	"Since a removal was requested from the navigation table, is not necessary to move to the parent directory"
 
 	^ false
+]
+
+{ #category : 'layout' }
+StFileNavigationSystemPresenter >> showPreview [
+	"Answer <true> if receiver should display a preview presenter"
+	
+	^ showPreview
+		ifNil: [ showPreview := self defaultShowPreview ]
+]
+
+{ #category : 'layout' }
+StFileNavigationSystemPresenter >> showPreview: aBoolean [
+	"Set the enabled preview to aBoolean"
+	
+	showPreview := aBoolean
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -1,6 +1,19 @@
 "
 General file system presenter, which replaces the older FileList tool.
 
+# Examples
+
+The default File Browser (without specifying any options), will open a presenter with Tree Navigation, Bookmarks, Breadcrumb, Navigation Buttons, File List, Filters and Preview:
+```smalltalk
+StFileSystemPresenter new open.
+```
+
+Open a File Browser without the preview presenter:
+```smalltalk
+StFileSystemPresenter new
+	disablePreview;
+	open.
+```
 "
 Class {
 	#name : 'StFileSystemPresenter',
@@ -105,6 +118,12 @@ StFileSystemPresenter >> defaultLayout [
 				yourself);			
 			add: fileNavigationSystem;
 			yourself
+]
+
+{ #category : 'accessing' }
+StFileSystemPresenter >> disablePreview [
+
+	self fileNavigationSystem showPreview: false
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
The default File Browser (without specifying any options) will open a presenter with Tree Navigation, Bookmarks, Breadcrumb, Navigation Buttons, File List, Filters, and Preview:

```smalltalk
StFileSystemPresenter new open.
```

This PR includes a feature to open a File Browser without the preview presenter:

```smalltalk
StFileSystemPresenter new
	disablePreview;
	open.
```

It can also be disabled globally (for all file browsers) through the UI using the File Browser settings button and unchecking "Enable preview."

