### PR TITLE
Moved IRMethod extension to OCIRMethod

### DIFF
--- a/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'IRMethod' }
+Extension { #name : 'OCIRMethod' }
 
 { #category : '*NewTools-Inspector-Extensions' }
-IRMethod >> inpectionIr [
+OCIRMethod >> inpectionIr [
 	<inspectorPresentationOrder: 40 title: 'Symbolic'>
 
 	^ SpTextPresenter new 


### PR DESCRIPTION
`IRMethod` got renamed to `OCIRMethod` in Pharo 13, but `inspectionIr` extension method (from NewTools) was still in `IRMethod` (its only method). It caused `CompiledMethod` "IR" inspection to fail. This PR moves the method. Fixes #973 and #974