### PR TITLE
Register new File Browser in tools registry

### DIFF
--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -39,6 +39,13 @@ StFileSystemPresenter class >> buildCommandsGroupWith: presenter forRoot: rootCo
 				yourself)
 ]
 
+{ #category : 'class initialization' }
+StFileSystemPresenter class >> initialize [
+	"Register myself as the file list tool once I'm loaded."
+
+	Smalltalk tools fileListTool: self
+]
+
 { #category : 'defaults' }
 StFileSystemPresenter class >> lastVisitedDirectory [
 


### PR DESCRIPTION
Alternative to https://github.com/pharo-spec/NewTools/pull/880

I'm not putting this in the post load of the baseline because if we load a group of the baseline we do not know if the file browser will be loaded or not. Pharo seems to load a subgroup of NewTools first and the file list is not in this subgroup.