### PR TITLE
Moved shortcuts browser from Pharo to NewTools

### DIFF
--- a/src/NewTools-ShortcutsBrowser/KMCategory.extension.st
+++ b/src/NewTools-ShortcutsBrowser/KMCategory.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'KMCategory' }
+
+{ #category : '*NewTools-ShortcutsBrowser' }
+KMCategory >> scopeName [
+
+	^  self name
+]

--- a/src/NewTools-ShortcutsBrowser/KMKeymap.extension.st
+++ b/src/NewTools-ShortcutsBrowser/KMKeymap.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'KMKeymap' }
+
+{ #category : '*NewTools-ShortcutsBrowser' }
+KMKeymap >> scope [
+
+	^ KMRepository default categories 
+		detect: [ : cat | cat keymaps includes: self ]
+]
+
+{ #category : '*NewTools-ShortcutsBrowser' }
+KMKeymap >> scopeName [
+
+	^  self scope scopeName
+]

--- a/src/NewTools-ShortcutsBrowser/StKMCategory.class.st
+++ b/src/NewTools-ShortcutsBrowser/StKMCategory.class.st
@@ -1,0 +1,101 @@
+Class {
+	#name : 'StKMCategory',
+	#superclass : 'Object',
+	#instVars : [
+		'categoryName',
+		'keymaps'
+	],
+	#category : 'NewTools-ShortcutsBrowser',
+	#package : 'NewTools-ShortcutsBrowser'
+}
+
+{ #category : 'copying' }
+StKMCategory >> , aKMCategory [
+
+	keymaps addAll: aKMCategory allEntries keymaps
+]
+
+{ #category : 'comparing' }
+StKMCategory >> = anObject [
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ categoryName = anObject categoryName and: [
+		  keymaps = anObject keymaps ]
+]
+
+{ #category : 'adding' }
+StKMCategory >> addAllShortcuts: aCollection [ 
+	"Add all keymaps in aCollection to the receiver"
+	
+	self keymaps addAll: aCollection
+]
+
+{ #category : 'accessing' }
+StKMCategory >> categoryName [
+
+	^ categoryName
+]
+
+{ #category : 'accessing' }
+StKMCategory >> categoryName: anObject [
+
+	categoryName := anObject
+]
+
+{ #category : 'comparing' }
+StKMCategory >> hash [
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ categoryName hash bitXor: keymaps hash
+]
+
+{ #category : 'accessing' }
+StKMCategory >> icon [
+
+	^ self iconNamed: self systemIconName
+]
+
+{ #category : 'initialization' }
+StKMCategory >> initialize [
+
+	super initialize.
+	keymaps := OrderedCollection new
+]
+
+{ #category : 'accessing' }
+StKMCategory >> keymaps [
+
+	^ keymaps
+]
+
+{ #category : 'accessing' }
+StKMCategory >> keymaps: anObject [
+
+	keymaps := anObject
+]
+
+{ #category : 'accessing' }
+StKMCategory >> model [
+	"Required by <SpDropListPresenter> ?"
+
+	^ self
+]
+
+{ #category : 'accessing' }
+StKMCategory >> name [
+
+	^  self categoryName
+]
+
+{ #category : 'printing' }
+StKMCategory >> printOn: aStream [
+	"Generate a string representation of the receiver based on its instance variables."
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' [';
+		print: categoryName;
+		nextPutAll: ']'
+]

--- a/src/NewTools-ShortcutsBrowser/StShortcutsBrowserPresenter.class.st
+++ b/src/NewTools-ShortcutsBrowser/StShortcutsBrowserPresenter.class.st
@@ -1,0 +1,198 @@
+"
+I am a shortcut browser that allows to see the available Pharo's shortcuts 
+"
+Class {
+	#name : 'StShortcutsBrowserPresenter',
+	#superclass : 'StPresenter',
+	#instVars : [
+		'actionBar',
+		'categoryList',
+		'shortcutTable',
+		'inputPresenter'
+	],
+	#category : 'NewTools-ShortcutsBrowser',
+	#package : 'NewTools-ShortcutsBrowser'
+}
+
+{ #category : 'accessing' }
+StShortcutsBrowserPresenter class >> defaultPreferredExtent [
+
+	^ 900 @ 650
+]
+
+{ #category : 'instance creation' }
+StShortcutsBrowserPresenter class >> descriptionText [
+
+	^ 'Show the system''s shortcuts'
+]
+
+{ #category : 'accessing' }
+StShortcutsBrowserPresenter class >> icon [
+
+	^ self iconNamed: #keymapBrowser
+]
+
+{ #category : 'instance creation' }
+StShortcutsBrowserPresenter class >> menuCommandOn: aBuilder [
+	<worldMenu>
+
+	(aBuilder item: 'Shortcuts Browser')
+		action: [ self open ];
+		order: 34;
+		parent: #Tools;
+		icon: self icon;
+		help: self descriptionText
+]
+
+{ #category : 'instance creation' }
+StShortcutsBrowserPresenter class >> open [
+
+	<script>
+	^ (self newApplication: StPharoApplication current) open
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> allAPIsEntry [
+	"Set the receiver's category items to a list of categories in aCollectionOfSymbols.
+	We also build an 'All' category including all keymaps in aCollectionOfSymbols"
+
+	| newCategoryItem |
+	newCategoryItem := StKMCategory new categoryName: 'All'.
+	KMRepository default categories inject: newCategoryItem into: [ :a :b | a , b ].
+	newCategoryItem addAllShortcuts: self shortcutActivationCmdInstances.
+	^ newCategoryItem
+]
+
+{ #category : 'callbacks' }
+StShortcutsBrowserPresenter >> browseKeyMapMethod: aKMKeyMap [
+
+	self application tools browser openOnMethod: aKMKeyMap action method
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> connectPresenters [
+
+	categoryList transmitTo: shortcutTable transform: [ :item | self keymapsAtCategory: item model ].
+	inputPresenter whenTextChangedDo: [ :text | self filterTable: text ].
+	shortcutTable whenActivatedDo: [ :item | self inspectKeyMap: item selectedItem ]
+]
+
+{ #category : 'layout' }
+StShortcutsBrowserPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  spacing: 6;
+		  add: (SpBoxLayout newLeftToRight
+				   add: 'Filter scopes' expand: false;
+				   add: categoryList;
+				   yourself)
+		  expand: false;
+		  add: inputPresenter expand: false;
+		  add: shortcutTable;
+		  add: actionBar withConstraints: [ :c | c height: 25 ];
+		  yourself
+]
+
+{ #category : 'callbacks' }
+StShortcutsBrowserPresenter >> filterTable: aText [
+
+	| newItems |
+	aText ifEmpty: [
+		shortcutTable items: (self keymapsAtCategory: categoryList selectedItem).
+		^ self ].
+
+	newItems := (self keymapsAtCategory: categoryList selectedItem) select: [ :each |
+		            { each name. each scopeName. each description } anySatisfy: [ :aString | 
+								aString includesSubstring: aText caseSensitive: false ] ].
+	shortcutTable items: newItems
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> initialize [
+
+	| shortcutCategories |
+	super initialize.
+
+	shortcutCategories := { self allAPIsEntry } , self shortcutActivationCategoriesItems
+	                      , (KMRepository default categories keys collect: [ :e | KMRepository default categoryForName: e ]).
+	categoryList items: shortcutCategories
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> initializePresenters [
+
+	categoryList := self newDropList
+		                display: [ :category | category name ];
+		                yourself.
+	inputPresenter := self newTextInput
+		                  placeholder: 'Filter';
+		                  yourself.
+
+	shortcutTable := self newTable.
+	shortcutTable
+		activateOnDoubleClick;
+		addColumn: (SpStringTableColumn new
+				 title: 'Name';
+				 evaluated: #name;
+				 beSortable;
+				 yourself);
+		addColumn: (SpStringTableColumn title: 'Shortcut' evaluated: #shortcut);
+		addColumn: (SpStringTableColumn title: 'Description' evaluated: #description);
+		addColumn: (SpStringTableColumn new
+				 title: 'Scope';
+				 evaluated: [ :each | each scopeName ];
+				 beSortable;
+				 width: 150;
+				 yourself);
+		beResizable.
+
+	actionBar := self newActionBar.
+	actionBar
+		addLast: (SpButtonPresenter new
+				 action: [ self browseKeyMapMethod: shortcutTable selectedItem  ];
+				 label: 'Browse';
+				 yourself);
+		addLast: (SpButtonPresenter new
+				 action: [ self inspectKeyMap: shortcutTable selectedItem ];
+				 label: 'Inspect';
+				 yourself)
+]
+
+{ #category : 'callbacks' }
+StShortcutsBrowserPresenter >> inspectKeyMap: aKMKeyMap [
+
+	self application tools inspector openOn: aKMKeyMap
+]
+
+{ #category : 'callbacks' }
+StShortcutsBrowserPresenter >> keymapsAtCategory: aKMCategoryOrKMCategoryAll [
+	"Answer a <Collection> of keymaps"
+	^ aKMCategoryOrKMCategoryAll keymaps
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> shortcutActivationCategoriesItems [
+	"Answer a <Collection> of <KMCategoryItemPresenter> representing each a category of keymaps created using the Commander 1 framework"
+	
+	| shortcutActivationCategories |
+	shortcutActivationCategories := (self shortcutActivationCmdInstances groupedBy: [ :cmdShortcutActivation |
+		                                 cmdShortcutActivation annotatedClass packageName ]) values.
+
+	^ shortcutActivationCategories collect: [ :keymaps |
+		  StKMCategory new
+			  categoryName: keymaps anyOne annotatedClass packageName;
+			  keymaps: keymaps;
+			  yourself ]
+]
+
+{ #category : 'initialization' }
+StShortcutsBrowserPresenter >> shortcutActivationCmdInstances [
+
+	^ CmdShortcutActivation registeredInstances copyWithoutAll: CmdShortcutActivation redefiningInstances
+]
+
+{ #category : 'accessing' }
+StShortcutsBrowserPresenter >> windowTitle [
+
+	^ 'Shortcuts Browser'
+]

--- a/src/NewTools-ShortcutsBrowser/package.st
+++ b/src/NewTools-ShortcutsBrowser/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-ShortcutsBrowser' }


### PR DESCRIPTION
Renamed and moved the shortcuts browser from the pharo repo to the NewToools repo. Now it's called `StShortcutsBrowserPresenter`