### PR TITLE
Branch: Making Playground Memorizing its Size

### DIFF
--- a/src/NewTools-Core/StPresenter.class.st
+++ b/src/NewTools-Core/StPresenter.class.st
@@ -7,3 +7,9 @@ Class {
 	#package : 'NewTools-Core',
 	#tag : 'Presenters'
 }
+
+{ #category : 'accessing' }
+StPresenter class >> defaultPreferredExtent [
+	
+	^ 600@400
+]

--- a/src/NewTools-Core/StTPresenter.trait.st
+++ b/src/NewTools-Core/StTPresenter.trait.st
@@ -14,6 +14,12 @@ StTPresenter classSide >> currentApplication [
 	^ SpToolCurrentApplication value ifNil: [ StPharoApplication current ]
 ]
 
+{ #category : 'accessing' }
+StTPresenter classSide >> defaultPreferredExtent [
+
+	^ 600@400
+]
+
 { #category : 'instance creation' }
 StTPresenter classSide >> new [
 
@@ -37,24 +43,13 @@ StTPresenter classSide >> owner: anOwningPresenter on: aDomainObject [
 		model: aDomainObject
 ]
 
-{ #category : 'accessing' }
-StTPresenter classSide >> preferredExtent [
-
-	^ 600@400
-]
-
 { #category : 'initialization' }
 StTPresenter >> initializeWindow: aWindowPresenter [
 	"All tools should call its parent"
 
+	super initializeWindow: aWindowPresenter.
 	self traversePresentersDo: [ :each |
 		each addWindowShortcutsTo: aWindowPresenter ]
-]
-
-{ #category : 'accessing' }
-StTPresenter >> preferredExtent [
-
-	^ self class preferredExtent
 ]
 
 { #category : 'private' }

--- a/src/NewTools-Inspector/StInspectorPresenter.class.st
+++ b/src/NewTools-Inspector/StInspectorPresenter.class.st
@@ -171,7 +171,6 @@ StInspectorPresenter >> initializeWindow: aWindowPresenter [
 	aWindowPresenter 
 		title: self windowTitle;
 		windowIcon: self windowIcon;
-		initialExtent: self class defaultPreferredExtent;
 		whenOpenedDo: [ self takeKeyboardFocus ];
 		whenFocusReceivedDo: [ self startProcessing ];
 		whenFocusLostDo: [ self stopProcessing ];

--- a/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
@@ -138,7 +138,6 @@ StPlaygroundPagesPresenter >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter 
 		title: self class defaultTitle;
-		initialExtent: self initialExtent;
 		whenOpenedDo: [ pageList takeKeyboardFocus ]
 ]
 


### PR DESCRIPTION
Making sure that preferredExtent redefinition does override the accessor of the superclass