### PR TITLE
Fix selection in save file presenter

### DIFF
--- a/src/NewTools-FileBrowser/StExtensionsFilter.class.st
+++ b/src/NewTools-FileBrowser/StExtensionsFilter.class.st
@@ -103,7 +103,6 @@ StExtensionsFilter >> predicate: aFileReference [
 
 	aFileReference isDirectory ifTrue: [ ^ true ].
 
-	^ (self extensionsWithDots anySatisfy: [ :extension | 
-		   aFileReference basename asLowercase endsWith: extension ]) and: [ 
-		  StAllFilter new predicate: aFileReference ]
+	^ self extensionsWithDots anySatisfy: [ :extension |
+		  aFileReference basename asLowercase endsWith: extension ]
 ]

--- a/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileNavigationSystemPresenter.class.st
@@ -362,7 +362,7 @@ StFileNavigationSystemPresenter >> nameText [
 { #category : 'accessing' }
 StFileNavigationSystemPresenter >> nameText: aString [
 	"Set the receive's name text to aString. This is displayed in a text presenter to display the currently selected file, or the name of a new file to be saved"
-	
+
 	nameText text: aString.
 ]
 

--- a/src/NewTools-FileBrowser/StPathBreadcrumbPresenter.class.st
+++ b/src/NewTools-FileBrowser/StPathBreadcrumbPresenter.class.st
@@ -134,8 +134,10 @@ StPathBreadcrumbPresenter >> pathTextChangedTo: aStringOrText [
 { #category : 'callbacks' }
 StPathBreadcrumbPresenter >> updatePathSelection: fileReference [
 	"Private - Receiver's path has changed, update owner's presenters. Prevent recursive updating because path selection could be triggered from file table or file tree presenters"
-	
-	self owner model currentDirectory = fileReference
-		ifFalse: [ self owner openFolder: fileReference ].
-	self owner nameText: fileReference basename.
+
+	self owner model currentDirectory = fileReference ifFalse: [
+		self owner openFolder: fileReference ].
+
+	fileReference isDirectory ifFalse: [
+		self owner nameText: fileReference basename ]
 ]

--- a/src/NewTools-FileBrowser/StSaveFilePresenter.class.st
+++ b/src/NewTools-FileBrowser/StSaveFilePresenter.class.st
@@ -75,6 +75,12 @@ StSaveFilePresenter >> initializePresenters [
 	fileNavigationSystem layout: self rightPaneLayout
 ]
 
+{ #category : 'showing' }
+StSaveFilePresenter >> openModal [
+
+	^ self asModalWindow open
+]
+
 { #category : 'layout' }
 StSaveFilePresenter >> rightPaneLayout [
 
@@ -88,8 +94,13 @@ StSaveFilePresenter >> rightPaneLayout [
 StSaveFilePresenter >> selectedEntry [
 
 	| entry |
-	entry := super selectedEntry ifNil: [ ^ nil ].
-	entry := filter addExtensionTo: entry.
+	"This dialog returns a file reference to the current selected directory with the selected name text"
+	entry := self currentDirectory / self nameText.
+
+	"Add the extension if not already there"
+	(self filter predicate: entry)
+		ifFalse: [ entry := self filter addExtensionTo: entry ].
+
 	entry exists ifFalse: [ ^ entry ].
 	entry = confirmedOverwrite ifTrue: [ ^ entry ].
 	(self application confirm: (self existingFileMessage: entry))


### PR DESCRIPTION
Part 2 of fix for https://github.com/pharo-project/pharo/issues/17549

 - now supports selecting unexisting files to save (dah!)
 - Breadcrums should only show directories
 - name text updates with file names but not directory names (which break save file selection)
 - only add extensions if not already there

Part 1 is in Pharo: https://github.com/pharo-project/pharo/pull/17767