### PR TITLE
Add drag&drop support to inspectors

### DIFF
--- a/src/NewTools-Inspector/StInspectorAssociationNode.class.st
+++ b/src/NewTools-Inspector/StInspectorAssociationNode.class.st
@@ -13,6 +13,12 @@ StInspectorAssociationNode class >> hostObject: anObject index: index [
 		yourself
 ]
 
+{ #category : 'testing' }
+StInspectorAssociationNode >> canSave [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StInspectorAssociationNode >> key [
 

--- a/src/NewTools-Inspector/StInspectorIndexedNode.class.st
+++ b/src/NewTools-Inspector/StInspectorIndexedNode.class.st
@@ -27,6 +27,12 @@ StInspectorIndexedNode >> = anObject [
 	^ super = anObject and: [ index = anObject index ]
 ]
 
+{ #category : 'testing' }
+StInspectorIndexedNode >> canSave [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StInspectorIndexedNode >> errorMessage [
 	^ 'error obtaining indexed variable value'

--- a/src/NewTools-Inspector/StInspectorNode.class.st
+++ b/src/NewTools-Inspector/StInspectorNode.class.st
@@ -42,6 +42,12 @@ StInspectorNode >> asInspectorModel [
 	^ StInspectorModel on: self rawValue
 ]
 
+{ #category : 'testing' }
+StInspectorNode >> canSave [
+
+	^ false
+]
+
 { #category : 'accessing' }
 StInspectorNode >> children [ 
 	

--- a/src/NewTools-Inspector/StInspectorSlotNode.class.st
+++ b/src/NewTools-Inspector/StInspectorSlotNode.class.st
@@ -25,6 +25,12 @@ StInspectorSlotNode >> = anObject [
 	^ super = anObject and: [ slot = anObject slot ]
 ]
 
+{ #category : 'testing' }
+StInspectorSlotNode >> canSave [
+
+	^ true
+]
+
 { #category : 'accessing' }
 StInspectorSlotNode >> errorMessage [
 	^ 'error obtaining variable value'

--- a/src/NewTools-Inspector/StRawInspectionPresenter.class.st
+++ b/src/NewTools-Inspector/StRawInspectionPresenter.class.st
@@ -84,6 +84,20 @@ StRawInspectionPresenter >> initializePresenters [
 	attributeTable := self newTreeTable
 		beResizable;
 		actions: self rootCommandsGroup;
+		dragEnabled: true;
+		whenDragStartDo: [ :announcement |
+			announcement transfer description: announcement transfer passenger first stringValue ];
+		wantsDrop: [ :transfer |
+			transfer target notNil and: [
+				transfer target canSave and: [
+					transfer passenger isArray and: [
+						transfer passenger size = 1 and: [
+							transfer passenger first isKindOf: StInspectorNode ] ] ] ] ];
+		acceptDrop: [ :transfer |
+			| value |
+			value := transfer passenger first value.
+			transfer target save: (transfer shouldCopy ifTrue: [ value copy ] ifFalse: [ value ]).
+			self step ];
 		yourself.
 	self addVariablesColumn.
 	self addValuesColumn.


### PR DESCRIPTION
This pull request adds drag&drop support to inspectors as proposed in [Pharo issue #15233](https://github.com/pharo-project/pharo/issues/15233). This allows using drag&drop to assign the value of a variable from the ‘Raw’ tab of one inspector to a variable on the ‘Raw’ tab of another, or the same, inspector. When the shift key is held, a copy of the value is assigned instead. Adding support to other tabs is left to ‘future work’, as is allowing dragging, say, a class between a browser and an inspector or vice-versa; currently, only dragging from an inspector to another inspector is supported. A known bug is that the value that is assigned is determined at the drop rather than at the start of the drag, which doesn’t take into account that the value could change during the drag. To better fit the analogy of physically moving the value, I considered a version in which nil would be assigned to the first variable (unless shift is held), but rejected that as likely not usually being the desired behavior.