### PR TITLE
Fixed linux terminal command, unified method for Windows

### DIFF
--- a/src/NewTools-FileBrowser-Tests/StFileBrowserOpenTerminalCommandTest.class.st
+++ b/src/NewTools-FileBrowser-Tests/StFileBrowserOpenTerminalCommandTest.class.st
@@ -1,0 +1,60 @@
+"
+A StFileBrowserOpenTerminalCommandTest is a test class for testing the behavior of StFileBrowserOpenTerminalCommand
+"
+Class {
+	#name : 'StFileBrowserOpenTerminalCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-FileBrowser-Tests-Commands',
+	#package : 'NewTools-FileBrowser-Tests',
+	#tag : 'Commands'
+}
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> terminalShellCommandTest: aBlock [
+
+	self terminalShellCommandTest: aBlock withPath: '/dev/null' asPath.
+	self terminalShellCommandTest: aBlock withPath: '/dev/null' asFileReference
+]
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> terminalShellCommandTest: aBlock withPath: aPath [
+
+	| command |
+	command := aBlock
+		           value: (StFileBrowserOpenTerminalCommand forContext:
+				            StFileSystemModel new)
+		           value: aPath.
+	self assert: (command includesSubstring: 'dev').
+	self assert: (command includesSubstring: 'null').
+	self deny: (command includesSubstring: 'Path ').
+	self deny: (command includesSubstring: 'File @ ')
+]
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> testOpenLinuxTerminalShellCommand [
+
+	self terminalShellCommandTest: [ :command :path |
+		command openLinuxTerminalShellCommand: path ]
+]
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> testOpenMacTerminalShellCommand [
+
+	self terminalShellCommandTest: [ :command :path |
+		command openMacTerminalShellCommand: path ]
+]
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> testOpenWindowsTerminalShellCommand [
+
+	self terminalShellCommandTest: [ :command :path |
+		command openWindowsTerminalCommand: path ]
+]
+
+{ #category : 'tests' }
+StFileBrowserOpenTerminalCommandTest >> testTerminalShellCommand [
+	"tests for a current platform"
+
+	self terminalShellCommandTest: [ :command :path |
+		command terminalShellCommand: path ]
+]

--- a/src/NewTools-FileBrowser/StFileBrowserOpenTerminalCommand.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserOpenTerminalCommand.class.st
@@ -41,7 +41,7 @@ StFileBrowserOpenTerminalCommand >> openLinuxTerminalShellCommand: aPath [
 	^ String streamContents: [ : stream |
 		stream
 			<< 'gnome-terminal --working-directory=';
-			<< aPath;
+			<< aPath fullName;
 			<< ' &' ]
 ]
 
@@ -70,7 +70,7 @@ StFileBrowserOpenTerminalCommand >> openTerminalOn: aPath [
 ]
 
 { #category : 'private' }
-StFileBrowserOpenTerminalCommand >> openWindowsTerminalOn: aPath [
+StFileBrowserOpenTerminalCommand >> openWindowsTerminalCommand: aPath [
 
 	^ String streamContents: [ : stream |
 		stream
@@ -105,7 +105,7 @@ StFileBrowserOpenTerminalCommand >> terminalShellCommand: aPath [
 	"Answer a <String> with the shell command to open a terminal for the receiver's OS"
 
 	Smalltalk os isWindows
-		ifTrue: [ ^ self openWindowsTerminalOn: aPath ].
+		ifTrue: [ ^ self openWindowsTerminalCommand: aPath ].
 	Smalltalk os isMacOS
 		ifTrue: [ ^ self openMacTerminalShellCommand: aPath ].
 	(Smalltalk os version beginsWith: 'linux')


### PR DESCRIPTION
Linux open terminal command no longer ends up in an error because of improper use of Streams.
Fixes https://github.com/pharo-spec/NewTools/issues/875

Unrelated to the issue, windows variant of the command generating method is now named similarly to others.