### PR TITLE
Cleanup the finder interface.

### DIFF
--- a/src/NewTools-Finder/StFinderEnvironmentBar.class.st
+++ b/src/NewTools-Finder/StFinderEnvironmentBar.class.st
@@ -34,7 +34,8 @@ StFinderEnvironmentBar >> defaultLayout [
 	^ SpBoxLayout newLeftToRight
 		  spacing: 2;
 		  vAlignCenter;
-		  add: statusLabel width: 180;
+		  add: statusLabel withConstraints: [ :constraints |
+				constraints expand: false ];
 		  add: allPackagesButton;
 		  add: chosenPackagesButton;
 		  yourself

--- a/src/NewTools-Finder/StFinderSearchBar.class.st
+++ b/src/NewTools-Finder/StFinderSearchBar.class.st
@@ -21,7 +21,7 @@ StFinderSearchBar >> defaultLayout [
 			spacing: 2;
 			add: searchModeDropList expand: false;
 			add: searchInput;
-			add: searchButton;
+			add: searchButton expand: false;
 			yourself
 ]
 


### PR DESCRIPTION
- There's no reason to have the search button be proportionally sized with the window
- Make the status label responsive to the text size instead of using a fixed width