### PR TITLE
Debug point browser fixes

### DIFF
--- a/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
@@ -130,7 +130,7 @@ DebugPointBrowserPresenter >> initializePresenters [
 		                   yourself
 ]
 
-{ #category : 'presenter building' }
+{ #category : 'initialization' }
 DebugPointBrowserPresenter >> initializeTable [
 
 	dpTable := self instantiate: DebugPointTablePresenter.
@@ -141,7 +141,7 @@ DebugPointBrowserPresenter >> initializeTable [
 			dp updateDebugPointUIManager: self ] ]
 ]
 
-{ #category : 'presenter building' }
+{ #category : 'initialization' }
 DebugPointBrowserPresenter >> initializeVariableTargetPresenter [
 
 	variableTargetPresenter := DebugPointVariableTargetPresenter new

--- a/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointBrowserPresenter.class.st
@@ -18,6 +18,12 @@ Class {
 }
 
 { #category : 'accessing' }
+DebugPointBrowserPresenter class >> currentApplication [
+
+	^ StPharoApplication current
+]
+
+{ #category : 'accessing' }
 DebugPointBrowserPresenter class >> defaultPreferredExtent [
 
 	^ 800 @ 600
@@ -105,7 +111,8 @@ DebugPointBrowserPresenter >> initialize [
 	self class codeSupportAnnouncer weak
 		when: DebugPointAdded send: #updateTable to: self;
 		when: DebugPointRemoved send: #updateTable to: self;
-		when: DebugPointChanged send: #updateEditor to: self
+		when: DebugPointChanged send: #updateEditor to: self.
+	self application: self class currentApplication
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-DebugPointsBrowser/DebugPointInstanceVariableTarget.extension.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointInstanceVariableTarget.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'DebugPointInstanceVariableTarget' }
 
 { #category : '*NewTools-DebugPointsBrowser' }
+DebugPointInstanceVariableTarget >> browseFrom: aSpBrowserPresenter [
+
+	aSpBrowserPresenter
+		browseInstanceVariable: self instanceVariable name
+		fromClass: self instanceVariable owningClass
+]
+
+{ #category : '*NewTools-DebugPointsBrowser' }
 DebugPointInstanceVariableTarget >> updateDebugPointUIManager: aDebugPointUIManager [
 
 	aDebugPointUIManager updateVariableTargetPresenterFrom: self.

--- a/src/NewTools-DebugPointsBrowser/DebugPointNodeTarget.extension.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointNodeTarget.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'DebugPointNodeTarget' }
 
 { #category : '*NewTools-DebugPointsBrowser' }
+DebugPointNodeTarget >> browseFrom: aSpBrowserPresenter [
+
+	^ self method browse
+]
+
+{ #category : '*NewTools-DebugPointsBrowser' }
 DebugPointNodeTarget >> updateDebugPointUIManager: aDebugPointUIManager [
 
 	aDebugPointUIManager switchToNodeTargetView.

--- a/src/NewTools-DebugPointsBrowser/DebugPointObjectTarget.extension.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointObjectTarget.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'DebugPointObjectTarget' }
 
 { #category : '*NewTools-DebugPointsBrowser' }
+DebugPointObjectTarget >> browseFrom: aSpBrowserPresenter [
+
+	^ aSpBrowserPresenter browseTarget: self subTarget
+]
+
+{ #category : '*NewTools-DebugPointsBrowser' }
 DebugPointObjectTarget >> updateDebugPointUIManager: aDebugPointUIManager [
 
 	^ self subTarget updateDebugPointUIManager: aDebugPointUIManager 

--- a/src/NewTools-DebugPointsBrowser/DebugPointTablePresenter.class.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointTablePresenter.class.st
@@ -8,6 +8,20 @@ Class {
 	#package : 'NewTools-DebugPointsBrowser'
 }
 
+{ #category : 'as yet unclassified' }
+DebugPointTablePresenter >> browseInstanceVariable: anInstVarName fromClass: aClass [
+
+	(self application tools browser openOnClass: aClass)
+		switchToVariables;
+		selectVariableNamed: anInstVarName
+]
+
+{ #category : 'as yet unclassified' }
+DebugPointTablePresenter >> browseTarget: aDebugPointTarget [
+
+	aDebugPointTarget browseFrom: self
+]
+
 { #category : 'context menu' }
 DebugPointTablePresenter >> debugPointActions [
 
@@ -21,7 +35,7 @@ DebugPointTablePresenter >> debugPointActions [
 			name: 'Browse Target';
 			description: 'browse target of the selected debug point';
 			actionEnabled: [ self selectedItem isNotNil ];
-			action: [ self selectedItem browse ] ];
+			action: [ self browseTarget: self selectedItem target ] ];
 		addActionWith: [ :anItem | anItem
 			name: 'Inspect Current Scope';
 			description: 'inspect the current scope of the selected debug point';

--- a/src/NewTools-DebugPointsBrowser/DebugPointTablePresenter.class.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointTablePresenter.class.st
@@ -8,7 +8,7 @@ Class {
 	#package : 'NewTools-DebugPointsBrowser'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'browsing' }
 DebugPointTablePresenter >> browseInstanceVariable: anInstVarName fromClass: aClass [
 
 	(self application tools browser openOnClass: aClass)
@@ -16,7 +16,7 @@ DebugPointTablePresenter >> browseInstanceVariable: anInstVarName fromClass: aCl
 		selectVariableNamed: anInstVarName
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'browsing' }
 DebugPointTablePresenter >> browseTarget: aDebugPointTarget [
 
 	aDebugPointTarget browseFrom: self

--- a/src/NewTools-DebugPointsBrowser/DebugPointTarget.extension.st
+++ b/src/NewTools-DebugPointsBrowser/DebugPointTarget.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'DebugPointTarget' }
 
 { #category : '*NewTools-DebugPointsBrowser' }
+DebugPointTarget >> browseFrom: aSpBrowserPresenter [
+
+	self subclassResponsibility 
+]
+
+{ #category : '*NewTools-DebugPointsBrowser' }
 DebugPointTarget >> updateDebugPointUIManager: aDebugPointUIManager [
 
 	^ self subclassResponsibility


### PR DESCRIPTION
Reinsert behavior removed in https://github.com/pharo-project/pharo/pull/17907 to recover browsing behavior.
The behavior is implemented using applications instead of referring directly to Smalltalk tools.
Browsing logic of debug point target fixed: "browsing" browses the target class (as expected) while "browsing target" browses the target entity of the breakpoint (eg the node or object or etc.).

Fixes #1024 https://github.com/pharo-spec/NewTools/issues/1024