### PR TITLE
Update world menu entry for the finder

### DIFF
--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -144,12 +144,12 @@ StFinderPresenter class >> defaultPreferredExtent [
 StFinderPresenter class >> menuFinderCommandOn: aBuilder [
 	<worldMenu>
 
-	(aBuilder item: #NewFinder)
+	(aBuilder item:  #Finder)
 		parent: #Searching ;
-		action: [ StFinderPresenter open ];
-		label: 'New Finder';
+		action: [ self open ];
+		label: 'Finder';
 		order: 2; 
-		help: 'Open the new Finder tool.';
+		help: 'Open the Finder tool.';
 		iconName: #smallFind.
 
 ]


### PR DESCRIPTION
The finder is called "New Finder" but we have only one in the image now. I propose to rename it just Finder

<img width="295" alt="image" src="https://github.com/user-attachments/assets/7ee99eae-5361-42d1-9b8d-6361460095bb" />
