### PR TITLE
Deleted subscribption by default since we dont want it

### DIFF
--- a/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
+++ b/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
@@ -64,7 +64,6 @@ SpClosedWindowListPresenter class >> enableCloseWindow: aBoolean [
 SpClosedWindowListPresenter class >> initialize [
 
 	SessionManager default registerUserClassNamed: self name.
-	self subscribeToWindowClosedAnnoucements 
 
 ]
 


### PR DESCRIPTION
-Since we don't want to use the unclose window logic by default now, I removed subscription at creation of the Singleton
-There's no need to test this