### PR TITLE
Finder: fix render of first items

### DIFF
--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -439,6 +439,7 @@ StFinderPresenter >> initializeResultTree [
 		beMultipleSelection;
 		display: [ :result | result displayString ];
 		displayIcon: [ :result | result displayIcon ];
+		children: [ :result | result children ];
 		addShortcutWith: [ :action | action 
 			shortcutKey: $b actionModifier;
 			action: [ self resultTree selectedItem browseAction ] ];
@@ -620,8 +621,7 @@ StFinderPresenter >> updateResultsWith: results time: time [
 	"Call to update resultTree with results."
 
 	resultTree
-		roots: results;
-		children: [ :result | result children ].
+		roots: results.
 	self updateResultsBehavior.
 	resultStatusBar pushMessage: (self updateStatusBarTextFrom: results time: time).
 ]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/17904

Set children block only once and not on each update.