### PR TITLE
Add critics on class option

### DIFF
--- a/src/NewTools-CodeCritiques/StClassCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StClassCritiqueBrowserPresenter.class.st
@@ -1,0 +1,71 @@
+"
+Implements a presenter that allows get a list of critiques that broken the selected rules in the selected classes. 
+
+It interacts with StCritiquePackageSelectorPresenter to get the list of selected packages.
+I interact with StCritiqueRuleSelectorPresenter to get the list of selected rules.
+I interact with StCritiquesCache to get the critiques saved as 'To-do' and marked as 'false positive'.
+
+## Examples
+
+`StClassCritiqueBrowserPresenter open`
+
+
+"
+Class {
+	#name : 'StClassCritiqueBrowserPresenter',
+	#superclass : 'StCritiqueBrowserPresenter',
+	#category : 'NewTools-CodeCritiques-Base',
+	#package : 'NewTools-CodeCritiques',
+	#tag : 'Base'
+}
+
+{ #category : 'menu' }
+StClassCritiqueBrowserPresenter class >> openOnCurrentWorkingConfiguration [
+
+	<script>
+	CBCritiqueWorkingConfiguration exists
+		ifTrue: [ StResetWindowPresenter new open ]
+		ifFalse: [ StClassCritiqueRuleSelectorPresenter open ]
+]
+
+{ #category : 'private' }
+StClassCritiqueBrowserPresenter >> applyRules [
+
+	| process |
+
+	self updateTree.
+	checker environment: rbEnvironment.
+	process := [ self processRules ] newProcess.
+	process name: 'SmallLint'.
+	process resume
+]
+
+{ #category : 'private' }
+StClassCritiqueBrowserPresenter >> processRules [
+
+	| packageCount nbPackage rules |
+	
+	nbPackage := rbEnvironment packages size.
+	packageCount := 0.
+	rules := self allRules.
+	
+	rbEnvironment classes do: [ :cls |
+		| windowTitle |
+		packageCount := packageCount + 1.
+		windowTitle := String streamContents: [ :s |
+			               s << 'run rules on ' << cls name << ' ('
+			               << packageCount asString << '/'
+			               << nbPackage asString << ')' ].
+		self setTitle: windowTitle.
+		checker
+			classRules: rules;
+			checkClass: cls ].
+	checker rule: rules.
+	self setTitle: self defaultTitle.
+	cache packages: rbEnvironment.
+	cache initCache.
+	self rules: (self allRules select: [ :r | self hasBrokenRules: r ]).
+	self rulesModel refresh.
+	self rebuildLayout.
+	self updateTree
+]

--- a/src/NewTools-CodeCritiques/StCritiqueClassRuleSelectorPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueClassRuleSelectorPresenter.class.st
@@ -1,0 +1,30 @@
+"
+## Example
+
+```
+StCritiqueClassRuleSelectorPresenter 
+	openWithEnvironment: (RBClassEnvironment new classes: { ReClassForGeneratingEqualAndHashExistingImplementors }) 
+	removeTestCase: false. 
+```
+
+"
+Class {
+	#name : 'StCritiqueClassRuleSelectorPresenter',
+	#superclass : 'StCritiqueRuleSelectorPresenter',
+	#category : 'NewTools-CodeCritiques-Applier',
+	#package : 'NewTools-CodeCritiques',
+	#tag : 'Applier'
+}
+
+{ #category : 'adding' }
+StCritiqueClassRuleSelectorPresenter >> nextAction [
+
+	self delete.
+
+	CBCritiqueWorkingConfiguration current
+		rule: selectedRules;
+		environment: environment;
+		removeTestCase: removeTestCase.
+	StClassCritiqueBrowserPresenter openOnWorkingConfiguration:
+		CBCritiqueWorkingConfiguration current
+]

--- a/src/NewTools-CodeCritiques/SycCmClassCritiqueCommand.class.st
+++ b/src/NewTools-CodeCritiques/SycCmClassCritiqueCommand.class.st
@@ -1,0 +1,41 @@
+"
+I am a command to make a class abstract by adding a method that returns whether the class is abstract
+"
+Class {
+	#name : 'SycCmClassCritiqueCommand',
+	#superclass : 'SycClassCmCommand',
+	#category : 'NewTools-CodeCritiques-Commands',
+	#package : 'NewTools-CodeCritiques',
+	#tag : 'Commands'
+}
+
+{ #category : 'testing' }
+SycCmClassCritiqueCommand >> canBeExecuted [ 
+
+	^ context lastSelectedClass realClass notNil
+]
+
+{ #category : 'executing' }
+SycCmClassCritiqueCommand >> execute [
+
+	StCritiqueClassRuleSelectorPresenter 
+		openWithEnvironment: (RBClassEnvironment new classes: { context lastSelectedClass realClass }) 
+		removeTestCase: false. 
+
+]
+
+{ #category : 'accessing' }
+SycCmClassCritiqueCommand >> icon [
+
+	^ self iconNamed: #smallQA
+]
+
+{ #category : 'accessing' }
+SycCmClassCritiqueCommand >> name [
+	^ 'Class Critique Browser'
+]
+
+{ #category : 'accessing' }
+SycCmClassCritiqueCommand >> order [
+	^ 45
+]


### PR DESCRIPTION
Currently, the Calypso browser in Pharo allows users to run critics on a selected class. However, it lacks the functionality to run critics on a specific chosen class (or multiple selected classes). This feature would enhance the browser's capabilities and provide more flexibility for developers when performing code analysis.

The issue is also described in https://github.com/pharo-project/pharo/issues/16863

This PR adds a menu item option in the Refactoring submenu of selected class(es) in Calypso browser.
