### PR TITLE
Add an Apply button for setting options

### DIFF
--- a/src/NewTools-SettingsBrowser/ActionSettingDeclaration.extension.st
+++ b/src/NewTools-SettingsBrowser/ActionSettingDeclaration.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'ActionSettingDeclaration' }
+
+{ #category : '*NewTools-SettingsBrowser' }
+ActionSettingDeclaration >> asSettingPresenter [
+	"Answer an appropriate <SpPresenter> for the receiver"
+
+	^ StSettingButtonPresenterItem on: self
+
+]

--- a/src/NewTools-SettingsBrowser/StSettingButtonPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingButtonPresenterItem.class.st
@@ -1,0 +1,21 @@
+"
+Wrapper for settings which present a button to apply a setting or open another presenter. This replaces the `dialog:` mechanism in the Morphic based Settings Browser.
+"
+Class {
+	#name : 'StSettingButtonPresenterItem',
+	#superclass : 'StSettingPresenterItem',
+	#category : 'NewTools-SettingsBrowser-Widgets',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'Widgets'
+}
+
+{ #category : 'initialization' }
+StSettingButtonPresenterItem >> initializePresenters [ 
+
+	setterPresenter := self newButton 
+		label: self model actionLabel; 
+		action: self model dialog;
+		yourself.
+	super initializePresenters.
+
+]

--- a/src/NewTools-SettingsBrowser/StSettingNode.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingNode.class.st
@@ -26,7 +26,9 @@ StSettingNode class >> with: aPragmaSetting [
 StSettingNode >> allChildren [
 	"Answer a <Collection> of the settings for which the receiver is set as parent"
 
-	^ self model childrenOf: self
+	^ self model 
+		ifNotNil: [ : m | m childrenOf: self ]
+		ifNil: [ OrderedCollection new ]
 ]
 
 { #category : 'converting' }
@@ -200,9 +202,8 @@ StSettingNode >> printOn: aStream [
 		nextPutAll: ' [';
 		nextPutAll: self parentName asString;
 		nextPutAll: '] '.
-	self declaration
-		ifNotNil: [ : i | aStream nextPutAll: i name asString  ].
-	aStream 
+	self declaration ifNotNil: [ : decl | decl printOn: aStream ].
+	aStream
 		nextPutAll: ' (';
 		nextPutAll: self allChildren size asString;
 		nextPutAll: ') '


### PR DESCRIPTION
**IMPORTANT: This PR should be applied after https://github.com/pharo-project/pharo/pull/17026 gets integrated into Pharo.**

It is part of the effort to migrate (Morphic) functionality to the new Settings Browser, see https://github.com/pharo-project/pharo/issues/16801

- Add StSettingButtonPresenterItem
- Fix a StSettingNode bug printOn: while debugging.
