### PR TITLE
SycCmClassCritiqueCommand should be in Extras submenu

### DIFF
--- a/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
@@ -78,7 +78,7 @@ StCritiqueBrowserPresenter class >> icon [
 { #category : 'icons' }
 StCritiqueBrowserPresenter class >> iconName [
 
-	^ #error
+	^ #smallQA
 ]
 
 { #category : 'instance creation' }

--- a/src/NewTools-CodeCritiques/SycCmClassCritiqueCommand.class.st
+++ b/src/NewTools-CodeCritiques/SycCmClassCritiqueCommand.class.st
@@ -3,7 +3,7 @@ I am a command to make a class abstract by adding a method that returns whether 
 "
 Class {
 	#name : 'SycCmClassCritiqueCommand',
-	#superclass : 'SycClassCmCommand',
+	#superclass : 'SycClassExtraCmCommand',
 	#category : 'NewTools-CodeCritiques-Commands',
 	#package : 'NewTools-CodeCritiques',
 	#tag : 'Commands'
@@ -37,5 +37,5 @@ SycCmClassCritiqueCommand >> name [
 
 { #category : 'accessing' }
 SycCmClassCritiqueCommand >> order [
-	^ 45
+	^ 60
 ]


### PR DESCRIPTION
One-liner PR to fix "Class Critique Browser menu Item should not be in refactoring" reported in https://github.com/pharo-project/pharo/issues/17079
