### PR TITLE
Add BrowserSearch dialog for Calypso

### DIFF
--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -1,3 +1,6 @@
+"
+I am a presenter that gets a list of elements and that allows one to select one (or multiple if the #multipleSelection option is enabled).
+"
 Class {
 	#name : 'StBrowserSearchPresenter',
 	#superclass : 'StPresenter',
@@ -20,6 +23,18 @@ StBrowserSearchPresenter class >> exampleConfiguringPresenter [
 		 presenter
 			 items: (self packageOrganizer packages sorted: #name ascending);
 			 searchWithItem: self class package ]) inspect
+]
+
+{ #category : 'examples' }
+StBrowserSearchPresenter class >> exampleConfiguringPresenterForMultipleSelection [
+
+	<example>
+	(self searchConfiguring: [ :presenter :dialog |
+		 dialog title: 'Choose package'.
+		 presenter
+			 items: (self packageOrganizer packages sorted: #name ascending);
+			 searchWithItem: self class package;
+			 multipleSelection ]) inspect
 ]
 
 { #category : 'instance creation' }

--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -33,7 +33,7 @@ StBrowserSearchPresenter class >> open [
 StBrowserSearchPresenter class >> searchConfiguring: aBlock [
 
 	<script>
-	| presenter dialog item |
+	| presenter dialog |
 	dialog := (presenter := self new) asBlockedDialogWindow.
 
 	aBlock cull: presenter cull: dialog.
@@ -44,11 +44,9 @@ StBrowserSearchPresenter class >> searchConfiguring: aBlock [
 
 	dialog cancelled ifTrue: [ ^ CmCommandAborted signal ].
 
-	item := presenter selectedItem.
-
-	item ifNil: [ CmCommandAborted signal ].
-
-	^ item
+	^ presenter itemsList isMultipleSelection
+		  ifTrue: [ presenter selectedItems ifEmpty: [ CmCommandAborted signal ] ]
+		  ifFalse: [ presenter selectedItem ifNil: [ CmCommandAborted signal ] ]
 ]
 
 { #category : 'initialization' }
@@ -116,6 +114,12 @@ StBrowserSearchPresenter >> itemsList [
 ]
 
 { #category : 'api' }
+StBrowserSearchPresenter >> multipleSelection [
+
+	itemsList beMultipleSelection
+]
+
+{ #category : 'api' }
 StBrowserSearchPresenter >> searchValue: aString [
 
 	searchField text: aString
@@ -127,7 +131,7 @@ StBrowserSearchPresenter >> searchWithItem: anItem [
 	self searchValue: (itemsList display value: anItem)
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 StBrowserSearchPresenter >> selectSearchPattern [
 
 	searchField selectAll
@@ -137,6 +141,12 @@ StBrowserSearchPresenter >> selectSearchPattern [
 StBrowserSearchPresenter >> selectedItem [
 
 	^ itemsList selectedItem
+]
+
+{ #category : 'accessing' }
+StBrowserSearchPresenter >> selectedItems [
+
+	^ itemsList selectedItems
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -1,0 +1,155 @@
+Class {
+	#name : 'StBrowserSearchPresenter',
+	#superclass : 'StPresenter',
+	#instVars : [
+		'items',
+		'itemsList',
+		'searchField'
+	],
+	#category : 'NewTools-Core-Calypso',
+	#package : 'NewTools-Core',
+	#tag : 'Calypso'
+}
+
+{ #category : 'examples' }
+StBrowserSearchPresenter class >> exampleConfiguringPresenter [
+
+	<example>
+	(self searchConfiguring: [ :presenter :dialog |
+		 dialog title: 'Choose package'.
+		 presenter
+			 items: (self packageOrganizer packages sorted: #name ascending);
+			 searchWithItem: self class package ]) inspect
+]
+
+{ #category : 'instance creation' }
+StBrowserSearchPresenter class >> open [
+
+	<script>
+	self new open
+]
+
+{ #category : 'instance creation' }
+StBrowserSearchPresenter class >> searchConfiguring: aBlock [
+
+	<script>
+	| presenter dialog item |
+	dialog := (presenter := self new) asBlockedDialogWindow.
+
+	aBlock cull: presenter cull: dialog.
+
+	presenter selectSearchPattern.
+
+	dialog open.
+
+	dialog cancelled ifTrue: [ ^ CmCommandAborted signal ].
+
+	item := presenter selectedItem.
+
+	item ifNil: [ CmCommandAborted signal ].
+
+	^ item
+]
+
+{ #category : 'initialization' }
+StBrowserSearchPresenter >> connectPresenters [
+
+	super connectPresenters.
+
+	searchField whenTextChangedDo: [ self updateList ]
+]
+
+{ #category : 'layout' }
+StBrowserSearchPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  spacing: 5;
+		  add: itemsList;
+		  add: searchField expand: false;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StBrowserSearchPresenter >> initializeDialogWindow: aDialogWindowPresenter [
+
+	super initializeDialogWindow: aDialogWindowPresenter.
+	searchField whenSubmitDo: [ :protocolName | aDialogWindowPresenter triggerOkAction ]
+]
+
+{ #category : 'initialization' }
+StBrowserSearchPresenter >> initializePresenters [
+
+	super initializePresenters.
+
+	itemsList := self newList.
+	searchField := self newTextInput.
+
+	itemsList display: [ :entity | entity name ].
+
+	searchField placeholder: 'Filter...'.
+	searchField eventHandler whenKeyDownDo: [ :anEvent | "If we press arrow up, we should get up in the list. If we press arrow down, we should get down in the list."
+		"31 = Arrow down"
+		anEvent keyValue = 31 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex + 1 min: itemsList items size) ].
+		"30 = Arrow up"
+		anEvent keyValue = 30 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex - 1 max: 1) ]  ]
+]
+
+{ #category : 'initialization' }
+StBrowserSearchPresenter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter title: 'Choose item'.
+
+	aWindowPresenter whenOpenedDo: [ searchField takeKeyboardFocus ]
+]
+
+{ #category : 'api' }
+StBrowserSearchPresenter >> items: aCollection [
+
+	items := aCollection.
+	self updateList
+]
+
+{ #category : 'accessing' }
+StBrowserSearchPresenter >> itemsList [
+	^ itemsList
+]
+
+{ #category : 'api' }
+StBrowserSearchPresenter >> searchValue: aString [
+
+	searchField text: aString
+]
+
+{ #category : 'api' }
+StBrowserSearchPresenter >> searchWithItem: anItem [
+
+	self searchValue: (itemsList display value: anItem)
+]
+
+{ #category : 'as yet unclassified' }
+StBrowserSearchPresenter >> selectSearchPattern [
+
+	searchField selectAll
+]
+
+{ #category : 'accessing' }
+StBrowserSearchPresenter >> selectedItem [
+
+	^ itemsList selectedItem
+]
+
+{ #category : 'updating' }
+StBrowserSearchPresenter >> updateList [
+
+	| newItems |
+	newItems := searchField text ifEmpty: [ items ] ifNotEmpty: [ :text |
+		            | regex |
+		            regex := text asRegexIgnoringCase.
+		            items select: [ :item | regex search: (itemsList display value: item) ] ].
+
+	itemsList items = newItems ifFalse: [
+		itemsList
+			items: newItems;
+			selectFirst ]
+]

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -19,9 +19,9 @@ Class {
 		'protocolNameField',
 		'concernedClass'
 	],
-	#category : 'NewTools-Core-ProtocolChooser',
+	#category : 'NewTools-Core-Calypso',
 	#package : 'NewTools-Core',
-	#tag : 'ProtocolChooser'
+	#tag : 'Calypso'
 }
 
 { #category : 'examples' }


### PR DESCRIPTION
This introduce a new search presenter to use instead of the Morphic search browser of Calypso.

If this gets integrated I have a PR for Pharo to remove all users of the Morphic browser search dialog