### PR TITLE
Use equality to compare file references in file navigation system

### DIFF
--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -101,7 +101,9 @@ StFileNavigationSystemPresenter class >> example [
 { #category : 'api' }
 StFileNavigationSystemPresenter >> beMultipleSelection [
 	
-	self fileReferenceTable beMultipleSelection 
+	self fileReferenceTable 
+		beMultipleSelection;
+		comparisonStrategy: [ :a :b | a = b ]
 ]
 
 { #category : 'api - customization' }


### PR DESCRIPTION
_Please note that this PR requires integration of https://github.com/pharo-spec/Spec/pull/1573 in Spec_

Update the file navigation system presenter (with multiple selection mode) so it can use a custom comparison for file references (using equality instead of identity)