### PR TITLE
Configure Setting Browser initialization properties

### DIFF
--- a/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsMainPresenter.class.st
@@ -139,10 +139,10 @@ StSettingsMainPresenter >> followPath: aStSettingNode in: aCollection [
 { #category : 'initialization' }
 StSettingsMainPresenter >> initialize [
 
-	super initialize.
 	self currentApplication
-		propertyAt: #settingsTree ifAbsentPut: StSettingsTree new;
-		styleSheet: self class styleSheet
+		propertyAt: #settingsTree ifAbsentPut: [ StSettingsTree new ];
+		styleSheet: self class styleSheet.
+	super initialize.
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This PR includes a little fix to configure the Setting Browser main presenter initialization before other presenters initialization. This is needed because sending `initialize` before configuring the styles refers to styling elements that aren't available until later.
