### PR TITLE
Remove dialog usage from setting button presenter.

### DIFF
--- a/src/NewTools-SettingsBrowser/LogicalFont.extension.st
+++ b/src/NewTools-SettingsBrowser/LogicalFont.extension.st
@@ -3,18 +3,19 @@ Extension { #name : 'LogicalFont' }
 { #category : '*NewTools-SettingsBrowser' }
 LogicalFont >> asSettingPresenter: aSettingDeclaration [ 
 
-	| info |
+	| info currentFont |
 
+	currentFont := StandardFonts perform: aSettingDeclaration name.
 	info := String streamContents: [ : stream |
 		stream 
-			<< self realFont textStyleName;
+			<< currentFont textStyleName;
 			<< ' (';
-			<< self realFont pointSize asString;
+			<< currentFont pointSize asString;
 			<< ')' ].
 	
 	^ (StSettingSHStyleButtonPresenterItem on: aSettingDeclaration)
 		buttonLabel: info;
-		buttonFont: self realFont;
+		buttonFont: currentFont realFont;
 		buttonAction: [ aSettingDeclaration getFont ];
 		yourself.
 ]

--- a/src/NewTools-SettingsBrowser/SmalltalkImage.extension.st
+++ b/src/NewTools-SettingsBrowser/SmalltalkImage.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*NewTools-SettingsBrowser' }
+SmalltalkImage >> name [
+
+	^ #Smalltalk
+]

--- a/src/NewTools-SettingsBrowser/StSettingButtonPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingButtonPresenterItem.class.st
@@ -14,8 +14,15 @@ StSettingButtonPresenterItem >> initializePresenters [
 
 	setterPresenter := self newButton 
 		label: self model actionLabel; 
-		action: self model dialog;
+		action: [ self target perform: self model name ];
 		yourself.
 	super initializePresenters.
 
+]
+
+{ #category : 'accessing' }
+StSettingButtonPresenterItem >> target [
+	"Answer an <Object> that is the receiver of the action"
+
+	^ self model target
 ]

--- a/src/NewTools-SettingsBrowser/StSettingTreeBuilder.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingTreeBuilder.class.st
@@ -11,3 +11,14 @@ StSettingTreeBuilder >> nodeClass [
 
 	^ StSettingNode
 ]
+
+{ #category : 'private - tree building' }
+StSettingTreeBuilder >> nodeClass: aClass name: aSymbol [
+	| node |
+	node := self nodeClass with: aClass new.
+	node item name: aSymbol.
+	node pragma: currentPragma.
+	node parentName: (currentParent ifNotNil: [currentParent name]).
+	self nodeList add: node.
+	^ (SettingNodeBuilder new) node: node; builder: self; yourself
+]

--- a/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
@@ -11,7 +11,8 @@ Class {
 	#instVars : [
 		'toolbarPresenter',
 		'detailsPresenter',
-		'mainCategoriesPresenter'
+		'mainCategoriesPresenter',
+		'buttonBarPresenter'
 	],
 	#category : 'NewTools-SettingsBrowser-UI',
 	#package : 'NewTools-SettingsBrowser',
@@ -42,23 +43,68 @@ StSettingsMainPresenter >> defaultInputPort [
 { #category : 'layout' }
 StSettingsMainPresenter >> defaultLayout [
 
-	^ SpPanedLayout newHorizontal 
-		positionOfSlider: 0.2;		
-		add: (SpBoxLayout newTopToBottom
-				add: toolbarPresenter withConstraints: [ : constraints |
-					constraints 
-						height: self class toolbarHeight + 10;
-						padding: 5 ];
-			add: mainCategoriesPresenter;
-			yourself);
-		add: detailsPresenter;
-		yourself
+	^ SpBoxLayout newTopToBottom
+		spacing: 5;
+		  add: (SpPanedLayout newHorizontal
+				   positionOfSlider: 0.2;
+				   add: (SpBoxLayout newTopToBottom
+						    add: toolbarPresenter withConstraints: [ :constraints |
+							    constraints
+								    height: self class toolbarHeight + 10;
+								    padding: 5 ];
+						    add: mainCategoriesPresenter;
+						    yourself);
+				   add: detailsPresenter);
+		  add: buttonBarPresenter expand: false;
+		  yourself
 ]
 
 { #category : 'ports' }
 StSettingsMainPresenter >> defaultOutputPort [ 
 
 	^ mainCategoriesPresenter
+]
+
+{ #category : 'export' }
+StSettingsMainPresenter >> exportSettings [
+	| nodes actions   |
+
+	nodes := self settingsTree nodeList.
+	actions := nodes 
+		collect: [ : e | e item exportSettingAction ]
+		thenReject: [ : e | e isNil ].
+	self 
+		exportAllSettings: actions 
+		by: 50 
+		withBasename: 'exported_settings'.
+	
+	buttonBarPresenter enable
+]
+
+{ #category : 'initialization' }
+StSettingsMainPresenter >> initializeButtonBar [
+
+	buttonBarPresenter := self newButtonBar
+		placeAtEnd;
+		add: (self newButton
+			addStyle: 'large';
+			icon: (self iconNamed: #openFromUrl);
+			label: 'Load';
+			help: 'Load settings from a file';
+			action: [ self loadSettings ];
+			enabled: self settingsTree hasSettingsFile;
+			yourself);
+		add: (self newButton
+			icon: (self application iconNamed: #save);
+			label: 'Export';
+			help: 'Save settings into a file';
+			action: [ self exportSettings ];
+			yourself);
+		add: (self newButton
+			icon: (self iconNamed: #cancel);
+			action: [ self delete ];
+			label: 'Cancel';
+			yourself).
 ]
 
 { #category : 'initialization' }
@@ -76,6 +122,7 @@ StSettingsMainPresenter >> initializePresenters [
 	toolbarPresenter := self instantiate: StSettingsToolbarPresenter on: self.
 	mainCategoriesPresenter := self instantiate: StSettingsCategoriesPresenter on: self.
 	detailsPresenter := self instantiate: StSettingsPagePresenter on: self.
+	self initializeButtonBar.
 	
 	self initializeFocus.
 ]
@@ -87,4 +134,12 @@ StSettingsMainPresenter >> initializeWindow: aWindowPresenter [
 		title: self browserTitle;
 		initialExtent: 1200 @ 700;
 		centered
+]
+
+{ #category : 'menu' }
+StSettingsMainPresenter >> loadSettings [
+	"Load the settings from the system settings file, if exists"
+
+	self settingsTree hasSettingsFile
+		ifTrue: [ self settingsTree updateSettingNodes ]
 ]

--- a/src/NewTools-SettingsBrowser/StSettingsTree.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsTree.class.st
@@ -19,6 +19,13 @@ StSettingsTree >> defaultCategories [
 	^ self treeRoots.
 ]
 
+{ #category : 'testing' }
+StSettingsTree >> hasSettingsFile [ 
+	"Answer <true> if a system settings file exists"
+
+	^ self persistence hasSettingsFile 
+]
+
 { #category : 'instance creation' }
 StSettingsTree >> newSettingTreeBuilderNodes [
 	"Walk over the receiver's pragmas. Build and answer a <Collection> of <StSettingNode>, each one representing a specific setting"

--- a/src/NewTools-SettingsBrowser/SystemSettingsPersistence.extension.st
+++ b/src/NewTools-SettingsBrowser/SystemSettingsPersistence.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'SystemSettingsPersistence' }
+
+{ #category : '*NewTools-SettingsBrowser' }
+SystemSettingsPersistence >> hasSettingsFile [
+	"Answer <true> if the system settings file exists"
+
+	^ fileReference exists
+]


### PR DESCRIPTION
The `dialog:` usage is being replaced by configuring the source setting with `button:` and the callback method as a parameter. This PR removes the dialog block execution in the NewTools Setting Browser
