### PR TITLE
File Browser: Enable multiple file selection for opening files or directories

### DIFF
--- a/src/NewTools-FileBrowser-Tests/StBreadcrumbPresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StBreadcrumbPresenterTest.class.st
@@ -11,14 +11,16 @@ Class {
 
 { #category : 'running' }
 StBreadcrumbPresenterTest >> setUp [
+
 	super setUp.
-	windowPathUI := StPathBreadcrumbPresenter 
-		owner: fileSystemPresenter 
-		on: fileSystemModel
+	windowPathUI := StPathBreadcrumbPresenter
+		                owner: fileSystemPresenter
+		                on: fileSystemModel
 ]
 
 { #category : 'running' }
 StBreadcrumbPresenterTest >> tearDown [
+
 	windowPathUI withWindowDo: [ :window | window close ].
 	super tearDown
 ]

--- a/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
@@ -56,6 +56,39 @@ StOpenFilePresenterTest >> testSelectFile [
 ]
 
 { #category : 'tests' }
+StOpenFilePresenterTest >> testSelectFileWithMultipleSelection [
+
+	| selectedFile |
+	dialog beMultipleSelection.
+	window := dialog openDialog.
+	self assert: dialog currentDirectory equals: root.
+	dialog selectFile: root / 'sth.ext'.
+
+	self assert: dialog selectedEntry equals: root / 'sth.ext'.
+
+	selectedFile := dialog confirm.
+
+	self assert: selectedFile equals: root / 'sth.ext'
+]
+
+{ #category : 'tests' }
+StOpenFilePresenterTest >> testSelectFileWithMultipleSelectionAccessingEntries [
+
+	| selectedFile |
+	dialog beMultipleSelection.
+	window := dialog openDialog.
+	self assert: dialog currentDirectory equals: root.
+	dialog selectFile: root / 'sth.ext'.
+	
+	"Multiple selection mode in tables only set the 'first' item and ignores the remaining items"
+	self assertCollection: dialog selectedEntries hasSameElements: { root / 'sth.ext' }.
+
+	selectedFile := dialog confirm.
+
+	self assert: selectedFile equals: root / 'sth.ext'
+]
+
+{ #category : 'tests' }
 StOpenFilePresenterTest >> testSelectedEntriesMultipleSelection [
 
 	window := dialog openDialog.

--- a/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StOpenFilePresenterTest.class.st
@@ -56,6 +56,26 @@ StOpenFilePresenterTest >> testSelectFile [
 ]
 
 { #category : 'tests' }
+StOpenFilePresenterTest >> testSelectedEntriesMultipleSelection [
+
+	window := dialog openDialog.
+	dialog selectFiles: { root / 'sth.ext' . root / 'patate.png' }.
+	self 
+		assertCollection: dialog selectedEntries 
+		hasSameElements: { root / 'sth.ext' . root / 'patate.png' }.
+
+]
+
+{ #category : 'tests' }
+StOpenFilePresenterTest >> testSelectedEntriesSingleSelection [
+
+	window := dialog openDialog.
+	dialog selectFile: root / 'sth.ext'.
+	self assertCollection: dialog selectedEntries hasSameElements: { root / 'sth.ext' }.
+
+]
+
+{ #category : 'tests' }
 StOpenFilePresenterTest >> testSetTitle [
 
 	dialog title: 'test set title'.

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -295,8 +295,9 @@ StFileDialogPresenter >> isolate [
 { #category : 'accessing - ui' }
 StFileDialogPresenter >> nameText [
 	"Answer a <String> with the text in the name presenter used to display the currently selected file/directory or a manually entered name"
-	
-	^ fileNavigationSystem nameText text.
+
+	^ fileNavigationSystem nameText text
+
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -316,12 +316,10 @@ StFileDialogPresenter >> open [
 	^ self openDialog
 ]
 
-{ #category : 'opening' }
+{ #category : 'showing' }
 StFileDialogPresenter >> openModal [
 
 	super openModal cancelled ifTrue: [ ^ nil ].
-	self isMultipleSelection 
-		ifFalse: [ ^ self selectedEntry ].
 	^ self selectedEntries
 ]
 

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -194,6 +194,7 @@ StFileNavigationSystemPresenter >> fileNameLayout [
 
 { #category : 'accessing' }
 StFileNavigationSystemPresenter >> fileReferenceTable [
+
 	^ fileReferenceTable
 ]
 
@@ -429,6 +430,13 @@ StFileNavigationSystemPresenter >> previousButton [
 ]
 
 { #category : 'menu - accessing' }
+StFileNavigationSystemPresenter >> selectEntries: aCollection [
+	"Set a <Collection> of <FileReference> representing user's selections"
+	
+	self fileReferenceTable selectItems: aCollection
+]
+
+{ #category : 'menu - accessing' }
 StFileNavigationSystemPresenter >> selectedEntries [
 	"Answer a <Collection> of <FileReference> representing user's selections"
 	
@@ -465,6 +473,7 @@ StFileNavigationSystemPresenter >> updateFileReferenceTable [
 	"Update the receiver's contents according to the current directory and apply configured filters"
 
 	| items |
+	
 	items := (filtersDropList selectedItem ifNil: [ filter ]) applyOn: self currentDirectoryChildren.
 	StFileBrowserSettings showHiddenFiles ifFalse: [ items := items reject: [ :file | file isHidden ] ].
 	fileReferenceTable items: items

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -116,6 +116,7 @@ StFileSystemPresenter >> expandPath: aFileReference [
 
 { #category : 'accessing' }
 StFileSystemPresenter >> fileNavigationSystem [
+
 	^ fileNavigationSystem
 ]
 

--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
@@ -27,3 +27,25 @@ StOpenFileOrDirectoryPresenter >> confirmLabel [
 StOpenFileOrDirectoryPresenter >> initialTitle [
 	^ self subclassResponsibility
 ]
+
+{ #category : 'utilities' }
+StOpenFileOrDirectoryPresenter >> selectFiles: aCollectionOfFiles [
+	"Be ware that updating the name text from the file navigation system, would unselect all files"
+
+	self beMultipleSelection.
+	self fileNavigationSystem selectedEntries = aCollectionOfFiles
+		ifFalse: [ self fileNavigationSystem selectEntries: aCollectionOfFiles ]
+]
+
+{ #category : 'menu - accessing' }
+StOpenFileOrDirectoryPresenter >> selectedEntries [
+	"Answer a <Collection> of user's selected <FileReference>s "
+
+	| entries |
+	((entries := self fileNavigationSystem selectedEntries) 
+		anySatisfy: [ : entry | (entry exists not and: [ entry isDirectory ]) ])
+			ifTrue: [ 
+				self inform: 'Only files could be selected (no directories)'.
+				^ nil ].
+	^ entries
+]

--- a/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
@@ -120,16 +120,3 @@ StOpenFilePresenter >> isMultipleSelection [
 	
 	^ self fileNavigationSystem isMultipleSelection 
 ]
-
-{ #category : 'menu - accessing' }
-StOpenFilePresenter >> selectedEntries [
-	"Answer a <Collection> of user's selected <FileReference>s "
-
-	| entries |
-	((entries := self fileNavigationSystem selectedEntries) 
-		anySatisfy: [ : entry | (entry exists not and: [ entry isDirectory ]) ])
-			ifTrue: [ 
-				self inform: 'Only files could be selected (no directories)'.
-				^ nil ].
-	^ entries
-]


### PR DESCRIPTION
This PR implements the following changes:

- Add `selectFiles:` and `selectedEntries` to the new File Browser.
- `openModal` now answers a Collection with the user's selections.
- Add helper method `selectEntries:` to file navigation system presenter.
- Add tests