### PR TITLE
Fix dependency test

### DIFF
--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -65,10 +65,10 @@ StProtocolNameChooserPresenter class >> requestProtocolNameConfiguring: aBlock [
 
 	protocolName := presenter protocolName.
 
-	protocolName isEmptyOrNil ifTrue: [ CmdCommandAborted signal ].
+	protocolName isEmptyOrNil ifTrue: [ CmCommandAborted signal ].
 	(protocolName beginsWith: '*') ifTrue: [
 		self inform: 'Star is forbidden for protocol name since this is used for method extensions.'.
-		^ CmdCommandAborted signal ].
+		^ CmCommandAborted signal ].
 	^ protocolName
 ]
 


### PR DESCRIPTION
A dependency test of Pharo is failing because of a Commander 1 dependency.

I added the possibility to handle Commander2 errors in Calypso and here I am migrating the errors from Commander1 to Commander2 to fix the dependency failure