### PR TITLE
Added open method to AndreasProfiler

### DIFF
--- a/src/NewTools-ProfilerUI/AndreasSystemProfiler.extension.st
+++ b/src/NewTools-ProfilerUI/AndreasSystemProfiler.extension.st
@@ -1,6 +1,27 @@
 Extension { #name : 'AndreasSystemProfiler' }
 
 { #category : '*NewTools-ProfilerUI' }
+AndreasSystemProfiler >> open [
+
+	| resultsPresenter profilerModel profilerPresenter |
+	profilerModel := StProfilerModel new
+		profiler: self;
+		yourself.
+	profilerModel setTallyRoot: (self tallyRoot asTallyModel
+			model: profilerModel;
+			yourself).
+	resultsPresenter :=( StProfilerResultsPresenter on: profilerModel)
+		handleProfilingFinished;
+		yourself.
+
+	profilerPresenter := StProfilerPresenter new
+		resultsPresenter: resultsPresenter;
+		disableInputPresenter;
+		yourself.
+	^ profilerPresenter open
+]
+
+{ #category : '*NewTools-ProfilerUI' }
 AndreasSystemProfiler >> runBlock: aBlock [
 	"Compatibility with TimeProfiler"
 

--- a/src/NewTools-ProfilerUI/StProfilerInputPresenter.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerInputPresenter.class.st
@@ -58,6 +58,14 @@ StProfilerInputPresenter >> code: aString [
 	codeInput text: aString
 ]
 
+{ #category : 'accessing' }
+StProfilerInputPresenter >> enabled: aBoolean [
+
+	profilerDropList enabled: aBoolean.
+	profileItButton enabled: aBoolean.
+	codeInput editable: aBoolean
+]
+
 { #category : 'initialization' }
 StProfilerInputPresenter >> initializeActions [
 

--- a/src/NewTools-ProfilerUI/StProfilerModel.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerModel.class.st
@@ -178,6 +178,12 @@ StProfilerModel >> profileCode: someCode notifying: requestor [
 ]
 
 { #category : 'accessing' }
+StProfilerModel >> profiler: aProfiler [
+
+	profiler := aProfiler
+]
+
+{ #category : 'accessing' }
 StProfilerModel >> profilerClass [
 	^ profilerClass ifNil: [ profilerClass := self allProfilerClasses at: 1 ]
 ]

--- a/src/NewTools-ProfilerUI/StProfilerPresenter.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerPresenter.class.st
@@ -14,15 +14,6 @@ Class {
 	#tag : 'Presenters'
 }
 
-{ #category : 'layout' }
-StProfilerPresenter class >> defaultLayout [
-	^ SpPanedLayout newTopToBottom
-		  positionOfSlider: 20 percent;
-		  add: #inputPresenter;
-		  add: #resultsPresenter;
-		  yourself
-]
-
 { #category : 'examples' }
 StProfilerPresenter class >> menuCommandOn: aBuilder [
 	<worldMenu>
@@ -59,18 +50,46 @@ StProfilerPresenter class >> profileCode: aString [
 		  yourself
 ]
 
+{ #category : 'layout' }
+StProfilerPresenter >> defaultLayout [
+
+	^ SpPanedLayout newTopToBottom
+		  positionOfSlider: 20 percent;
+		  add: inputPresenter;
+		  add: resultsPresenter;
+		  yourself
+]
+
+{ #category : 'private - factory' }
+StProfilerPresenter >> disableInputPresenter [
+
+	inputPresenter enabled: false
+]
+
 { #category : 'constants' }
 StProfilerPresenter >> initExtent [
 	^ 800 @ 800
 ]
 
+{ #category : 'private - factory' }
+StProfilerPresenter >> initializeInputPresenter [
+
+	^ inputPresenter ifNil: [
+		  inputPresenter := StProfilerInputPresenter on: self viewModel ]
+]
+
 { #category : 'initialization' }
 StProfilerPresenter >> initializePresenters [
 
-	inputPresenter := self newInputPresenter.
-	resultsPresenter := self newResultsPresenter
-		                    enabled: false;
-		                    yourself
+	self initializeInputPresenter.
+	self initializeResultsPresenter
+]
+
+{ #category : 'private - factory' }
+StProfilerPresenter >> initializeResultsPresenter [
+
+	^ resultsPresenter ifNil: [
+		  resultsPresenter := StProfilerResultsPresenter on: self viewModel ]
 ]
 
 { #category : 'initialization' }
@@ -86,12 +105,6 @@ StProfilerPresenter >> initializeWindow: aWindowPresenter [
 StProfilerPresenter >> newInputPresenter [
 
 	^ StProfilerInputPresenter on: self viewModel
-]
-
-{ #category : 'private - factory' }
-StProfilerPresenter >> newResultsPresenter [
-
-	^ StProfilerResultsPresenter on: self viewModel
 ]
 
 { #category : 'constants' }
@@ -122,6 +135,12 @@ StProfilerPresenter >> profileCode: aString [
 	inputPresenter
 		code: aString;
 		profileIt
+]
+
+{ #category : 'private - factory' }
+StProfilerPresenter >> resultsPresenter: aPresenter [
+
+	resultsPresenter := aPresenter
 ]
 
 { #category : 'subscription' }


### PR DESCRIPTION
Added an open method to allow to open the UI without the need of using the profiler presenter.

For example:

```st
prof := AndreasSystemProfiler spyOn: [ 1000000 timesRepeat: [ OrderedDictionary new ] ].

prof open
```