### PR TITLE
New finder enhacements

### DIFF
--- a/src/NewTools-Finder/StFinderExampleSearch.class.st
+++ b/src/NewTools-Finder/StFinderExampleSearch.class.st
@@ -10,7 +10,7 @@ Class {
 	#tag : 'Search'
 }
 
-{ #category : 'execution' }
+{ #category : 'private' }
 StFinderExampleSearch >> buildResult: aListOfStMethodFinderSend [
 
 	| results |

--- a/src/NewTools-Finder/StFinderModel.class.st
+++ b/src/NewTools-Finder/StFinderModel.class.st
@@ -1,11 +1,7 @@
 "
-I am the model for the `Finder` tool.
+Model for the `Finder` tool, responsible for holding the search environment, executing searches and returning search results.
 
-I am responsible for holding the search environment, executing searches and
-returning search results.
-
-For searching I use the interface defined by ̀FinderSearch̀ and all searches
-should therefor be subclasses of ̀FinderSearch̀.
+For searching, this class use the interface defined by ̀StFinderSearch̀ and all searches should therefor be subclasses of ̀StFinderSearch̀.
 
 "
 Class {
@@ -15,12 +11,13 @@ Class {
 		'searchString',
 		'useRegex',
 		'searchEnvironment',
-		'availableSearches',
 		'currentSearch',
 		'results',
 		'useExact',
 		'useCase',
-		'time'
+		'time',
+		'availableSearchTargets',
+		'useSubstring'
 	],
 	#category : 'NewTools-Finder-Core',
 	#package : 'NewTools-Finder',
@@ -28,8 +25,8 @@ Class {
 }
 
 { #category : 'default values' }
-StFinderModel class >> defaultSearches [
-	"Returns a list of supported searches. Each item in the list is a subclass of `FinderSearch`."
+StFinderModel class >> defaultSearchTargets [
+	"Returns a list of supported searches. Each item in the list is a subclass of `StFinderSearch`."
 
 	"The first element is used as the default search mode."
 
@@ -47,7 +44,7 @@ StFinderModel class >> defaultSearches [
 StFinderModel >> addSearch: aFinderSearch [
 	"Add aFinderSearch to the availableSearches."
 
-	availableSearches add: aFinderSearch.
+	self availableSearchTargets add: aFinderSearch.
 	self searchTypesChanged
 ]
 
@@ -61,10 +58,24 @@ StFinderModel >> availablePackages [
 ]
 
 { #category : 'accessing' }
-StFinderModel >> availableSearches [
+StFinderModel >> availableSearchTargets [
 	"Returns the searches available to the model. The first one is used as the default search mode."
 
-	^ availableSearches
+	^ availableSearchTargets
+]
+
+{ #category : 'accessing' }
+StFinderModel >> availableSearchTargets: aCollection [
+	"Set the receiver's targets to aCollection containing <StFinderSearch> instances"
+
+	availableSearchTargets := aCollection
+]
+
+{ #category : 'accessing' }
+StFinderModel >> availableSearchTargetsFromClasses: aCollection [
+	"Set the receiver's targets to aCollection containing classes"
+
+	^ self availableSearchTargets: (self newSearchTargetsWith: aCollection) 
 ]
 
 { #category : 'accessing' }
@@ -91,18 +102,32 @@ StFinderModel >> initialize [
 	useExact := false.
 	useCase := false.
 
-	availableSearches := self class defaultSearches
-		                     collect: [ :search | search new ]
-		                     as: OrderedCollection.
-	currentSearch := availableSearches first.
+	self initializeSearchTargets.
+	currentSearch := availableSearchTargets first.
 	self selectAllPackages
+]
+
+{ #category : 'initialization' }
+StFinderModel >> initializeSearchTargets [
+	"Private - Set the receiver's default search targets"
+
+	self availableSearchTargets: (self newSearchTargetsWith: self class defaultSearchTargets)
+]
+
+{ #category : 'initialization' }
+StFinderModel >> newSearchTargetsWith: aCollectionOfStFinderSearchClasses [
+	"Answer a <Collection> of <StFinderSearch> subinstances matching aCollectionOfStFinderSearch classes"
+
+	^ aCollectionOfStFinderSearchClasses
+		collect: [ :searchTargetClass | searchTargetClass new ]
+		as: OrderedCollection
 ]
 
 { #category : 'removing' }
 StFinderModel >> removeSearchByName: aString [
 	"Removes a search from availableSearches by its name."
 
-	availableSearches removeAllSuchThat: [ :each | each name = aString ].
+	self availableSearchTargets removeAllSuchThat: [ :each | each name = aString ].
 	self searchTypesChanged
 ]
 
@@ -203,7 +228,7 @@ StFinderModel >> searchTypesChanged [
 	"This method is used internally and called whenever a availableSearches modified."
 
 	self announcer announce:
-		(StFinderSearchTypesChanged newValue: self availableSearches)
+		(StFinderSearchTypesChanged newValue: self availableSearchTargets)
 ]
 
 { #category : 'selection' }
@@ -278,6 +303,18 @@ StFinderModel >> useRegex [
 StFinderModel >> useRegex: aBoolean [
 
 	useRegex := aBoolean
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useSubstring [
+
+	^ useSubstring
+]
+
+{ #category : 'accessing' }
+StFinderModel >> useSubstring: aBoolean [
+
+	useSubstring := aBoolean
 ]
 
 { #category : 'announcing' }

--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -215,11 +215,36 @@ The Method Finder is not trying all methods in the system so if it will find not
 
 ]
 
-{ #category : 'instance creation' }
+{ #category : 'opening' }
 StFinderPresenter class >> open [
 	<script>
 	
 	(self on: StFinderModel new) open
+]
+
+{ #category : 'opening' }
+StFinderPresenter class >> openOnTargets: aCollection [
+	"Open the receiver with only search targets (classes) in aCollection. See `availableSearchTargets:` for details"
+	
+	| finderModel |
+	
+	finderModel := StFinderModel new
+		availableSearchTargetsFromClasses: aCollection;
+		yourself.
+	^ (self on: finderModel) 
+		open;
+		yourself
+]
+
+{ #category : 'searching' }
+StFinderPresenter class >> searchBy: aString [ 
+	self shouldBeImplemented.
+]
+
+{ #category : 'updating - widgets' }
+StFinderPresenter >> cleanResults [
+
+	resultTree roots: Array empty
 ]
 
 { #category : 'initialization' }
@@ -233,6 +258,7 @@ StFinderPresenter >> connectPresenters [
 			open ].
 
 	self connectSearchOptions.
+	searchOptions substringBox click.
 
 	environmentBar
 		whenAllPackagesSelectedDo: [ self searchInAllPackages ];
@@ -273,20 +299,41 @@ StFinderPresenter >> connectSearchBar [
 StFinderPresenter >> connectSearchOptions [
 
 	searchOptions
+		whenSubstringActivatedDo: [ 
+			self model useSubstring: true.
+			searchOptions 
+				disableExact;
+				disableRegex ];
+		whenSubstringDeactivatedDo: [ 
+			self model useSubstring: false.
+			searchOptions
+				enableExact;
+				enableRegex ];
+
 		whenRegexActivatedDo: [ 
 			self model useRegex: true.
-			searchOptions disableExact. ];
+			searchOptions 
+				disableSubstring;
+				disableExact. ];
 		whenRegexDeactivatedDo: [ 
 			self model useRegex: false.
-			searchOptions enableExact ];
+			searchOptions 
+				enableSubstring;
+				enableExact ];
+		
 		whenCaseActivatedDo: [ self model useCase: true ];
 		whenCaseDeactivatedDo: [ self model useCase: false ];
+		
 		whenExactActivatedDo: [
 			self model useExact: true.
-			searchOptions disableRegex ];
+			searchOptions 
+				disableSubstring;
+				disableRegex ];
 		whenExactDeactivatedDo: [ 
 			self model useExact: false.
-			searchOptions enableRegex ].
+			searchOptions 
+				enableSubstring;
+				enableRegex ].
 ]
 
 { #category : 'layout' }
@@ -315,7 +362,7 @@ StFinderPresenter >> defaultLayout [
 { #category : 'initialization' }
 StFinderPresenter >> initialExtentForWindow [
 
-	^ (700 @ 500) scaledByDisplayScaleFactor
+	^ (800 @ 500) scaledByDisplayScaleFactor
 ]
 
 { #category : 'initialization' }
@@ -332,7 +379,7 @@ StFinderPresenter >> initializeFocus [
 StFinderPresenter >> initializePresenters [
 
 	searchBar := self instantiate: StFinderSearchBar.
-	searchBar searchModes: self model availableSearches.
+	searchBar searchModes: self model availableSearchTargets.
 
 	configButton := self newButton
 		              icon: (self iconNamed: #config);
@@ -412,6 +459,12 @@ StFinderPresenter >> resultTree [
 StFinderPresenter >> searchBar [
 
 	^ searchBar
+]
+
+{ #category : 'searching' }
+StFinderPresenter >> searchBy: aString [ 
+
+	^ self announcingObject searchBy: aString
 ]
 
 { #category : 'private' }

--- a/src/NewTools-Finder/StFinderResult.class.st
+++ b/src/NewTools-Finder/StFinderResult.class.st
@@ -94,6 +94,11 @@ StFinderResult >> displayString [
 	^ content asString
 ]
 
+{ #category : 'private' }
+StFinderResult >> forFinderPreview: aSpCodePresenter [ 
+	^ self subclassResponsibility
+]
+
 { #category : 'testing' }
 StFinderResult >> hasBrowseAction [
 
@@ -220,6 +225,11 @@ StFinderResult >> printOn: aStream [
 	super printOn: aStream.
 	aStream space.
 	self content printOn: aStream.
+]
+
+{ #category : 'private' }
+StFinderResult >> selectItemIn: aSpTreePresenter [ 
+	^ self subclassResponsibility
 ]
 
 { #category : 'action' }

--- a/src/NewTools-Finder/StFinderSearch.class.st
+++ b/src/NewTools-Finder/StFinderSearch.class.st
@@ -1,8 +1,7 @@
 "
 I am an abstract base class for searches in the `Finder` Tool.
 
-I provide a common interface for performing searches and results are expected to be returned in
-form of a `FinderResult` composite object.
+It provides a common interface for performing searches and results are expected to be returned in form of a `StFinderResult` composite object.
 
 # Subclass Responsibilities
 
@@ -24,6 +23,11 @@ Class {
 	#package : 'NewTools-Finder',
 	#tag : 'Search'
 }
+
+{ #category : 'private' }
+StFinderSearch >> buildResult: aListOfClasses [ 
+	^ self subclassResponsibility
+]
 
 { #category : 'testing' }
 StFinderSearch >> isFinderExampleSearch [

--- a/src/NewTools-Finder/StFinderSearchBar.class.st
+++ b/src/NewTools-Finder/StFinderSearchBar.class.st
@@ -158,6 +158,8 @@ StFinderSearchBar >> updatePreview: aStFinderSelectorSearch [
 { #category : 'updating - widgets' }
 StFinderSearchBar >> updateSearch: aString [
 
+	(StFinderSettings cleanResultsOnEmptyInput and: [ aString isEmpty ])
+		ifTrue: [ self owner cleanResults ].
 	(StFinderSettings searchAsYouType and: [ aString size >= 3 ])
 		ifTrue: [ self searchBy: aString ]
 ]
@@ -165,7 +167,7 @@ StFinderSearchBar >> updateSearch: aString [
 { #category : 'updating - widgets' }
 StFinderSearchBar >> updateSearchModes [
 
-	searchModeDropList items: self owner model availableSearches
+	searchModeDropList items: self owner model availableSearchTargets
 ]
 
 { #category : 'updating - widgets' }

--- a/src/NewTools-Finder/StFinderSearchOptions.class.st
+++ b/src/NewTools-Finder/StFinderSearchOptions.class.st
@@ -29,7 +29,8 @@ Class {
 	#instVars : [
 		'regexpCheckBox',
 		'exactCheckBox',
-		'caseCheckBox'
+		'caseCheckBox',
+		'substringBox'
 	],
 	#category : 'NewTools-Finder-Widgets',
 	#package : 'NewTools-Finder',
@@ -38,11 +39,12 @@ Class {
 
 { #category : 'initialization' }
 StFinderSearchOptions >> activateAll [
-	"Deactivate all the receiver's search options"
+	"Activate all the receiver's search options"
 
 	regexpCheckBox enabled: true.
 	exactCheckBox enabled: true.
 	caseCheckBox enabled: true.
+	substringBox enabled: true
 ]
 
 { #category : 'accessing' }
@@ -58,6 +60,7 @@ StFinderSearchOptions >> deactivateAll [
 	regexpCheckBox enabled: false.
 	exactCheckBox enabled: false.
 	caseCheckBox enabled: false.
+	substringBox enabled: false
 ]
 
 { #category : 'layout' }
@@ -65,6 +68,7 @@ StFinderSearchOptions >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
 		spacing: 2;
+		add: substringBox width: 95;
 		add: regexpCheckBox width: 70;
 		add: exactCheckBox width: 70;
 		add: caseCheckBox width: 70;
@@ -84,6 +88,12 @@ StFinderSearchOptions >> disableRegex [
 ]
 
 { #category : 'accessing' }
+StFinderSearchOptions >> disableSubstring [
+
+	substringBox enabled: false.
+]
+
+{ #category : 'accessing' }
 StFinderSearchOptions >> enableExact [
 
 	exactCheckBox enabled: true.
@@ -93,6 +103,12 @@ StFinderSearchOptions >> enableExact [
 StFinderSearchOptions >> enableRegex [
 
 	regexpCheckBox enabled: true.
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> enableSubstring [
+
+	substringBox enabled: true.
 ]
 
 { #category : 'accessing' }
@@ -117,13 +133,24 @@ StFinderSearchOptions >> initializePresenters [
 	caseCheckBox := self newCheckBox 
 		label: 'Case';
 		help: 'Use match case';
-		yourself
+		yourself.
+		
+	substringBox := self newCheckBox
+		label: 'Substring';
+		help: 'Use substring search';
+		yourself.
 ]
 
 { #category : 'accessing' }
 StFinderSearchOptions >> regexpCheckBox [
 
 	^ regexpCheckBox
+]
+
+{ #category : 'accessing' }
+StFinderSearchOptions >> substringBox [
+
+	^ substringBox
 ]
 
 { #category : 'events' }
@@ -163,4 +190,16 @@ StFinderSearchOptions >> whenRegexActivatedDo: aBlock [
 StFinderSearchOptions >> whenRegexDeactivatedDo: aBlock [
 
 	regexpCheckBox whenDeactivatedDo: aBlock
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenSubstringActivatedDo: aBlock [
+
+	substringBox whenActivatedDo: aBlock
+]
+
+{ #category : 'events' }
+StFinderSearchOptions >> whenSubstringDeactivatedDo: aBlock [
+
+	substringBox whenDeactivatedDo: aBlock
 ]

--- a/src/NewTools-Finder/StFinderSettings.class.st
+++ b/src/NewTools-Finder/StFinderSettings.class.st
@@ -7,6 +7,7 @@ Class {
 	#name : 'StFinderSettings',
 	#superclass : 'Object',
 	#classVars : [
+		'CleanResultsOnEmptyInput',
 		'EvaluationTimeout',
 		'ExcludeTests',
 		'ExpandResults',
@@ -21,6 +22,33 @@ Class {
 	#package : 'NewTools-Finder',
 	#tag : 'Core'
 }
+
+{ #category : 'system settings' }
+StFinderSettings class >> cleanResultsOnEmptyInput [
+	"Modified by settings Finder: self classSide >> #cleanResultsOnEmptyInputOn:"
+
+	^ CleanResultsOnEmptyInput
+		ifNil: [ CleanResultsOnEmptyInput := false ]
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> cleanResultsOnEmptyInput: aBoolean [
+	"Modified by settings Finder: self classSide >> #cleanResultsOnEmptyInputOn:"
+
+	CleanResultsOnEmptyInput := aBoolean
+]
+
+{ #category : 'system settings' }
+StFinderSettings class >> cleanResultsOnEmptyInputOn: aBuilder [
+	<systemsettings>
+	
+	(aBuilder setting: #cleanResultsOnEmptyInput)
+		parent: #finder;
+		default: false;
+		label: 'Clean results on clean text input';
+		description: 'Clean results after text input is cleaned';
+		target: self
+]
 
 { #category : 'system settings' }
 StFinderSettings class >> evaluationTimeout [


### PR DESCRIPTION
This PR introduces multiple enhancements to the New Finder UI:

- Add a new setting and feature to clean results when the input becomes empty.
- Refactoring search targets. Now it is possible to specify the "targets" to search for. For instance, you can do:

```smalltalk
StFinderPresenter openOnTargets:
    { StFinderSelectorSearch .
      StFinderClassSearch }.
```

- Add default option "use substring" checkbox.
