### PR TITLE
Multiple FileBrowser directory handling fixes for Windows

### DIFF
--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -49,11 +49,13 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 	"Expand the receiver's tree to aFileLocator reference"
 
 	| path aPathForSpec currentNode |
-	path := aFileLocator asPath segments asOrderedCollection.
-	aPathForSpec := OrderedCollection new.
-	aPathForSpec add: 1.
+	path := aFileLocator absolutePath segments asOrderedCollection.
+	aPathForSpec := OrderedCollection with: 1.
 
 	currentNode := directoryTreePresenter roots anyOne.
+	Smalltalk os isWindows ifTrue: [
+		currentNode := currentNode asFileReference parent.
+		aPathForSpec := OrderedCollection new ].
 
 	path do: [ :aPart |
 		| subdirs |
@@ -69,10 +71,11 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 	directoryTreePresenter
 		selectPath: aPathForSpec
 		scrollToSelection: true.
-		
+
 	"The Morphic `configureScrolling` is executed **AFTER** the desired scroll was configured from the `StDirectoryTreePresenter`. Furthermore, the `configureScrolling` uses the `desiredVisibleRow` which is always set to 1. This statement updates the desired visible row to the last visible index of whatever the selection is pointing to."
 
-	directoryTreePresenter verticalAlignment desiredVisibleRow: directoryTreePresenter verticalAlignment lastVisibleRowIndex.
+	directoryTreePresenter verticalAlignment desiredVisibleRow:
+		directoryTreePresenter verticalAlignment lastVisibleRowIndex
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StFileBrowserBookmark.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserBookmark.class.st
@@ -12,23 +12,30 @@ Class {
 	#tag : 'Bookmark'
 }
 
-{ #category : 'defaultClassVariable' }
+{ #category : 'default bookmarks' }
+StFileBrowserBookmark class >> createDriveBookmarks [
+
+	^ StFileSystemItemWrapper roots
+		  collect: [ :each |
+			  self
+				  name: each label
+				  location: each asFileReference
+				  icon: each icon ]
+		  as: OrderedCollection
+]
+
+{ #category : 'default bookmarks' }
 StFileBrowserBookmark class >> defaultBookmarks [
 
 	| presets |
-	
-	presets := (Smalltalk os isWindows
-		           ifTrue: [ self windowsDrives ]
-		           ifFalse: [ { self root } ]) asOrderedCollection.
-	presets addAll: { 
-			self home.
-			self workingDirectory.
-			self desktop.
-			self documents.
-			self downloads }.
+	presets := self createDriveBookmarks , {
+		           self home.
+		           self workingDirectory.
+		           self desktop.
+		           self documents.
+		           self downloads }.
 
-	^ OrderedCollection with:
-		  (StFileBrowserGroupBookmark
+	^ OrderedCollection with: (StFileBrowserGroupBookmark
 			   name: 'Bookmarks'
 			   collection: presets
 			   iconName: #book)
@@ -84,30 +91,11 @@ StFileBrowserBookmark class >> name: aName location: aLocation icon: anIcon [
 ]
 
 { #category : 'default bookmarks' }
-StFileBrowserBookmark class >> root [
-
-	^ self
-		  name: '/'
-		  location: FileLocator root
-		  icon: (self iconNamed: #smallWindow)
-]
-
-{ #category : 'default bookmarks' }
 StFileBrowserBookmark class >> tmp [
 	^ StFileBrowserBookmark
 		name: 'tmp'
 		location: FileLocator temp asFileReference
 		icon: (self iconNamed: #book)
-]
-
-{ #category : 'default bookmarks' }
-StFileBrowserBookmark class >> windowsDrives [
-
-	^ FileLocator root asFileReference directories collect: [ :each | 
-		  self
-			  name: each basename
-			  location: each
-			  icon: (self iconNamed: #smallWindow) ]
 ]
 
 { #category : 'default bookmarks' }

--- a/src/NewTools-FileBrowser/StFileSystemItemWrapper.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemItemWrapper.class.st
@@ -42,8 +42,12 @@ StFileSystemItemWrapper class >> on: aFileReference [
 StFileSystemItemWrapper class >> roots [
 
 	^ Smalltalk os isWindows
-		ifTrue: [ FileSystem root directories collect: [:each | StRootDriveWrapper on: each ] ]
-		ifFalse: [ Array with: (StRootDirectoryWrapper on: FileSystem root) ]
+		  ifTrue: [
+			  FileSystem root directories
+				  select: [ :each | each exists and: [ each isReadable ] ]
+				  thenCollect: [ :each | StRootDriveWrapper on: each ] ]
+		  ifFalse: [
+		  Array with: (StRootDirectoryWrapper on: FileSystem root) ]
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-FileBrowser/StFileSystemModel.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemModel.class.st
@@ -34,7 +34,8 @@ StFileSystemModel class >> defaultDirectory [
 StFileSystemModel class >> initializeBookmarks [
 	"Set the initial <Collection> of receiver's bookmarks"
 
-	Bookmarks := StFileBrowserBookmark defaultBookmarks.
+	<script>
+	Bookmarks := StFileBrowserBookmark defaultBookmarks
 ]
 
 { #category : 'defaults' }

--- a/src/NewTools-FileBrowser/StPathPresenter.class.st
+++ b/src/NewTools-FileBrowser/StPathPresenter.class.st
@@ -64,8 +64,12 @@ StPathPresenter >> addSeparator [
 { #category : 'accessing' }
 StPathPresenter >> file: aFile [
 
+	| parts |
 	self initializeLayout.
-	aFile asAbsolute fullPath withParents
+	parts := aFile asAbsolute fullPath withParents.
+	Smalltalk os isWindows ifTrue: [
+		parts first isRoot ifTrue: [ parts := parts copyWithoutFirst ] ].
+	parts
 		do: [ :path | self addLinkTo: path ]
 		separatedBy: [ self addSeparator ]
 ]


### PR DESCRIPTION
Mulitiple FileBrowser fixes for Windows:
- Directory tree now scrolls to current directory (used to only work for Linux)
- Drives without any partitions are no longer listed amongst drives (a Windows 11 update started assinging drive letters to such drives)
- Breadcrumbs no longer contain Root part on Windows (used to result in error when used as there is no real single root)
- Unified drive icons between "directories" and bookmarks
- Bookmarks now (re)use already existing code for finding roots/drives instead of using own implementation

And a fix for all platforms:
- Working directory bookmark now opens the actual working directory instead of root