### PR TITLE
Sorting items in bag inspector by default

### DIFF
--- a/src/NewTools-Inspector-Extensions/Bag.extension.st
+++ b/src/NewTools-Inspector-Extensions/Bag.extension.st
@@ -2,20 +2,26 @@ Extension { #name : 'Bag' }
 
 { #category : '*NewTools-Inspector-Extensions' }
 Bag >> inspectionItems: aBuilder [
-	<inspectorPresentationOrder: 0 title: 'Items'> 
 
-	^ aBuilder newTable		
-		addColumn: (SpStringTableColumn new 
-			title: 'Items';
-			evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: each key ];
-			beNotExpandable;
-			beSortable;
-			yourself);
-		addColumn: (SpStringTableColumn new  
-			title: 'Occurences'; 
-			evaluated: [ :each | StObjectPrinter asTruncatedTextFrom: (self occurrencesOf: each key) ];
-			beSortable;
-			yourself);
-		items: contents associations;
-		yourself
+	<inspectorPresentationOrder: 0 title: 'Items'>
+	| sortFuction |
+	sortFuction := [ :c1 :c2 | c1 value > c2 value ].
+
+	^ aBuilder newTable
+		  addColumn: (SpStringTableColumn new
+				   title: 'Items';
+				   evaluated: [ :each |
+					   StObjectPrinter asTruncatedTextFrom: each key ];
+				   beNotExpandable;
+				   beSortable;
+				   yourself);
+		  addColumn: (SpStringTableColumn new
+				   title: 'Occurences';
+				   evaluated: [ :each |
+					   StObjectPrinter asTruncatedTextFrom:
+							   (self occurrencesOf: each key) ];
+				   beSortable;
+				   yourself);
+		  items: (contents associations sort: sortFuction);
+		  yourself
 ]


### PR DESCRIPTION
Fix pharo-project/pharo#17419
Items can already be sorted when clicking on the column name.
With this, the items are sorted by default at the creation of the inspector.

with @fouziray and @ValentinBourcier 