### PR TITLE
Add package ‘NewTools-DebugPointsBrowser-Tests’ with a subclass of SpSmokeTest for DebugPointBrowserPresenter

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -67,6 +67,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Debugger-Breakpoints-Tools' with: [ spec requires: #( 'NewTools-Inspector' ) ];
 			"Debug points"
 			package: 'NewTools-DebugPointsBrowser' with: [spec requires: #( 'NewTools-SpTextPresenterDecorators' )];
+			package: 'NewTools-DebugPointsBrowser-Tests' with: [ spec requires: #( 'NewTools-DebugPointsBrowser' ) ];
 			package: 'NewTools-ObjectCentricDebugPoints' with: [spec requires: #( 'NewTools-DebugPointsBrowser' 'NewTools-Inspector' 'NewTools-Debugger' )];
 			package: 'NewTools-ProjectLoader';
 			package: 'NewTools-ProjectLoader-Microdown';
@@ -132,6 +133,7 @@ BaselineOfNewTools >> baseline: spec [
 				    	'NewTools-Debugger-Fuel-Tests' 
 					 	'NewTools-Utils'
 						'NewTools-DebugPointsBrowser'
+						'NewTools-DebugPointsBrowser-Tests'
 						'NewTools-ObjectCentricDebugPoints' );
 			group: 'Spotter' with: #( 
 						'NewTools-Morphic-Spotter' 

--- a/src/NewTools-DebugPointsBrowser-Tests/DebugPointBrowserPresenterTest.class.st
+++ b/src/NewTools-DebugPointsBrowser-Tests/DebugPointBrowserPresenterTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'DebugPointBrowserPresenterTest',
+	#superclass : 'SpSmokeTest',
+	#category : 'NewTools-DebugPointsBrowser-Tests',
+	#package : 'NewTools-DebugPointsBrowser-Tests'
+}
+
+{ #category : 'accessing' }
+DebugPointBrowserPresenterTest >> adapter [
+
+	self shouldNotImplement
+]
+
+{ #category : 'accessing' }
+DebugPointBrowserPresenterTest >> classToTest [
+
+	^ DebugPointBrowserPresenter
+]

--- a/src/NewTools-DebugPointsBrowser-Tests/package.st
+++ b/src/NewTools-DebugPointsBrowser-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-DebugPointsBrowser-Tests' }


### PR DESCRIPTION
This pull request adds a package ‘NewTools-DebugPointsBrowser-Tests’ with a subclass of SpSmokeTest for DebugPointBrowserPresenter as I suggested [in Pharo issue #17316](https://github.com/pharo-project/pharo/issues/17316#issuecomment-2445274643) so that there is a test testing that the browser can at least be opened (`#testOpen` inherited from SpSmokeTest).