### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NewTools
-All development tools for Pharo, developed with Spec.
+All development tools for Pharo, developed with Spec2.
 Available by default in Pharo 10.
 
 [![NewTools-Pharo-Integration](https://github.com/pharo-spec/NewTools/actions/workflows/newtools-all.yml/badge.svg)](https://github.com/pharo-spec/NewTools/actions/workflows/newtools-all.yml)  


### PR DESCRIPTION
We should be correct here: NewTools are mostly based on Spec2 framework