### PR TITLE
Handles permission problems on FileBrowser

### DIFF
--- a/src/NewTools-FileBrowser/StRootDriveWrapper.class.st
+++ b/src/NewTools-FileBrowser/StRootDriveWrapper.class.st
@@ -21,7 +21,9 @@ StRootDriveWrapper >> directories [
 
 	^ [ (fileReference basename , '\') asFileReference directories ]
 		  on: FileSystemError
-		  do: [ #(  ) ]
+		  do: [
+			  self inform: 'Missing permissions on ' , fileReference basename.
+			  #(  ) ]
 ]
 
 { #category : 'testing' }

--- a/src/NewTools-FileBrowser/StRootDriveWrapper.class.st
+++ b/src/NewTools-FileBrowser/StRootDriveWrapper.class.st
@@ -15,8 +15,13 @@ StRootDriveWrapper class >> icon [
 ]
 
 { #category : 'private - accessing' }
-StRootDriveWrapper >> directories [ 
-	^(fileReference basename, '\') asFileReference directories
+StRootDriveWrapper >> directories [
+	"We catch errors because we might not have the rights on the drives and in that case we will get an error.
+	This mecanism should probably be generalized."
+
+	^ [ (fileReference basename , '\') asFileReference directories ]
+		  on: FileSystemError
+		  do: [ #(  ) ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This should fix some Pharo failing test (I hope). When we have a drive without permissions currently we get an error at the opening. I'm adding a handling of this problem