### PR TITLE
Changed the logic behind adding itself in SpClosedWindowListPresenter

### DIFF
--- a/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
+++ b/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
@@ -166,8 +166,8 @@ SpClosedWindowListPresenter >> addClosedWindow: aModel [
 
 	self items size >= 5 ifTrue: [
 		5 to: self items size do: [ :i | self items removeLast close ] ].
-
-	aModel model presenter = SpClosedWindowListPresenter uniqueInstance
+	
+	aModel model presenter = SpClosedWindowListPresenter uniqueInstance 
 		ifFalse: [
 			aModel setProperty: #isClosed toValue: true.
 			self items addFirst: aModel ]

--- a/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
+++ b/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
@@ -167,7 +167,7 @@ SpClosedWindowListPresenter >> addClosedWindow: aModel [
 	self items size >= 5 ifTrue: [
 		5 to: self items size do: [ :i | self items removeLast close ] ].
 	
-	aModel model presenter = SpClosedWindowListPresenter uniqueInstance 
+	aModel labelString = 'Window Uncloser'
 		ifFalse: [
 			aModel setProperty: #isClosed toValue: true.
 			self items addFirst: aModel ]


### PR DESCRIPTION
-Before I checked if the model presenter of the parameter was itself class, but not every window have a model presenter, so test failed
-Now checks the labelString of the parameter, so it don't add "Window Uncloser" in the closed windows