### PR TITLE
Revert "latest changes"

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -814,7 +814,6 @@ StDebugger >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter
 		title: self debuggerActionModel statusStringForContext;
-		windowIcon: (self iconNamed: #smallDebug);
 		initialExtent: self initialExtent;
 		whenClosedDo: [ self clear ].
 

--- a/src/NewTools-Inspector/StInspectionContext.class.st
+++ b/src/NewTools-Inspector/StInspectionContext.class.st
@@ -191,8 +191,6 @@ StInspectionContext >> newInspectionView [
 StInspectionContext >> newPresenterBuilder [
 
 	^ SpPresenterBuilder new
-		application: StPharoApplication current;
-		yourself
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StEntry.class.st
+++ b/src/NewTools-Spotter-Processors/StEntry.class.st
@@ -113,7 +113,7 @@ StEntry >> printOn: aStream [
 { #category : 'accessing' }
 StEntry >> spotterPreview [
 
-	^ (content spotterPreview: (SpPresenterBuilder newApplication: StPharoApplication current))
+	^ (content spotterPreview: SpPresenterBuilder new)
 		addStyle: 'stSpotterPreview';
 		yourself
 ]

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -203,7 +203,7 @@ StSpotter class >> registerToolsOn: registry [
 StSpotter class >> reset [
 	
 	spotter ifNotNil: [ 
-		spotter withWindowDo: [ :window | window close ].
+		spotter window close.
 		spotter := nil ]
 ]
 


### PR DESCRIPTION
Reverts pharo-spec/NewTools#791

This breaks the spotter and inspector because the presenter builder cannot deal with the application for now

@estebanlm Tagging you so that you know part of what you did was revert