### PR TITLE
Discard Finder unnecessary evaluation with time out in the Compiler

### DIFF
--- a/src/NewTools-Finder/OpalCompiler.extension.st
+++ b/src/NewTools-Finder/OpalCompiler.extension.st
@@ -3,11 +3,15 @@ Extension { #name : 'OpalCompiler' }
 { #category : '*NewTools-Finder' }
 OpalCompiler >> evaluateWithTimeOut: anInteger [ 
 
-	| runner |
+	"| runner |
 
 	runner := TKTLocalProcessTaskRunner new.
 	^ runner 
 		schedule: [ self evaluate ] asTask
-		timeout: anInteger milliSeconds.
+		timeout: anInteger milliSeconds."
+		
+	"See issue https://github.com/pharo-project/pharo/issues/16759"
+	self flag: #ToDo.
+	^ self evaluate
 
 ]

--- a/src/NewTools-Finder/StFinderSearch.class.st
+++ b/src/NewTools-Finder/StFinderSearch.class.st
@@ -26,6 +26,13 @@ Class {
 }
 
 { #category : 'accessing' }
+StFinderSearch >> application [
+
+	^ application 
+		ifNil: [ StPharoApplication current ]
+]
+
+{ #category : 'accessing' }
 StFinderSearch >> application: anApplication [ 
 	application := anApplication
 ]


### PR DESCRIPTION
This is a temporary solution that fixes https://github.com/pharo-project/pharo/issues/16759

The TaskIt scheduled execution with time out is not working well, and it needs to be checked before integration in the New Finder.

Also, fix the missing application in New Finder