### PR TITLE
[Suggestion] Making sure the 'save as' treeNavigationPresenter points to the right file system   

### DIFF
--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -56,6 +56,11 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 	Smalltalk os isWindows ifTrue: [
 		currentNode := currentNode asFileReference parent.
 		aPathForSpec := OrderedCollection new ].
+	
+	"This code is (a certainly wrong) way to ensure the treeNavigationPresenter widget points to the right fileSystem (that could be a MemoryStore) as it search for roots of the disk and doesn't allow to check in a MemoryStore "
+	"(currentNode fileReference fileSystem = aFileLocator fileSystem)
+        ifFalse: [ directoryTreePresenter roots: { StRootDirectoryWrapper on: aFileLocator fileSystem root }.
+                    currentNode fileReference: aFileLocator ]."
 
 	path do: [ :aPart |
 		| subdirs |


### PR DESCRIPTION
Hello, this snippet is trying to link the widget file system to the right one, this is useful when working with artificial file systems.

This was a fix done during a sprint to make a new test pass. 
