### PR TITLE
rename Playground "Do it"

### DIFF
--- a/src/NewTools-Playground/StPlaygroundDoItCommand.class.st
+++ b/src/NewTools-Playground/StPlaygroundDoItCommand.class.st
@@ -25,7 +25,7 @@ StPlaygroundDoItCommand class >> defaultIconName [
 { #category : 'default' }
 StPlaygroundDoItCommand class >> defaultName [
 
-	^ 'Do it'
+	^ 'Do it all'
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Branch: pharoIssue17191,  Fixes https://github.com/pharo-project/pharo/issues/17191, rename Playground "Do it" button to "Do it all" to better describe its functionality and distinquish it from the regular "Do it"