### PR TITLE
Add missing callbacks for setting checkboxes and droplists

### DIFF
--- a/src/NewTools-SettingsBrowser/StSettingBooleanPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingBooleanPresenterItem.class.st
@@ -12,8 +12,31 @@ Class {
 { #category : 'initialization' }
 StSettingBooleanPresenterItem >> initializePresenters [ 
 
-	setterPresenter := self newCheckBox.
+	setterPresenter := self newCheckBox
+		whenActivatedDo: [ self updateSetting: self model value: true ];
+		whenDeactivatedDo: [ self updateSetting: self model value: false ].
 	super initializePresenters.
+
+]
+
+{ #category : 'initialization' }
+StSettingBooleanPresenterItem >> updateSetting: aSettingDeclaration value: aBoolean [
+	"Private - Callback for updating aSettingDeclaration with the new receiver's selected item"
+
+	self model targetSelector
+	 ifNil: [ 
+		| modelTarget realTarget |
+		modelTarget := 	self model target.
+		realTarget := modelTarget isClass
+			ifTrue: [ modelTarget name ]
+			ifFalse: [ modelTarget ].
+		(self class environment at: realTarget) 
+			perform: self model setSelector
+			with: aBoolean ] 
+	ifNotNil: [
+		(self model target perform: self model targetSelector) 
+			perform: self model setSelector
+			with: aBoolean ]
 
 ]
 

--- a/src/NewTools-SettingsBrowser/StSettingDropListPresenterItem.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingDropListPresenterItem.class.st
@@ -13,8 +13,25 @@ StSettingDropListPresenterItem >> initializePresenters [
 		items: self model domainValues;
 		display: [ : item | item asString ];
 		selectIndex: self model index;
+		whenSelectedItemChangedDo: [ :item | self updateSetting: item ];
 		yourself.
 	super initializePresenters.
+]
+
+{ #category : 'initialization' }
+StSettingDropListPresenterItem >> updateSetting: aSettingDeclaration [ 
+	"Private - Callback for updating aSettingDeclaration with the new receiver's selected item"
+
+	self model targetSelector
+	 ifNil: [ 
+		self model target 
+			perform: self model setSelector
+			with: aSettingDeclaration default ] 
+	ifNotNil: [
+		(self model target perform: self model targetSelector) 
+			perform: self model setSelector
+			with: aSettingDeclaration default ]
+
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
In the new Settings Browser, live updates of checkboxes and drop lists were not implemented. This PR adds callbacks to update modified settings "in situ".
