### PR TITLE
Update transmissionBlock: -> transmits:

### DIFF
--- a/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTransmissionNode.class.st
@@ -17,7 +17,7 @@ StInspectorTransmissionNode class >> hostObject: anObject transmissionBlock: aFu
 
 	^ self new
 		  hostObject: anObject;
-		  transmissionBlock: aFullBlockClosure;
+		  transmits: aFullBlockClosure;
 		  yourself
 ]
 


### PR DESCRIPTION
Small PR to update the deprecated use of `transmissionBlock:` changed to `transmits:`

This change is requested because `testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented` is failing in Pharo13 CI (https://github.com/pharo-project/pharo/issues/16825)