### PR TITLE
Fix Autoscroll file tree presenter when opened

### DIFF
--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -40,6 +40,11 @@ StDirectoryTreePresenter >> defaultOutputPort [
 ]
 
 { #category : 'accessing' }
+StDirectoryTreePresenter >> directoryTreePresenter [
+	^ directoryTreePresenter
+]
+
+{ #category : 'accessing' }
 StDirectoryTreePresenter >> expandPath: aFileLocator [
 	"Expand the receiver's tree to aFileLocator reference"
 
@@ -63,7 +68,11 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 
 	directoryTreePresenter
 		selectPath: aPathForSpec
-		scrollToSelection: false
+		scrollToSelection: true.
+		
+	"The Morphic `configureScrolling` is executed **AFTER** the desired scroll was configured from the `StDirectoryTreePresenter`. Furthermore, the `configureScrolling` uses the `desiredVisibleRow` which is always set to 1. This statement updates the desired visible row to the last visible index of whatever the selection is pointing to."
+
+	directoryTreePresenter verticalAlignment desiredVisibleRow: directoryTreePresenter verticalAlignment lastVisibleRowIndex.
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileDialogPresenter.class.st
@@ -356,7 +356,7 @@ StFileDialogPresenter >> showDirectory: aFileReference [
 	self fileNavigationSystem currentDirectory: aFileReference
 ]
 
-{ #category : 'initialization' }
+{ #category : 'accessing - history' }
 StFileDialogPresenter >> updateWidgetWithFileReference: aFileReference [
 
 	self currentDirectory: aFileReference.

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -531,6 +531,5 @@ StFileNavigationSystemPresenter >> updateWidgetWithFileReference: aFileReference
 	pathBreadcrumbPresenter 
 		currentDirectory: self currentDirectory;
 		updatePathSelection: aFileReference.
-
-
+	
 ]

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -60,9 +60,7 @@ StFileSystemPresenter class >> navigationSystemClass [
 StFileSystemPresenter class >> open [ 
 	<script>
 
-	^ self new 
-		open;
-		centered
+	^ self new open
 ]
 
 { #category : 'accessing - bookmarks' }
@@ -94,6 +92,8 @@ StFileSystemPresenter >> connectPresenters [
 	"Here we check that the window is displayed. 
 	If it's not, that means this is a first opening so it should preserve the path selected by the user (through openOnLastDirectory preference, or defaultRoot: message send) and not to transmit the directory selection"
 
+	super connectPresenters.
+	
 	treeNavigationSystem
 		transmitDo: [ : selection | 
 			(self isDisplayed and: [ selection isNotNil ])
@@ -102,8 +102,11 @@ StFileSystemPresenter >> connectPresenters [
 	bookmarksTreeTable whenSelectionChangedDo: [ :selection | 
 		selection selectedItem ifNotNil: [ :selectedItem | 
 			selectedItem isComposite ifFalse: [ 
-				self fileNavigationSystem openFolder: selectedItem location ] ] ]
+				self fileNavigationSystem openFolder: selectedItem location ] ] ].
 
+	self whenDisplayDo: [ 
+		self centered.
+		treeNavigationSystem expandPath: fileNavigationSystem currentDirectory ].
 ]
 
 { #category : 'layout' }
@@ -180,7 +183,6 @@ StFileSystemPresenter >> initializePresenters [
 	fileNavigationSystem nameText disable.
 
 	treeNavigationSystem := self instantiate: StDirectoryTreePresenter on: self model.
-	treeNavigationSystem expandPath: fileNavigationSystem currentDirectory.	
 
 	self initializeBookmarksTreeTable.
 ]
@@ -257,7 +259,7 @@ StFileSystemPresenter >> updateTreeNavigationWithFileReference: aFileReference [
 	treeNavigationSystem updateWidgetWithFileReference: aFileReference
 ]
 
-{ #category : 'utilities' }
+{ #category : 'accessing - history' }
 StFileSystemPresenter >> updateWidgetWithFileReference: aFileReference [ 
 
 	fileNavigationSystem updateWidgetWithFileReference: aFileReference

--- a/src/NewTools-FileBrowser/StNoteBookPreviewerPresenter.class.st
+++ b/src/NewTools-FileBrowser/StNoteBookPreviewerPresenter.class.st
@@ -12,9 +12,9 @@ Class {
 	#classVars : [
 		'IconCache'
 	],
-	#category : 'NewTools-FileBrowser-UI',
+	#category : 'NewTools-FileBrowser-Previewers',
 	#package : 'NewTools-FileBrowser',
-	#tag : 'UI'
+	#tag : 'Previewers'
 }
 
 { #category : 'layout' }


### PR DESCRIPTION
This PR fixes the problem described in #699: When opened, the File Browser should automatically scroll the tree directory to whatever the user has as a selected file reference.

- Move the expandPath out of `initializePresenters` since it is something that should be done **after** the window is opened.
- Move the center and scroll to selection to the deferred actions configured after displaying.
- Change the scrollToSelection to true so that when the File Browser is opened, the file tree automatically scrolls to the selected path.

