### PR TITLE
Add setting browser tabs

### DIFF
--- a/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
@@ -29,6 +29,16 @@ StSettingPresenter >> initializePresenters [
 	title := self newLabel label: settingNode label. 
 ]
 
+{ #category : 'printing' }
+StSettingPresenter >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream 
+		<< ' [';
+		<< self title asString;
+		<< ']'
+]
+
 { #category : 'initialization' }
 StSettingPresenter >> sectionTitle [
 
@@ -50,8 +60,8 @@ StSettingPresenter >> setModelBeforeInitialization: aModel [
 
 { #category : 'accessing' }
 StSettingPresenter >> updateHelp: aString [ 
-	
-	self owner 
+
+	self owner owner owner
 		updateSetting: settingNode declaration label 
 		helpText: aString.
 ]

--- a/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
@@ -29,6 +29,12 @@ StSettingPresenter >> initializePresenters [
 	title := self newLabel label: settingNode label. 
 ]
 
+{ #category : 'accessing' }
+StSettingPresenter >> pagePresenter [
+
+	^ self owner pagePresenter
+]
+
 { #category : 'printing' }
 StSettingPresenter >> printOn: aStream [
 
@@ -60,8 +66,9 @@ StSettingPresenter >> setModelBeforeInitialization: aModel [
 
 { #category : 'accessing' }
 StSettingPresenter >> updateHelp: aString [ 
+	"Private - Callback to display the selected setting node help text in the receiver's setting browser"
 
-	self owner owner owner
+	self pagePresenter
 		updateSetting: settingNode declaration label 
 		helpText: aString.
 ]

--- a/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingPresenter.class.st
@@ -23,6 +23,13 @@ StSettingPresenter class >> with: aPragmaSetting [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'testing' }
+StSettingPresenter >> hasChildren [
+	"Answer <true> if the receiver's node has any children"
+	
+	^ settingNode hasChildren
+]
+
 { #category : 'initialization' }
 StSettingPresenter >> initializePresenters [
 

--- a/src/NewTools-SettingsBrowser/StSettingsCategoryItemPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsCategoryItemPresenter.class.st
@@ -69,6 +69,15 @@ StSettingsCategoryItemPresenter >> node [
 	^ node
 ]
 
+{ #category : 'printing' }
+StSettingsCategoryItemPresenter >> printOn: aStream [
+
+	aStream 
+		<< 'Category {node: ';
+		<< node asString;
+		<< '}'
+]
+
 { #category : 'accessing - model' }
 StSettingsCategoryItemPresenter >> setModelBeforeInitialization: aSettingNode [
 

--- a/src/NewTools-SettingsBrowser/StSettingsPageNotebookPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPageNotebookPresenter.class.st
@@ -32,6 +32,13 @@ StSettingsPageNotebookPresenter >> initializePresenters [
 ]
 
 { #category : 'accessing' }
+StSettingsPageNotebookPresenter >> pagePresenter [
+	"Answer the receiver's <StSettingsPagePresenter>"
+
+	^ self owner owner
+]
+
+{ #category : 'accessing' }
 StSettingsPageNotebookPresenter >> parentNode [
 
 	^ parentNode

--- a/src/NewTools-SettingsBrowser/StSettingsPageNotebookPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPageNotebookPresenter.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : 'StSettingsPageNotebookPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'settingsBox',
+		'parentNode'
+	],
+	#category : 'NewTools-SettingsBrowser-UI',
+	#package : 'NewTools-SettingsBrowser',
+	#tag : 'UI'
+}
+
+{ #category : 'adding' }
+StSettingsPageNotebookPresenter >> add: aStSettingSectionPresenter expand: aBoolean [ 
+
+	settingsBox add: aStSettingSectionPresenter expand: aBoolean 
+]
+
+{ #category : 'layout' }
+StSettingsPageNotebookPresenter >> defaultLayout [
+
+	^ SpScrollableLayout with: settingsBox
+		
+]
+
+{ #category : 'initialization' }
+StSettingsPageNotebookPresenter >> initializePresenters [
+
+	settingsBox := SpBoxLayout newTopToBottom 
+			spacing: 5;
+			yourself
+]
+
+{ #category : 'accessing' }
+StSettingsPageNotebookPresenter >> parentNode [
+
+	^ parentNode
+]
+
+{ #category : 'printing' }
+StSettingsPageNotebookPresenter >> printOn: aStream [
+
+	settingsBox
+		ifNotNil: [ : sb | 
+			super printOn: aStream.
+			aStream 
+				<< ' (children: ';
+				<< sb children size asString;
+				<< ')' ]
+		ifNil: [ aStream << '(Page with no children yet)' ]
+]
+
+{ #category : 'removing' }
+StSettingsPageNotebookPresenter >> removeAll [
+	"Remove all presenters in the layout"
+
+	settingsBox removeAll
+]
+
+{ #category : 'accessing - model' }
+StSettingsPageNotebookPresenter >> setModelBeforeInitialization: aNode [
+
+	parentNode := aNode
+]

--- a/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
@@ -7,9 +7,9 @@ Class {
 	#superclass : 'StSettingsAbstractPresenter',
 	#instVars : [
 		'pageTitle',
-		'settingsBox',
 		'settingDocPresenter',
-		'settingDocLabel'
+		'settingDocLabel',
+		'notebook'
 	],
 	#category : 'NewTools-SettingsBrowser-UI',
 	#package : 'NewTools-SettingsBrowser',
@@ -30,7 +30,7 @@ StSettingsPagePresenter >> defaultLayout [
 		add: pageTitle expand: false;
 		add: (SpPanedLayout newVertical 
 			positionOfSlider: 0.85;
-			add: (SpScrollableLayout with: settingsBox);
+			add: notebook;
 			add: (SpBoxLayout newTopToBottom
 				spacing: 5;
 				add: settingDocLabel expand: false;
@@ -41,14 +41,32 @@ StSettingsPagePresenter >> defaultLayout [
 ]
 
 { #category : 'initialization' }
-StSettingsPagePresenter >> initializePresenters [ 
+StSettingsPagePresenter >> initializePresenters [
 
 	pageTitle := self newLabel.
+	notebook := self newNotebook
+		            whenSelectedPageChangedDo: [ :presenter |
+			            presenter ifNotNil: [
+					            presenter activePresenter removeAll.
+					            self
+						            updatePresenterTree: presenter activePresenter parentNode
+						            level: 2 ] ];
+		            yourself.
 	settingDocLabel := self newLabel
-		addStyle: 'settingDocTitle';
-		yourself.
-	settingDocPresenter := self newText.
-	settingsBox := SpBoxLayout newTopToBottom spacing: 10
+		                   addStyle: 'settingDocTitle';
+		                   yourself.
+	settingDocPresenter := self newText
+]
+
+{ #category : 'accessing' }
+StSettingsPagePresenter >> newNodePresenterFrom: aSettingNode level: anInteger [
+
+	| nodePresenter |
+	nodePresenter := self
+		                 instantiate: aSettingNode presenterClass
+		                 on: aSettingNode.
+	nodePresenter sectionTitleStyle: 'sectionTitleL' , anInteger asString.
+	^ nodePresenter
 ]
 
 { #category : 'accessing - model' }
@@ -58,24 +76,37 @@ StSettingsPagePresenter >> setModel: aNode [
 	pageTitle 
 		label: aNode label;
 		addStyle: 'pageTitle'.
-	
-	settingsBox removeAll.
-	self updatePresenterTree: aNode level: 1.
+	notebook removeAll.
+	self updatePages: aNode.
+
 ]
 
 { #category : 'accessing' }
-StSettingsPagePresenter >> updatePresenterTree: aStSettingNode level: anInteger [ 
+StSettingsPagePresenter >> updatePages: aStSettingNode [
 	"Private - Recursively iterate aStSettingNode children using anInteger as 'level' indicator for title styling purposes"
 
-	aStSettingNode allChildren do: [ : aSettingNode | 
+	aStSettingNode allChildren do: [ :aSettingNode |
 		| nodePresenter |
+		nodePresenter := self
+			                 instantiate: aSettingNode presenterClass
+			                 on: aSettingNode.
+		nodePresenter sectionTitleStyle: 'sectionTitleL1'.
+		notebook addPage: (SpNotebookPage new
+				 icon: (self iconNamed: #smallQuestion);
+				 presenterProvider: [ StSettingsPageNotebookPresenter on: aSettingNode ];
+				 title: aSettingNode label;
+				 yourself) ]
+]
 
-		nodePresenter := self instantiate: aSettingNode presenterClass on: aSettingNode.
-		nodePresenter sectionTitleStyle: 'sectionTitleL' , anInteger asString.	
-		settingsBox 
-			add: nodePresenter
-			expand: false.
-		self updatePresenterTree: aSettingNode level: anInteger + 1 ]
+{ #category : 'accessing' }
+StSettingsPagePresenter >> updatePresenterTree: aStSettingNode level: anInteger [
+	"Private - Recursively iterate aStSettingNode children using anInteger as 'level' indicator for title styling purposes"
+
+	aStSettingNode allChildren do: [ :aSettingNode |
+		| nodePresenter |
+		nodePresenter := self newNodePresenterFrom: aSettingNode level: anInteger.
+		notebook selectedPage activePresenter add: nodePresenter expand: false.
+		self updatePresenterTree: aSettingNode level: anInteger + 1 ].
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
@@ -9,30 +9,66 @@ Class {
 		'pageTitle',
 		'settingDocPresenter',
 		'settingDocLabel',
-		'notebook'
+		'notebook',
+		'settingTree'
 	],
 	#category : 'NewTools-SettingsBrowser-UI',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'UI'
 }
 
-{ #category : 'adding' }
-StSettingsPagePresenter >> addHeaderForSettingsWithoutParent: aSpNotebookPage [
+{ #category : 'private' }
+StSettingsPagePresenter >> activePage [
 
-	| generalSettingNode currentParent generalNodePresenter |
-	aSpNotebookPage activePresenter removeAll.
+	^ notebook selectedPage activePresenter
+]
 
-	currentParent := aSpNotebookPage activePresenter parentNode.
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> addDefaultGeneralTabFrom: aStSettingNode [
+	"Private - Add General Settings default"
+
+	| generalSettingNode |
+	
 	generalSettingNode := StSettingNode with: PragmaSetting new.
-	generalSettingNode item name: 'General'.
-	generalSettingNode parentName: (currentParent ifNotNil: [ currentParent name ]).
+	generalSettingNode item name: self generalTitle.
+	generalSettingNode parentName: aStSettingNode name.
+	notebook addPage: (SpNotebookPage new
+				 icon: (self iconNamed: #smallQuestion);
+				 presenterProvider: [ StSettingsPageNotebookPresenter on: generalSettingNode ];
+				 title: self generalTitle;
+				 yourself).
+]
 
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> addHeaderForSettingsWithoutParent: aSpNotebookPage [
+	"Private - We add a 'General' header (2nd level) for those nodes without parent other than the root"
+
+	| generalSettingNode generalNodePresenter |
+
+	generalSettingNode := self newGeneralSetting: aSpNotebookPage.
 	generalNodePresenter := self
 		                        newSectionNodePresenterFrom: generalSettingNode
 		                        level: 2.
-	notebook selectedPage activePresenter
+	self activePage 
 		add: generalNodePresenter
 		expand: false
+]
+
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> addTabsFrom: aStSettingNode [
+
+	aStSettingNode allChildren do: [ :aSettingNode |
+		| nodePresenter |
+		(nodePresenter := self
+			                  instantiate: aSettingNode presenterClass
+			                  on: aSettingNode) hasChildren 
+			ifTrue: [
+				nodePresenter sectionTitleStyle: 'sectionTitleL1'.
+				notebook addPage: (SpNotebookPage new
+						 icon: (self iconNamed: #smallQuestion);
+						 presenterProvider: [ StSettingsPageNotebookPresenter on: aSettingNode ];
+					 title: aSettingNode label;
+					 yourself) ] ]
 ]
 
 { #category : 'initialization' }
@@ -59,6 +95,12 @@ StSettingsPagePresenter >> defaultLayout [
 		yourself
 ]
 
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> generalTitle [
+
+	^ 'General'
+]
+
 { #category : 'initialization' }
 StSettingsPagePresenter >> initializePresenters [
 
@@ -72,7 +114,19 @@ StSettingsPagePresenter >> initializePresenters [
 	settingDocPresenter := self newText
 ]
 
-{ #category : 'accessing' }
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> newGeneralSetting: aSpNotebookPage [
+
+	| currentParent generalSettingNode |
+	
+	currentParent := aSpNotebookPage activePresenter parentNode.
+	generalSettingNode := StSettingNode with: PragmaSetting new.
+	generalSettingNode item name: self generalTitle.
+	generalSettingNode parentName: (currentParent ifNotNil: [ currentParent name ]).
+	^ generalSettingNode
+]
+
+{ #category : 'callbacks' }
 StSettingsPagePresenter >> newNodePresenterFrom: aSettingNode level: anInteger [
 
 	| nodePresenter |
@@ -83,7 +137,7 @@ StSettingsPagePresenter >> newNodePresenterFrom: aSettingNode level: anInteger [
 	^ nodePresenter
 ]
 
-{ #category : 'accessing' }
+{ #category : 'callbacks' }
 StSettingsPagePresenter >> newSectionNodePresenterFrom: aSettingNode level: anInteger [
 	"Private - This is a temporary method until finding a proper solution for 'hand-wired' sections, since some settings declarations are not grouped"
 
@@ -99,6 +153,7 @@ StSettingsPagePresenter >> newSectionNodePresenterFrom: aSettingNode level: anIn
 StSettingsPagePresenter >> setModel: aNode [ 
 	"Private - Set the receiver's content iterating recursively starting from aNode"
 
+	settingTree := aNode model childrenOf: aNode.
 	pageTitle 
 		label: aNode label;
 		addStyle: 'pageTitle'.
@@ -107,45 +162,51 @@ StSettingsPagePresenter >> setModel: aNode [
 
 ]
 
-{ #category : 'accessing' }
+{ #category : 'callbacks' }
 StSettingsPagePresenter >> updatePages: aStSettingNode [
 	"Private - Recursively iterate aStSettingNode children using anInteger as 'level' indicator for title styling purposes"
 
-	aStSettingNode allChildren do: [ :aSettingNode |
-		| nodePresenter |
-		nodePresenter := self
-			                 instantiate: aSettingNode presenterClass
-			                 on: aSettingNode.
-		nodePresenter sectionTitleStyle: 'sectionTitleL1'.
-		notebook addPage: (SpNotebookPage new
-				 icon: (self iconNamed: #smallQuestion);
-				 presenterProvider: [ StSettingsPageNotebookPresenter on: aSettingNode ];
-				 title: aSettingNode label;
-				 yourself) ]
+	self addDefaultGeneralTabFrom: aStSettingNode.
+	self addTabsFrom: aStSettingNode.
 ]
 
-{ #category : 'accessing' }
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> updatePresenterGeneralNodes: aCollection [
+
+	| nodePresenter |
+	aCollection do: [ :settingNode |
+		nodePresenter := self newNodePresenterFrom: settingNode level: 2.
+		self activePage add: nodePresenter expand: false ]
+]
+
+{ #category : 'callbacks' }
 StSettingsPagePresenter >> updatePresenterTree: aStSettingNode level: anInteger [
 	"Private - Recursively iterate aStSettingNode children using anInteger as 'level' indicator for title styling purposes"
 
 	aStSettingNode allChildren do: [ :aSettingNode |
 		| nodePresenter |
-		nodePresenter := self newNodePresenterFrom: aSettingNode level: anInteger.
-		notebook selectedPage activePresenter add: nodePresenter expand: false.
-		self updatePresenterTree: aSettingNode level: anInteger + 1 ].
+		nodePresenter := self
+			                 newNodePresenterFrom: aSettingNode
+			                 level: anInteger.
+		self activePage add: nodePresenter expand: false.
+		self updatePresenterTree: aSettingNode level: anInteger + 1 ]
 ]
 
-{ #category : 'initialization' }
-StSettingsPagePresenter >> updateSelectedPage: presenter [
+{ #category : 'callbacks' }
+StSettingsPagePresenter >> updateSelectedPage: aSpNotebookPage [
 	
-	presenter ifNotNil: [ 
-		self addHeaderForSettingsWithoutParent: presenter.
-		self
-			updatePresenterTree: presenter activePresenter parentNode
-			level: 2 ]
+	aSpNotebookPage ifNotNil: [ 
+		| tabNode |
+		aSpNotebookPage activePresenter removeAll.
+		"Do not add a 'General' header if we are already in the General tab" 
+		aSpNotebookPage title = self generalTitle
+			ifFalse: [ self addHeaderForSettingsWithoutParent: aSpNotebookPage ]
+			ifTrue: [ self updatePresenterGeneralNodes: (settingTree reject: [ : node | node hasChildren ]) ].
+		tabNode := aSpNotebookPage activePresenter parentNode.
+		self updatePresenterTree: tabNode level: 2 ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'callbacks' }
 StSettingsPagePresenter >> updateSetting: labelString helpText: settingHelpString [
 
 	settingDocLabel label: labelString.

--- a/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsPagePresenter.class.st
@@ -16,6 +16,25 @@ Class {
 	#tag : 'UI'
 }
 
+{ #category : 'adding' }
+StSettingsPagePresenter >> addHeaderForSettingsWithoutParent: aSpNotebookPage [
+
+	| generalSettingNode currentParent generalNodePresenter |
+	aSpNotebookPage activePresenter removeAll.
+
+	currentParent := aSpNotebookPage activePresenter parentNode.
+	generalSettingNode := StSettingNode with: PragmaSetting new.
+	generalSettingNode item name: 'General'.
+	generalSettingNode parentName: (currentParent ifNotNil: [ currentParent name ]).
+
+	generalNodePresenter := self
+		                        newSectionNodePresenterFrom: generalSettingNode
+		                        level: 2.
+	notebook selectedPage activePresenter
+		add: generalNodePresenter
+		expand: false
+]
+
 { #category : 'initialization' }
 StSettingsPagePresenter >> defaultInputPort [ 
 
@@ -45,12 +64,7 @@ StSettingsPagePresenter >> initializePresenters [
 
 	pageTitle := self newLabel.
 	notebook := self newNotebook
-		            whenSelectedPageChangedDo: [ :presenter |
-			            presenter ifNotNil: [
-					            presenter activePresenter removeAll.
-					            self
-						            updatePresenterTree: presenter activePresenter parentNode
-						            level: 2 ] ];
+		            whenSelectedPageChangedDo: [ :presenter | self updateSelectedPage: presenter ];
 		            yourself.
 	settingDocLabel := self newLabel
 		                   addStyle: 'settingDocTitle';
@@ -64,6 +78,18 @@ StSettingsPagePresenter >> newNodePresenterFrom: aSettingNode level: anInteger [
 	| nodePresenter |
 	nodePresenter := self
 		                 instantiate: aSettingNode presenterClass
+		                 on: aSettingNode.
+	nodePresenter sectionTitleStyle: 'sectionTitleL' , anInteger asString.
+	^ nodePresenter
+]
+
+{ #category : 'accessing' }
+StSettingsPagePresenter >> newSectionNodePresenterFrom: aSettingNode level: anInteger [
+	"Private - This is a temporary method until finding a proper solution for 'hand-wired' sections, since some settings declarations are not grouped"
+
+	| nodePresenter |
+	nodePresenter := self
+		                 instantiate: StSettingSectionPresenter
 		                 on: aSettingNode.
 	nodePresenter sectionTitleStyle: 'sectionTitleL' , anInteger asString.
 	^ nodePresenter
@@ -107,6 +133,16 @@ StSettingsPagePresenter >> updatePresenterTree: aStSettingNode level: anInteger 
 		nodePresenter := self newNodePresenterFrom: aSettingNode level: anInteger.
 		notebook selectedPage activePresenter add: nodePresenter expand: false.
 		self updatePresenterTree: aSettingNode level: anInteger + 1 ].
+]
+
+{ #category : 'initialization' }
+StSettingsPagePresenter >> updateSelectedPage: presenter [
+	
+	presenter ifNotNil: [ 
+		self addHeaderForSettingsWithoutParent: presenter.
+		self
+			updatePresenterTree: presenter activePresenter parentNode
+			level: 2 ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR includes a major upgrade in the new settings browser UI to include tabs for 2nd-level categories.
Each 2nd-level category now includes a "General" settings tab, which holds those settings that do not belong to a sub-category.
Additionally, each sub-category (or tab) has a "General" sub-section to hold its general settings.


https://github.com/user-attachments/assets/46b07cb4-f834-47b8-9d8a-b8a499f73747

