### PR TITLE
Put back correct refresh icon in inspectors

### DIFF
--- a/src/NewTools-Inspector/StInspectorRefreshCommand.class.st
+++ b/src/NewTools-Inspector/StInspectorRefreshCommand.class.st
@@ -18,7 +18,7 @@ StInspectorRefreshCommand class >> defaultDescription [
 { #category : 'initialization' }
 StInspectorRefreshCommand class >> defaultIconName [
 
-	^ #refresh
+	^ #refreshCircling
 ]
 
 { #category : 'default' }


### PR DESCRIPTION
This commit https://github.com/pharo-spec/NewTools/commit/fb41b460211590f4f372ec44eaa60c3f60daa6b8 introduced a wrong icon for the "refresh" buttons.

It is because the "refresh" icon is actually a simple arrow, while the "refreshCycling", previously refered as "glamorousRefresh" has a double arrow that looks like better for refreshing.

I put it back to the correct one ("refreshcycling") in the inspector, but the core problem is the bad naming of icons which I cannot handle for now (I am in holidays).
My fix is important because in the meantime, the "simple arrow" pointed by "refresh" is really too disturbing :p