### PR TITLE
Adapted SpClosedWindowListPresenter tests to updates

### DIFF
--- a/src/NewTools-WindowManager-Tests/SpClosedWindowListPresenterTest.class.st
+++ b/src/NewTools-WindowManager-Tests/SpClosedWindowListPresenterTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'TestCase',
 	#instVars : [
 		'presenter',
-		'testWindow'
+		'testWindow',
+		'originalEnableCloseWindow'
 	],
 	#category : 'NewTools-WindowManager-Tests',
 	#package : 'NewTools-WindowManager-Tests'
@@ -13,7 +14,7 @@ Class {
 SpClosedWindowListPresenterTest >> setUp [
 
 	super setUp.
-
+	originalEnableCloseWindow := SpClosedWindowListPresenter uniqueInstance enableCloseWindow.
 	presenter := SpClosedWindowListPresenter uniqueInstance.
 	presenter unsubscribeToWindowClosedAnnoucements .
 	presenter enableCloseWindow: true.
@@ -22,6 +23,13 @@ SpClosedWindowListPresenterTest >> setUp [
 		              extent: 300 @ 200;
 		              yourself.
 	SpClosedWindowListPresenter uniqueInstance items removeAll
+]
+
+{ #category : 'running' }
+SpClosedWindowListPresenterTest >> tearDown [
+
+	super tearDown.
+	presenter enableCloseWindow: originalEnableCloseWindow
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-WindowManager-Tests/SpClosedWindowListPresenterTest.class.st
+++ b/src/NewTools-WindowManager-Tests/SpClosedWindowListPresenterTest.class.st
@@ -16,7 +16,7 @@ SpClosedWindowListPresenterTest >> setUp [
 
 	presenter := SpClosedWindowListPresenter uniqueInstance.
 	presenter unsubscribeToWindowClosedAnnoucements .
-	presenter subscribeToWindowClosedAnnoucements .
+	presenter enableCloseWindow: true.
 	testWindow := SystemWindow new
 		              setLabel: 'Test Window';
 		              extent: 300 @ 200;
@@ -29,6 +29,7 @@ SpClosedWindowListPresenterTest >> testActivateCheckBoxEnableAndDisableSelf [
 
 	| announcement |
 	presenter activateBox click.
+	presenter activateBox click.
 	announcement := WindowClosed new
 		                window: testWindow;
 		                yourself.
@@ -36,7 +37,8 @@ SpClosedWindowListPresenterTest >> testActivateCheckBoxEnableAndDisableSelf [
 	self assert: presenter items isEmpty.
 	presenter activateBox click.
 	self currentWorld announcer announce: announcement.
-	self assert: presenter items first equals: testWindow
+	self assert: presenter items first equals: testWindow.
+	presenter activateBox click
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
-Since now the presenter is off by default, some tests were failing due to the singleton state
-Now added ``` presenter activateBox click``` calls to make it the same state as enableCloseWindow sharedVariable
-Put the shared variable to true in the setUp in case the Window Unclose is disabled in the current image.
@jecisc this fix the test failures in Pharo normally