### PR TITLE
Create NewTools-Calypso

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -29,6 +29,8 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-MethodBrowsers' with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];
 			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
 			package: 'NewTools-KeymapBrowser';
+			"Calypso - This will contains part of Calypso that we are migrating"
+			package: 'NewTools-Calypso'  with: [  spec requires: #('NewTools-Core') ];
 			"inspector"
 			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Inspector-Extensions' ) ];
 			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #( 'NewTools-Core' ) ];
@@ -109,6 +111,7 @@ BaselineOfNewTools >> baseline: spec [
 
 		spec
 			group: 'Core' with: #( 'NewTools-Core' 'NewTools-Core-Tests' 'NewTools-Morphic' );
+			group: 'Calypso' with: #('NewTools-Calypso');
 			group: 'Playground' with: #( 'Core' 'NewTools-Playground' 'NewTools-Playground-Tests' );
 			group: 'Inspector' with: #( 'Core' 'NewTools-Inspector' 'NewTools-Inspector-Tests' );
 			group: 'Debugger' with: #( 
@@ -178,6 +181,7 @@ BaselineOfNewTools >> baseline: spec [
 						'NewTools-SettingsBrowser-Tests');
 
 			group: 'default' with: #( 
+						Calypso
 						'Playground' 
 						'Inspector' 
 						'CritiqueBrowser' 

--- a/src/NewTools-Calypso/ManifestNewToolsCalypso.class.st
+++ b/src/NewTools-Calypso/ManifestNewToolsCalypso.class.st
@@ -1,0 +1,10 @@
+"
+I am a package containing parts of Calypso migration to Spec
+"
+Class {
+	#name : 'ManifestNewToolsCalypso',
+	#superclass : 'PackageManifest',
+	#category : 'NewTools-Calypso-Manifest',
+	#package : 'NewTools-Calypso',
+	#tag : 'Manifest'
+}

--- a/src/NewTools-Calypso/package.st
+++ b/src/NewTools-Calypso/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Calypso' }


### PR DESCRIPTION
This package is empty for now and here is the reason:

I'm introducing this package because I migrated a part of Calypso in NewTools-Core. But this introduces a dependency on some packages we do not want in the core of Pharo. So, to fix this dependency here is my proposal:
- Introduce an empty package NewTools-Calypso with a group 'Calypso'
- Load this new group in Pharo before Calypso but after NewTools-Core
- Move the presenter used by Calypso to this new package and cut the bad dependency