### PR TITLE
add error handler for latin1 encoding failure

### DIFF
--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -8,7 +8,7 @@ String >> inspectionEncoding: specBuilder [
 	shorterString := self truncateWithElipsisTo: 1000.
 	^ (StSimpleInspectorBuilder on: specBuilder)
 			key: #UTF8 value: shorterString utf8Encoded printString;
-			key: #Latin1 value: (shorterString encodeWith: #Latin1) printString;
+			key: #Latin1 value: ([shorterString encodeWith: #Latin1] on: Error do: [:ex | nil]) printString;
 			table
 ]
 


### PR DESCRIPTION
When inspecting a unicode string that can't be encoded in Latin-1, the encoding tab of the inspector fails because the encoder emits error. This PR adds an error handler so that encoding error will result in nil.