### PR TITLE
Fix MetaBrowserPresenter filtering

### DIFF
--- a/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
+++ b/src/NewTools-Inspector/StMetaBrowserPresenter.class.st
@@ -74,7 +74,10 @@ StMetaBrowserPresenter >> connectPresenters [
 	classes
 		transmitTo: methods
 		transform: [ :aClass | self methodsOf: aClass ]
-		postTransmission: [ :destination | destination selectIndex: 1 ].
+		postTransmission: [ :destination | 
+			methods unfilteredItems: destination items.
+			methods filterInputPresenter clearContent.
+			destination selectIndex: 1 ].
 
 	methods transmitDo: [ :aMethod |
 		self selectedMethod


### PR DESCRIPTION
Fix filtering of methods in MetaBrowserPresenter.

<img width="764" alt="image" src="https://github.com/user-attachments/assets/7be0dc1b-216e-4d33-a3f9-7557748268b7">


Merge first https://github.com/pharo-spec/Spec/pull/1629 and re-run the CI