### PR TITLE
Message Browser advances (scoping)

### DIFF
--- a/src/NewTools-MethodBrowsers/RBBrowserEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBBrowserEnvironment.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'RBBrowserEnvironment' }
+
+{ #category : '*NewTools-MethodBrowsers' }
+RBBrowserEnvironment >> selectMessagesFrom: aCollection [ 
+	"Since the receiver is a system environment, answer all messages in aCollection"	
+
+	^ aCollection 
+]

--- a/src/NewTools-MethodBrowsers/RBBrowserEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBBrowserEnvironment.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : 'RBBrowserEnvironment' }
 
 { #category : '*NewTools-MethodBrowsers' }
-RBBrowserEnvironment >> selectMessagesFrom: aCollection [ 
+RBBrowserEnvironment >> selectMessagesFrom: aCollectionOfCompiledMethod [ 
 	"Since the receiver is a system environment, answer all messages in aCollection"	
 
-	^ aCollection 
+	^ aCollectionOfCompiledMethod 
 ]

--- a/src/NewTools-MethodBrowsers/RBClassEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBClassEnvironment.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'RBClassEnvironment' }
+
+{ #category : '*NewTools-MethodBrowsers' }
+RBClassEnvironment >> selectMessagesFrom: aCollection [ 
+	"Answer a <Collection> of <CompiledMethod> present in the receiver"
+
+	self halt.
+	^ self classes flatCollect: [ : cls | 
+		aCollection select: [ : item | cls = item  ] ].
+]

--- a/src/NewTools-MethodBrowsers/RBClassEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBClassEnvironment.extension.st
@@ -1,10 +1,10 @@
 Extension { #name : 'RBClassEnvironment' }
 
 { #category : '*NewTools-MethodBrowsers' }
-RBClassEnvironment >> selectMessagesFrom: aCollection [ 
-	"Answer a <Collection> of <CompiledMethod> present in the receiver"
+RBClassEnvironment >> selectMessagesFrom: aCollectionOfCompiledMethod [ 
+	"Filter methods in aCollectionOfCompiledMethod for which their method class is present in the receiver's classes
+	 Answer a <Collection> of <CompiledMethod>"
 
-	self halt.
 	^ self classes flatCollect: [ : cls | 
-		aCollection select: [ : item | cls = item  ] ].
+		aCollectionOfCompiledMethod select: [ : cm | cls = cm methodClass  ] ].
 ]

--- a/src/NewTools-MethodBrowsers/RBClassHierarchyEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBClassHierarchyEnvironment.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'RBClassHierarchyEnvironment' }
+
+{ #category : '*NewTools-MethodBrowsers' }
+RBClassHierarchyEnvironment >> selectMessagesFrom: aCollectionOfCompiledMethod [ 
+	"Since the receiver is a system environment, answer all messages in aCollection"	
+
+	^ (aCollectionOfCompiledMethod 
+		reject: [ : cm | cm methodClass isMeta ]) "see https://github.com/pharo-project/pharo/issues/17139"
+			select: [ : cm | cm methodClass isInClassHierarchyOf: class ]
+]

--- a/src/NewTools-MethodBrowsers/RBCompositeEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBCompositeEnvironment.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'RBCompositeEnvironment' }
+
+{ #category : '*NewTools-MethodBrowsers' }
+RBCompositeEnvironment >> selectMessagesFrom: aCollectionOfCompiledMethod [ 
+	"Filter methods in aCollectionOfCompiledMethod for which their method class is present in the receiver's classes
+	 Answer a <Collection> of <CompiledMethod>"
+
+	^ self classes flatCollect: [ : cls | 
+		aCollectionOfCompiledMethod select: [ : cm | cls = cm methodClass  ] ].
+]

--- a/src/NewTools-MethodBrowsers/RBPackageEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBPackageEnvironment.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : 'RBPackageEnvironment' }
 
 { #category : '*NewTools-MethodBrowsers' }
-RBPackageEnvironment >> selectMessagesFrom: aCollection [ 
+RBPackageEnvironment >> selectMessagesFrom: aCollectionOfCompiledMethod [ 
 	"Answer a <Collection> of <CompiledMethod> present in the receiver"
 
-	^ self packages flatCollect: [ : pck | 
-		aCollection select: [ : mth | 
-			pck
-				includesSelector: mth selector 
-				ofClass: mth methodClass ] ].
+	^ self packages flatCollect: [ : aPackage | 
+		aCollectionOfCompiledMethod select: [ : cm | 
+			aPackage
+				includesSelector: cm selector 
+				ofClass: cm methodClass ] ].
 ]

--- a/src/NewTools-MethodBrowsers/RBPackageEnvironment.extension.st
+++ b/src/NewTools-MethodBrowsers/RBPackageEnvironment.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'RBPackageEnvironment' }
+
+{ #category : '*NewTools-MethodBrowsers' }
+RBPackageEnvironment >> selectMessagesFrom: aCollection [ 
+	"Answer a <Collection> of <CompiledMethod> present in the receiver"
+
+	^ self packages flatCollect: [ : pck | 
+		aCollection select: [ : mth | 
+			pck
+				includesSelector: mth selector 
+				ofClass: mth methodClass ] ].
+]

--- a/src/NewTools-MethodBrowsers/StAbstractMessageCentricBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StAbstractMessageCentricBrowserPresenter.class.st
@@ -54,6 +54,12 @@ StAbstractMessageCentricBrowserPresenter >> isMethodDefinition: anItem [
 		or: [  anItem isCompiledMethod ]
 ]
 
+{ #category : 'accessing' }
+StAbstractMessageCentricBrowserPresenter >> messageList [
+
+	^ messageList
+]
+
 { #category : 'initialization' }
 StAbstractMessageCentricBrowserPresenter >> newMessageList [
 	

--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -413,7 +413,8 @@ StMessageBrowser >> messages [
 { #category : 'api' }
 StMessageBrowser >> messages: aCollection [
 
-	messageList messages: aCollection
+	messageList messages: aCollection.
+	self toolbarPresenter updatePresenter.
 ]
 
 { #category : 'announcements' }

--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -527,7 +527,7 @@ StMessageBrowser >> selectItem: item [
 	self installIconStylerFor: item
 ]
 
-{ #category : 'accessing' }
+{ #category : 'backstops' }
 StMessageBrowser >> selectedClass [
 	^ self selectedMethod origin
 ]

--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -533,7 +533,7 @@ StMessageBrowser >> selectedClass [
 
 { #category : 'api' }
 StMessageBrowser >> selectedMessage: aMessage [
-	messageList selectMessage: aMessage
+	messageList updateVisitedScopesFrom: aMessage
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -131,6 +131,7 @@ StMessageBrowser class >> taskbarIconName [
 
 { #category : 'specs' }
 StMessageBrowser class >> title [
+
 	^ 'Message Browser'
 ]
 

--- a/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
@@ -45,7 +45,8 @@ StMessageListPresenter >> allScopes [
 		add: self browserEnvironment;
 		addAll: self packageEnvironments;
 		addAll: self classesEnvironments;		
-		"addAll: self hierarchyEnvironments;"
+		addAll: self classHierarchyEnvironments;
+		addAll: self compositeEnvironments;
 		yourself
 ]
 
@@ -84,11 +85,36 @@ StMessageListPresenter >> cacheHierarchyForClasses: aCollection [
 
 { #category : 'private - scopes' }
 StMessageListPresenter >> classEnvironmentFor: aClass [
-	"Answer a <RBClassEnvironment> for the selected packages"
+	"Answer a <RBClassEnvironment> for aClass"
 
 	^ RBBrowserEnvironment default forClasses: { aClass }
 
 
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> classHierarchyEnvironmentFor: aClass [
+	"Answer a <RBClassEnvironment> for aClass"
+
+	^ RBBrowserEnvironment default forClassHierarchy: aClass
+
+
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> classHierarchyEnvironments [
+	"Answer a <Collection> of <RBClassEnvironment> for the receiver's selected classes"
+	
+	^ self visitedScopes 
+		select: [ : anObject | anObject isClass ]
+		thenCollect: [ : aClass | self classHierarchyEnvironmentFor: aClass  ]
+]
+
+{ #category : 'private' }
+StMessageListPresenter >> classHierarchyOf: aCompiledMethod [
+	"Answer a <Collection> of superclasses of aCompiledMethod method class"
+
+	^ RBClassHierarchyEnvironment class: aCompiledMethod methodClass
 ]
 
 { #category : 'private' }
@@ -107,6 +133,14 @@ StMessageListPresenter >> classesEnvironments [
 		thenCollect: [ : aClass | self classEnvironmentFor: aClass  ]
 ]
 
+{ #category : 'private - scopes' }
+StMessageListPresenter >> compositeEnvironments [
+
+	^ self visitedScopes reject: [ : anObject | anObject isClass or: [ anObject isPackage ] ]
+
+
+]
+
 { #category : 'transmission' }
 StMessageListPresenter >> defaultOutputPort [
 
@@ -119,9 +153,13 @@ StMessageListPresenter >> defaultScopes [
 
 	^ self selectedMessage
 		ifNil: [ Set empty ]
-		ifNotNil: [ Set 
-				with: (self packageOf: self selectedMessage)
-				with: (self classOf: self selectedMessage) ]
+		ifNotNil: [ 
+			Set new
+				add: (self packageOf: self selectedMessage);
+				add: (self classOf: self selectedMessage);
+				add: (self classHierarchyOf: self selectedMessage);
+				addAll: ScopesManager availableScopes;
+				yourself ]
 ]
 
 { #category : 'private - actions' }
@@ -371,7 +409,7 @@ StMessageListPresenter >> selectorOf: anItem [
 	^ anItem selector
 ]
 
-{ #category : 'initialization' }
+{ #category : 'accessing - model' }
 StMessageListPresenter >> setModelBeforeInitialization: aMethod [
 ]
 
@@ -421,13 +459,14 @@ StMessageListPresenter >> topologicSort: anObject [
 
 { #category : 'private - scopes' }
 StMessageListPresenter >> updateVisitedScopesFrom: aCompiledMethod [
-	"Update the list of the visited packages"
+	"Private - Update the list of the visited scopes"
 
 	visitedScopes 
 		ifNotNil: [ 
 			visitedScopes 
 				add: (self packageOf: aCompiledMethod);
-				add: (self classOf: aCompiledMethod) ]
+				add: (self classOf: aCompiledMethod);
+				add: (self classHierarchyOf: aCompiledMethod) ]
 ]
 
 { #category : 'private - scopes' }

--- a/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
@@ -22,8 +22,8 @@ Class {
 		'topologySort',
 		'listPresenter',
 		'scopes',
-		'selectedPackages',
-		'allMessages'
+		'allMessages',
+		'visitedScopes'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -35,6 +35,17 @@ StMessageListPresenter class >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
 		add: #listPresenter;
+		yourself
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> allScopes [
+
+	^ OrderedCollection new
+		add: self browserEnvironment;
+		addAll: self packageEnvironments;
+		addAll: self classesEnvironments;		
+		"addAll: self hierarchyEnvironments;"
 		yourself
 ]
 
@@ -71,6 +82,31 @@ StMessageListPresenter >> cacheHierarchyForClasses: aCollection [
 	cachedHierarchy := self buildHierarchyForMessages: aCollection.
 ]
 
+{ #category : 'private - scopes' }
+StMessageListPresenter >> classEnvironmentFor: aClass [
+	"Answer a <RBClassEnvironment> for the selected packages"
+
+	^ RBBrowserEnvironment default forClasses: { aClass }
+
+
+]
+
+{ #category : 'private' }
+StMessageListPresenter >> classOf: aCompiledMethod [
+	"Answer the <Class> of aCompiledMethod"
+
+	^ aCompiledMethod methodClass
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> classesEnvironments [
+	"Answer a <Collection> of <RBClassEnvironment> for the receiver's selected classes"
+	
+	^ self visitedScopes 
+		select: [ : anObject | anObject isClass ]
+		thenCollect: [ : aClass | self classEnvironmentFor: aClass  ]
+]
+
 { #category : 'transmission' }
 StMessageListPresenter >> defaultOutputPort [
 
@@ -79,22 +115,13 @@ StMessageListPresenter >> defaultOutputPort [
 
 { #category : 'private - scopes' }
 StMessageListPresenter >> defaultScopes [
-
-	^ { 
-		self browserEnvironment .
-		self packageEnvironment .
-		"'Hierarchy' .
-		'Classes'"
-	 }
-]
-
-{ #category : 'private - scopes' }
-StMessageListPresenter >> defaultSelectedPackages [
 	"Private - By default we answer the <Package> of the currently selected item"
 
 	^ self selectedMessage
 		ifNil: [ Set empty ]
-		ifNotNil: [ Set with: (self packageOf: self selectedMessage) ]
+		ifNotNil: [ Set 
+				with: (self packageOf: self selectedMessage)
+				with: (self classOf: self selectedMessage) ]
 ]
 
 { #category : 'private - actions' }
@@ -166,8 +193,7 @@ StMessageListPresenter >> initializePresenters [
 			title: 'Package' 
 			evaluated: [ :item | self packageNameOf: item ]);
 		beResizable.
-		
-	listPresenter whenSelectedDo: [ : method | self selectMessage: method ].
+
 	listPresenter outputActivationPort transmitDo: [ :aMethod | self doBrowseMethod ].
 		
 	listPresenter 
@@ -262,10 +288,21 @@ StMessageListPresenter >> outputSelectionPort [
 ]
 
 { #category : 'private - scopes' }
-StMessageListPresenter >> packageEnvironment [
+StMessageListPresenter >> packageEnvironmentFor: aPackage [
 	"Answer a <RBPackageEnvironment> for the selected packages"
 
-	^ RBBrowserEnvironment default forPackages: self selectedPackages
+	^ RBBrowserEnvironment default forPackages: { aPackage }
+
+
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> packageEnvironments [
+	"Answer a <Collection> of <RBPackageEnvironment> for the receiver's selected packages"
+
+	^ self visitedScopes 
+		select: [ : anObject | anObject isPackage ]
+		thenCollect: [ : aPackage | self packageEnvironmentFor: aPackage ]
 
 
 ]
@@ -300,21 +337,13 @@ StMessageListPresenter >> scopes [
 	"Answer a <Collection> of the receiver's message list scopes"
 	
 	^ scopes
-		ifNil: [ scopes := self defaultScopes ]
+		ifNil: [ scopes := self allScopes ]
 ]
 
 { #category : 'selecting' }
 StMessageListPresenter >> selectIndex: anInteger [
 
 	listPresenter selectIndex: anInteger
-]
-
-{ #category : 'accessing' }
-StMessageListPresenter >> selectMessage: aMessage [
-	"Select aMessage in the receiver and update the list of the visited packages"
-
-	listPresenter selectItem: aMessage.
-	selectedPackages ifNotNil: [ selectedPackages add: (self packageOf: aMessage) ]
 ]
 
 { #category : 'selecting' }
@@ -334,16 +363,6 @@ StMessageListPresenter >> selectedMethod [
 
 	self selectedMessage ifNil: [ ^ nil ].
 	^ self selectedMessage compiledMethod
-]
-
-{ #category : 'private - scopes' }
-StMessageListPresenter >> selectedPackages [
-	"Answer a <Collection> of <Package> which has been selected in the receiver"
-	
-	^ selectedPackages
-		ifNil: [ selectedPackages := self defaultSelectedPackages ]
-
-
 ]
 
 { #category : 'accessing' }
@@ -382,20 +401,10 @@ StMessageListPresenter >> sortingBlock: aBlock [
 ]
 
 { #category : 'private - scopes' }
-StMessageListPresenter >> switchScopeTo: aPackage [ 
+StMessageListPresenter >> switchScopeTo: aRBBrowserEnvironment [ 
 
-	| filteredMessages |
-	
-	aPackage isSystem
-		ifTrue: [ 
-			listPresenter items: allMessages.
-			^ self ].
-	filteredMessages := aPackage packages flatCollect: [ : pck | 
-		(self messages select: [ : mth | 
-			pck
-				includesSelector: mth selector 
-				ofClass: mth methodClass ]) ].
-	listPresenter items: filteredMessages
+	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages)
+
 ]
 
 { #category : 'accessing' }
@@ -408,6 +417,27 @@ StMessageListPresenter >> topologicSort [
 StMessageListPresenter >> topologicSort: anObject [
 
 	topologySort := anObject
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> updateVisitedScopesFrom: aCompiledMethod [
+	"Update the list of the visited packages"
+
+	visitedScopes 
+		ifNotNil: [ 
+			visitedScopes 
+				add: (self packageOf: aCompiledMethod);
+				add: (self classOf: aCompiledMethod) ]
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> visitedScopes [
+	"Answer a <Collection> of <Package> which has been selected in the receiver"
+	
+	^ visitedScopes
+		ifNil: [ visitedScopes := self defaultScopes ]
+
+
 ]
 
 { #category : 'api - events' }

--- a/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
@@ -45,7 +45,6 @@ StMessageListPresenter >> allScopes [
 		add: self browserEnvironment;
 		addAll: self packageEnvironments;
 		addAll: self classesEnvironments;		
-		addAll: self classHierarchyEnvironments;
 		addAll: self compositeEnvironments;
 		yourself
 ]
@@ -440,6 +439,7 @@ StMessageListPresenter >> sortingBlock: aBlock [
 
 { #category : 'private - scopes' }
 StMessageListPresenter >> switchScopeTo: aRBBrowserEnvironment [ 
+	"Private - Callback to scope selection from the user"
 
 	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages)
 

--- a/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageListPresenter.class.st
@@ -20,7 +20,10 @@ Class {
 	#instVars : [
 		'cachedHierarchy',
 		'topologySort',
-		'listPresenter'
+		'listPresenter',
+		'scopes',
+		'selectedPackages',
+		'allMessages'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -33,6 +36,12 @@ StMessageListPresenter class >> defaultLayout [
 	^ SpBoxLayout newTopToBottom
 		add: #listPresenter;
 		yourself
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> browserEnvironment [
+
+	^ ClyNavigationEnvironment currentImageScope asRBEnvironment label: 'current image'
 ]
 
 { #category : 'testing' }
@@ -66,6 +75,26 @@ StMessageListPresenter >> cacheHierarchyForClasses: aCollection [
 StMessageListPresenter >> defaultOutputPort [
 
 	^ self outputSelectionPort
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> defaultScopes [
+
+	^ { 
+		self browserEnvironment .
+		self packageEnvironment .
+		"'Hierarchy' .
+		'Classes'"
+	 }
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> defaultSelectedPackages [
+	"Private - By default we answer the <Package> of the currently selected item"
+
+	^ self selectedMessage
+		ifNil: [ Set empty ]
+		ifNotNil: [ Set with: (self packageOf: self selectedMessage) ]
 ]
 
 { #category : 'private - actions' }
@@ -117,8 +146,8 @@ StMessageListPresenter >> doRemoveMethod [
 StMessageListPresenter >> initialize [
 
 	super initialize.
-	topologySort := true
-
+	topologySort := true.
+	allMessages := Set empty.
 ]
 
 { #category : 'initialization' }
@@ -135,9 +164,10 @@ StMessageListPresenter >> initializePresenters [
 			evaluated: [ :item | self selectorOf: item ]);
 		addColumn: (SpStringTableColumn 
 			title: 'Package' 
-			evaluated: [ :item | self packageOf: item ]);
+			evaluated: [ :item | self packageNameOf: item ]);
 		beResizable.
 		
+	listPresenter whenSelectedDo: [ : method | self selectMessage: method ].
 	listPresenter outputActivationPort transmitDo: [ :aMethod | self doBrowseMethod ].
 		
 	listPresenter 
@@ -199,6 +229,7 @@ StMessageListPresenter >> messages: aCollection [
 
 	self cacheHierarchyForClasses: aCollection.
 	listPresenter items: cachedHierarchy keys asOrderedCollection.
+	allMessages := listPresenter items.
 	listPresenter listSize > 0 ifTrue: [ 
 		listPresenter selectIndex: 1 ]
 ]
@@ -230,20 +261,46 @@ StMessageListPresenter >> outputSelectionPort [
 		yourself
 ]
 
+{ #category : 'private - scopes' }
+StMessageListPresenter >> packageEnvironment [
+	"Answer a <RBPackageEnvironment> for the selected packages"
+
+	^ RBBrowserEnvironment default forPackages: self selectedPackages
+
+
+]
+
 { #category : 'private' }
 StMessageListPresenter >> packageNameForItem: anItem [
 	^ anItem package ifNil: [ '' ] ifNotNil: [ :package | package name ]
 ]
 
 { #category : 'private' }
-StMessageListPresenter >> packageOf: anItem [
+StMessageListPresenter >> packageNameOf: anItem [
+	"Answer a <String> matching anItem"
+
 	^ '[' , (self packageNameForItem: anItem) , ']'
+]
+
+{ #category : 'private' }
+StMessageListPresenter >> packageOf: aCompiledMethod [
+	"Answer the <Package> of aCompiledMethod"
+
+	^ self packageOrganizer packageOf: aCompiledMethod methodClass
 ]
 
 { #category : 'private' }
 StMessageListPresenter >> protocolNameForItem: anItem [
 
 	^ anItem protocolName ifNil: [ '' ]
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> scopes [
+	"Answer a <Collection> of the receiver's message list scopes"
+	
+	^ scopes
+		ifNil: [ scopes := self defaultScopes ]
 ]
 
 { #category : 'selecting' }
@@ -254,8 +311,10 @@ StMessageListPresenter >> selectIndex: anInteger [
 
 { #category : 'accessing' }
 StMessageListPresenter >> selectMessage: aMessage [
+	"Select aMessage in the receiver and update the list of the visited packages"
 
-	listPresenter selectItem: aMessage
+	listPresenter selectItem: aMessage.
+	selectedPackages ifNotNil: [ selectedPackages add: (self packageOf: aMessage) ]
 ]
 
 { #category : 'selecting' }
@@ -275,6 +334,16 @@ StMessageListPresenter >> selectedMethod [
 
 	self selectedMessage ifNil: [ ^ nil ].
 	^ self selectedMessage compiledMethod
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> selectedPackages [
+	"Answer a <Collection> of <Package> which has been selected in the receiver"
+	
+	^ selectedPackages
+		ifNil: [ selectedPackages := self defaultSelectedPackages ]
+
+
 ]
 
 { #category : 'accessing' }
@@ -310,6 +379,23 @@ StMessageListPresenter >> sortClassesInCachedHierarchy: aMethodDefinition b: oth
 StMessageListPresenter >> sortingBlock: aBlock [
 
 	listPresenter sortingBlock: aBlock
+]
+
+{ #category : 'private - scopes' }
+StMessageListPresenter >> switchScopeTo: aPackage [ 
+
+	| filteredMessages |
+	
+	aPackage isSystem
+		ifTrue: [ 
+			listPresenter items: allMessages.
+			^ self ].
+	filteredMessages := aPackage packages flatCollect: [ : pck | 
+		(self messages select: [ : mth | 
+			pck
+				includesSelector: mth selector 
+				ofClass: mth methodClass ]) ].
+	listPresenter items: filteredMessages
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
@@ -16,13 +16,10 @@ StMessageToolbarPresenter >> connectPresenters [
 	scopeList whenSelectedItemChangedDo: [ : scopeEnvironment | 
 		scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
 	
-
 	messageList whenSelectedDo: [ : item |
 		item ifNotNil: [
 			messageList updateVisitedScopesFrom: item.
-			scopeList 
-				items: messageList allScopes;
-				selectIndex: 1 ] ]
+			scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ] ] ]
 
 ]
 

--- a/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
@@ -51,21 +51,23 @@ StMessageToolbarPresenter >> initializePresenters [
 	
 	scopeList := self newDropList
 		addStyle: 'stMessageBrowserScopeList';
-		display: [ :each | each description ];
+		display: [ : item | item description ];
 		yourself.
 	
 	toolbarPresenter add: (self newToolbarButton
 		label: 'Flip';
-		action: [ self doFlipLayout ])
+		action: [ self doFlipLayout ]).
+		
+	messageList whenSelectionChangedDo: [ : item |
+		item selectedItem ifNotNil: [ : realItem | 
+			scopeList items: messageList scopes ] ]
 ]
 
-{ #category : 'initialization' }
-StMessageToolbarPresenter >> updatePresenter [
+{ #category : 'accessing' }
+StMessageToolbarPresenter >> owner: aPresenter [
 
-	super updatePresenter.
-	
-	messageList ifNil: [ ^ self ].
-	scopeList items: (messageList scopes ifNil: [ #() ])
+	super owner: aPresenter.
+	messageList := aPresenter messageList.
 ]
 
 { #category : 'events' }

--- a/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageToolbarPresenter.class.st
@@ -13,8 +13,17 @@ Class {
 { #category : 'initialization' }
 StMessageToolbarPresenter >> connectPresenters [
 
-	scopeList whenSelectedItemChangedDo: [ :item | 
-		item ifNotNil: [ messageList switchScopeTo: item ] ]
+	scopeList whenSelectedItemChangedDo: [ : scopeEnvironment | 
+		scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
+	
+
+	messageList whenSelectedDo: [ : item |
+		item ifNotNil: [
+			messageList updateVisitedScopesFrom: item.
+			scopeList 
+				items: messageList allScopes;
+				selectIndex: 1 ] ]
+
 ]
 
 { #category : 'layout' }
@@ -57,10 +66,7 @@ StMessageToolbarPresenter >> initializePresenters [
 	toolbarPresenter add: (self newToolbarButton
 		label: 'Flip';
 		action: [ self doFlipLayout ]).
-		
-	messageList whenSelectionChangedDo: [ : item |
-		item selectedItem ifNotNil: [ : realItem | 
-			scopeList items: messageList scopes ] ]
+
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR includes features to complete a minimum usable implementation of the new Message Browser, now implemented mostly in `StMessageListPresenter` and `StMethodToolbarPresenter`. 

Most of the changes are related to adding the features of the "scopes drop list" which is initially opened with the scope of the queried method, and as the user selects methods is dynamically populated with selected packages, classes, and hierarchies. This way the user can select new scopes to filter the list of messages.
 
## Demos

- Dynamically populating packages and switching to package scopes:

https://github.com/user-attachments/assets/95234632-49ef-4e38-947c-a5fac79c54f9

- Selection of multiple methods to query its senders. Scrolling speed. Opening new Implementors window from selection.

https://github.com/user-attachments/assets/ec738b4d-765e-4bdc-8b63-943927ac82f2

- Switching scope to a custom scope

https://github.com/user-attachments/assets/b1dbf4e1-4c03-4a36-b749-99101018a5df

## Notes

- For packages: The system browser is not needed anymore to create package scopes (`ClyPackageScope`), i.e.: `ClyQueryBrowserMorph>>#packageScopeOfSelectedItems`
- For classes: Getting class information no longer needs `systemDefinition` from `ClyDataSourceItem>>#systemDefinition` and `ClyBrowserItem>>#systemDefinition`.
- For class hierarchies: Not inherited scopes and annotations used to create them, `ClyInheritedScopeProviderAnnotation` is unnecessary. 
- Many of the methods of `ClyQueryBrowserMorph` were rewritten in Spec 2 NewTools, to detach the scoping functionality from the Calypso query system, which is also attached to Morphic. This also reduced the complexity of the implementation.
- The new scopes drop list includes the result of `ScopesManager availableScopes` to filter composite environments defined in the Scopes Editor.
- The title of the message list browser includes **all** the methods selected for both sender and implementor windows.

## Known issues

These issues could be fixed in upcoming PR's

- The hierarchy scopes are duplicated in the scopes list.
- New instances of the message browsers will be opened in new windows, instead of spawning as tabs.

