### PR TITLE
Inprove the UX of the Calypso search

### DIFF
--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -100,11 +100,10 @@ StBrowserSearchPresenter >> initializePresenters [
 	itemsList display: [ :entity | entity name ].
 
 	searchField placeholder: 'Filter...'.
-	searchField eventHandler whenKeyDownDo: [ :anEvent | "If we press arrow up, we should get up in the list. If we press arrow down, we should get down in the list."
-		"31 = Arrow down"
-		anEvent keyValue = 31 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex + 1 min: itemsList items size) ].
+	searchField eventHandler whenKeyDownDo: [ :anEvent | "If we press arrow up, we should get up in the list. If we press arrow down, we should get down in the list.""31 = Arrow down"
+		anEvent keyValue = 31 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex + 1 min: itemsList items size) scrollToSelection: true ].
 		"30 = Arrow up"
-		anEvent keyValue = 30 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex - 1 max: 1) ]  ]
+		anEvent keyValue = 30 ifTrue: [ itemsList selectIndex: (itemsList selection selectedIndex - 1 max: 1) scrollToSelection: true ] ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Inspector-Extensions/ASTProgramNode.extension.st
+++ b/src/NewTools-Inspector-Extensions/ASTProgramNode.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'RBProgramNode' }
+Extension { #name : 'ASTProgramNode' }
 
 { #category : '*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionAST [
+ASTProgramNode >> inspectionAST [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 
 	^ SpTreePresenter new 
@@ -20,7 +20,7 @@ RBProgramNode >> inspectionAST [
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionASTDump [
+ASTProgramNode >> inspectionASTDump [
 	<inspectorPresentationOrder: 50 title: 'AST Dump'>
 
 	^ SpCodePresenter new 
@@ -30,7 +30,7 @@ RBProgramNode >> inspectionASTDump [
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }
-RBProgramNode >> inspectionSource [
+ASTProgramNode >> inspectionSource [
 	<inspectorPresentationOrder: 30 title: 'Method Source'>
 
 	^ SpCodePresenter new 


### PR DESCRIPTION
When we navigate up and down in the search dialog, we should scroll to the selected element.

I also commited some deprecation rewrites