### PR TITLE
StClassCritiqueBrowserPresenter: Remove method with Undeclared

### DIFF
--- a/src/NewTools-CodeCritiques/StClassCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StClassCritiqueBrowserPresenter.class.st
@@ -19,15 +19,6 @@ Class {
 	#tag : 'Base'
 }
 
-{ #category : 'menu' }
-StClassCritiqueBrowserPresenter class >> openOnCurrentWorkingConfiguration [
-
-	<script>
-	CBCritiqueWorkingConfiguration exists
-		ifTrue: [ StResetWindowPresenter new open ]
-		ifFalse: [ StClassCritiqueRuleSelectorPresenter open ]
-]
-
 { #category : 'private' }
 StClassCritiqueBrowserPresenter >> applyRules [
 


### PR DESCRIPTION
this removes the method referencing a non-existing class in StClassCritiqueBrowserPresenter>>#openOnCurrentWorkingConfiguration