### PR TITLE
Branch: SpotterImprovements,  based on the spotter poll results

### DIFF
--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -259,6 +259,21 @@ StFinderPresenter class >> openOnTargets: aCollection [
 	^ presenter
 ]
 
+{ #category : 'instance creation' }
+StFinderPresenter class >> openWithText: aText [
+
+	| model presenter |
+	model := StFinderModel new.
+	presenter := self
+		             newApplication: StPresenter currentApplication
+		             model: model.
+	model application: presenter application.
+	presenter open.
+	
+	presenter searchBar searchInput text: aText.
+	^ presenter
+]
+
 { #category : 'searching' }
 StFinderPresenter class >> searchBy: aString [ 
 	self shouldBeImplemented.

--- a/src/NewTools-Spotter-Processors/StClassProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StClassProcessor.class.st
@@ -25,7 +25,7 @@ StClassProcessor class >> hideInSettings [
 { #category : 'accessing' }
 StClassProcessor class >> order [
 	
-	^ 100
+	^ 60
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StHistoryProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StHistoryProcessor.class.st
@@ -17,8 +17,8 @@ StHistoryProcessor class >> defaultEnabled [
 
 { #category : 'accessing' }
 StHistoryProcessor class >> order [
-	
-	^ 80
+
+	^ 50
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StImplementorsProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StImplementorsProcessor.class.st
@@ -25,7 +25,7 @@ StImplementorsProcessor class >> hideInSettings [
 { #category : 'accessing' }
 StImplementorsProcessor class >> order [
 	
-	^ 100
+	^ 70
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StSendersProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StSendersProcessor.class.st
@@ -19,7 +19,7 @@ StSendersProcessor class >> defaultEnabled [
 { #category : 'accessing' }
 StSendersProcessor class >> order [
 	
-	^ 150
+	^ 130
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StWindowsProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StWindowsProcessor.class.st
@@ -18,7 +18,7 @@ StWindowsProcessor class >> defaultEnabled [
 { #category : 'accessing' }
 StWindowsProcessor class >> order [
 	
-	^ 50
+	^ 140
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter-Processors/StWorldMenuProcessor.class.st
+++ b/src/NewTools-Spotter-Processors/StWorldMenuProcessor.class.st
@@ -18,7 +18,7 @@ StWorldMenuProcessor class >> defaultEnabled [
 { #category : 'accessing' }
 StWorldMenuProcessor class >> order [
 	
-	^ 90
+	^ 150
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -191,7 +191,18 @@ StSpotter class >> openOnOrigin: anObject [
 { #category : 'instance creation' }
 StSpotter class >> openWithText: aText [
 
-	^ (self newWithText: aText) openModal
+"If a Spotter is already open, it closes itself and opens the Finder instead.  
+ Otherwise, it initializes a new Spotter. The purpose of this is so users can 
+ press 'shift+enter' inside the Spotter to open the Finder."
+   | searchText |
+	spotter ifNotNil: [
+		spotter isVisible ifTrue: [
+			searchText := spotter searchText text.
+			self reset.
+			^ StFinderPresenter openWithText: searchText ] ].
+	
+	spotter := self newWithText: aText.
+	^ spotter openModal
 ]
 
 { #category : 'settings' }
@@ -323,32 +334,48 @@ StSpotter >> addPreviewPanelTo: contentsLayout [
 ]
 
 { #category : 'initialization' }
-StSpotter >> addTipsPanel [ 
+StSpotter >> addTipsPanel [
 
 	self layout: (SpBoxLayout newTopToBottom
-		add: self layout;
-		add: (SpBoxLayout newLeftToRight
-				vAlignCenter;
-				borderWidth: 3;
-				spacing: 3;
-				add: (self newImage 
-					image: (self application iconNamed: #smallHelp);
-					in: [ :this | this eventHandler whenMouseDownDo: [ :anEvent | self feedTip ] ];
-					yourself)
-					expand: false;
-				add: ((tip := self newLabel)
-					in: [ :this | this eventHandler whenMouseDownDo: [ :anEvent | self feedTip ] ];
-					yourself);
-				addLast: (SpBoxLayout newTopToBottom 
-					add: (self newLink 
-						label: 'Advanced Search...';
-						action: [ self openFinder ];
-						yourself);
-					yourself)
-					expand: false;
-				yourself)
-			expand: false;
-		yourself)
+			 add: self layout;
+			 add: (SpBoxLayout newLeftToRight
+					  vAlignCenter;
+					  borderWidth: 3;
+					  spacing: 3;
+					  add: (self newImage
+							   image: (self application iconNamed: #smallHelp);
+							   in: [ :this |
+								   this eventHandler whenMouseDownDo: [ :anEvent |
+										   self feedTip ] ];
+							   yourself)
+					  expand: false;
+					  add: ((tip := self newLabel)
+							   in: [ :this |
+								   this eventHandler whenMouseDownDo: [ :anEvent |
+										   self feedTip ] ];
+							   yourself);
+					  addLast: (SpBoxLayout newLeftToRight
+							   vAlign: SpLayoutWidgetAlignment start;
+							   borderWidth: 3;
+							   spacing: 3;
+							   add: (self newImage
+									    image: (self application iconNamed: #smallFind);
+									    action: [ self openFinder ];
+									    yourself)
+							   expand: false);
+					  addLast: (SpBoxLayout newTopToBottom
+							   borderWidth: 3;
+							   vAlign: SpLayoutWidgetAlignment end;
+							   add: (self newLink
+									    label: 'Finder...';
+									    action: [ self openFinder ];
+									    help: 'Open the Finder tool (Shift + Return).';
+									    yourself);
+							   yourself)
+					  expand: false;
+					  yourself)
+			 expand: false;
+			 yourself)
 ]
 
 { #category : 'private' }
@@ -611,8 +638,9 @@ StSpotter >> maybeActivateFirstElementOfResultList [
 	resultList presenters
 		detect: [ :each | each matchesText: text ]
 		ifFound: [ :aPresenter | self activate: aPresenter ]."
-		
-	self activate: resultList selectedItem 
+	self model isFree ifFalse: [ ^ self ].	
+	self activate: resultList selectedItem.
+	
 ]
 
 { #category : 'accessing - model' }
@@ -802,7 +830,7 @@ StSpotter >> startProcessing [
 
 { #category : 'private' }
 StSpotter >> stopProcessing [
-	"Start the process."
+	"Stop the process."
 
 	self model stopProcessing
 ]

--- a/src/NewTools-Spotter/StSpotterModel.class.st
+++ b/src/NewTools-Spotter/StSpotterModel.class.st
@@ -109,7 +109,7 @@ StSpotterModel >> defaultProcessors [
 
 	^ (StSpotterProcessor allEnabledSubclasses 
 		collect: [ :each | each new ])
-		sort: #order ascending
+		sort: #order ascending 
 ]
 
 { #category : 'private - queries' }
@@ -141,6 +141,12 @@ StSpotterModel >> initializeOrigin: anObject [
 	self addStep: (self newStep
 		origin: anObject;
 		yourself)
+]
+
+{ #category : 'testing' }
+StSpotterModel >> isFree [ 
+
+  ^ scheduler isFree
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
- Changed ‘Advanced Search...’ corner button for ‘Finder…’
- Changed the default order of the lists
- When you open another spotter inside of the spotter you open the finder, which copies the text in the search bar of the spotter.
- When you press enter while there is an ongoing query nothing happens (so it doesn’t close/select anything).