### PR TITLE
Make playgrounds refresh styling after removing bindings

### DIFF
--- a/src/NewTools-Playground/StPlaygroundBindingsPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundBindingsPresenter.class.st
@@ -200,7 +200,7 @@ StPlaygroundBindingsPresenter >> newInspectorWithTransmission: aClass on: aBindi
 { #category : 'actions' }
 StPlaygroundBindingsPresenter >> removeAllBindings [
 	
-	parent interactionModel removeAllBindings.
+	parent removeAllBindings.
 	self updatePresenterKeepingSelection
 ]
 

--- a/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
@@ -340,7 +340,8 @@ StPlaygroundPagePresenter >> preferredExtent: aSize [
 { #category : 'actions' }
 StPlaygroundPagePresenter >> removeAllBindings [
 
-	self interactionModel removeAllBindings
+	self interactionModel removeAllBindings.
+	self text refreshStyling.
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagePresenter.class.st
@@ -337,6 +337,12 @@ StPlaygroundPagePresenter >> preferredExtent: aSize [
 	self class preferredExtent: aSize
 ]
 
+{ #category : 'actions' }
+StPlaygroundPagePresenter >> removeAllBindings [
+
+	self interactionModel removeAllBindings
+]
+
 { #category : 'accessing' }
 StPlaygroundPagePresenter >> selectAll [
 	


### PR DESCRIPTION
This pull request makes playgrounds refresh their styling after bindings are removed, which fixes [Pharo issue #17190](https://github.com/pharo-project/pharo/issues/17190).

[Spec pull request #1655](https://github.com/pharo-spec/Spec/pull/1655) needs to be merged first.