### PR TITLE
Speedup class search and minor fixes

### DIFF
--- a/src/NewTools-Finder-Tests/StFinderClassTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderClassTest.class.st
@@ -78,7 +78,10 @@ StFinderClassTest >> testSearchForRegexpStartWithCaseInsensitive [
 
 	self 
 		assertCollection: (results collect: [ : r | r content name ])
-		hasSameElements: #(#StFinderMockC #StFinderMocka #StFinderMockB).
+		hasSameElements: #(
+			#StFinderMockC #'StFinderMockC class' 
+			#StFinderMocka #'StFinderMocka class'
+			#StFinderMockB #'StFinderMockB class').
 ]
 
 { #category : 'tests' }
@@ -92,7 +95,7 @@ StFinderClassTest >> testSearchForRegexpStartWithCaseSensitive [
 	results := presenter resultTree roots.
 	self 
 		assert: results size
-		equals: 1.
+		equals: 2.
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-Finder/StFinderClassSearch.class.st
+++ b/src/NewTools-Finder/StFinderClassSearch.class.st
@@ -94,6 +94,6 @@ StFinderClassSearch >> searchBySubstring: aString in: anEnvironment [
 StFinderClassSearch >> searchClasses: aSelectBlock in: anEnvironment [
 
 	^ OrderedCollection streamContents: [ :stream |
-		  anEnvironment classesAndTraitsDo: [ :class |
+		  anEnvironment classesDo: [ :class |
 			  (aSelectBlock value: class) ifTrue: [ stream nextPut: class ] ] ]
 ]

--- a/src/NewTools-Finder/StFinderPragmaSearch.class.st
+++ b/src/NewTools-Finder/StFinderPragmaSearch.class.st
@@ -29,12 +29,11 @@ StFinderPragmaSearch >> buildResult: aDictionary [
 		| pragmaResult |
 		"Sadly Pragmas with the same selector are not unique keys in a Dictionary."
 		pragmaResult := results
-			                detect: [ :result |
-			                result content selector = pragma ]
+			                detect: [ :result | result content selector = pragma ]
 			                ifFound: [ :result |
 				                isNewResult := false.
 				                result ]
-			                ifNone: [ StFinderPragmaResult new content: pragma ].
+			                ifNone: [ StFinderPragmaResult new content: pragma; yourself ].
 
 		methods do: [ :method |
 			| classResult |

--- a/src/NewTools-Finder/StFinderPragmaSearch.class.st
+++ b/src/NewTools-Finder/StFinderPragmaSearch.class.st
@@ -120,10 +120,10 @@ StFinderPragmaSearch >> searchPragmas: aSelectBlock in: anEnvironment [
 	| findings |
 	findings := Dictionary new.
 
-	anEnvironment classesAndTraitsDo: [ :class |
+	anEnvironment classesDo: [ :class |
 		class pragmasDo: [ :pragma |
 			(aSelectBlock value: pragma) ifTrue: [
-				(findings at: pragma selector ifAbsentPut: OrderedCollection new)
+				(findings at: pragma ifAbsentPut: OrderedCollection new)
 					add: pragma method ] ].
 		"Include Metaclasses too, since a lot of pragmas are only found there."
 		class class pragmasDo: [ :pragma |

--- a/src/NewTools-Finder/StFinderSelectorSearch.class.st
+++ b/src/NewTools-Finder/StFinderSelectorSearch.class.st
@@ -105,7 +105,7 @@ StFinderSelectorSearch >> searchBySubstring: aString in: anEnvironment [
 StFinderSelectorSearch >> searchMethods: aSelectBlock in: anEnvironment [
 
 	^ OrderedCollection streamContents: [ :stream |
-		  anEnvironment classesAndTraitsDo: [ :class |
+		  anEnvironment classesDo: [ :class |
 			  class methodsDo: [ :method |
 				  (aSelectBlock value: method) ifTrue: [ stream nextPut: method ] ].
 			  class classSide methodsDo: [ :method |

--- a/src/NewTools-Finder/StFinderSettings.class.st
+++ b/src/NewTools-Finder/StFinderSettings.class.st
@@ -44,7 +44,9 @@ StFinderSettings class >> evaluationTimeoutOn: aBuilder [
 		parent: #finder;
 		default: 500;
 		label: 'Evaluation timeout';
-		description: 'Maximum timeout delay for individual calls in Examples search. Expects an integer giving the number of miliseconds';
+		description: 'Maximum timeout delay for individual calls in Examples search. Expects an integer giving the number of miliseconds.
+		
+Setting a value of 0 will set the evaluation to run without timeout';
 		target: self
 ]
 

--- a/src/NewTools-Finder/StMethodFinder.class.st
+++ b/src/NewTools-Finder/StMethodFinder.class.st
@@ -17,10 +17,17 @@ Class {
 StMethodFinder >> findMethodsByExampleInput: inputCollection andExpectedResult: expectedResult timeout: anInteger [
 	"Search for methods which giving each elements of input returns the corresponding elements of outputs."
 	
+	| evaluationSelector |
+
+	evaluationSelector := anInteger = 0
+		ifTrue: [ #resultIn: ]
+		ifFalse: [ #resultIn:timeout: ].
 	^ (self possibleSolutionsForInput: inputCollection) asSet select: [ :send |
 		  send 
-			resultIn: (expectedResult evaluateWithTimeOut: anInteger)
-			timeout: anInteger ]
+				perform: evaluationSelector 
+				withArguments: { 
+					(expectedResult evaluateWithTimeOut: anInteger) .
+					anInteger } ]
 ]
 
 { #category : 'public access' }


### PR DESCRIPTION
This PR includes multiple fixes involving speed-up of search in the New Finder:

- Omit to search in Traits for now, because iterators using `classesAndTraitsDo:` are much slower than `classesDo:`. This should be investigated and addressed in another issue in the Pharo repository.
- Fix a bug in the pragma searching method: Instance side methods with pragmas were added using its selector as key instead of the Pragma itself while collecting results. This happened in the method `StFinderPragmaSearch>>#searchPragmas:in:`
- Some searches resulted in Timeout. So this PR enables search without timeout by setting the timeout value to 0, in the New Finder settings, or programmatically.
