### PR TITLE
Use new message browser instead of morphic-based system navigation

### DIFF
--- a/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
@@ -71,7 +71,7 @@ StMessageListPresenter >> defaultOutputPort [
 { #category : 'private - actions' }
 StMessageListPresenter >> doBrowseImplementors [
 		
-	self systemNavigation browseAllImplementorsOf: self selectedMethod selector
+	StMessageBrowser browseImplementorsOf: self selectedMethod selector
 ]
 
 { #category : 'private - actions' }
@@ -83,7 +83,7 @@ StMessageListPresenter >> doBrowseMethod [
 { #category : 'private - actions' }
 StMessageListPresenter >> doBrowseSenders [
 
-	self systemNavigation browseAllSendersOf: self selectedMethod selector
+	StMessageBrowser browseSendersOf: self selectedMethod selector
 ]
 
 { #category : 'private - actions' }


### PR DESCRIPTION
This PR updates two methods to make the new message list presenter to use the message browser instead of "system navigation"