### PR TITLE
Fix opening of new transcript

### DIFF
--- a/src/NewTools-Transcript/StTranscriptPresenter.class.st
+++ b/src/NewTools-Transcript/StTranscriptPresenter.class.st
@@ -18,7 +18,7 @@ Class {
 { #category : 'accessing' }
 StTranscriptPresenter class >> defaultPreferredExtent [
 
-	^ 300@700
+	^ (447 @ 300) scaledByDisplayScaleFactor
 ]
 
 { #category : 'accessing' }
@@ -56,10 +56,17 @@ StTranscriptPresenter class >> menuCommandOn: aBuilder [
 	aBuilder withSeparatorAfter
 ]
 
+{ #category : 'instance creation' }
+StTranscriptPresenter class >> open [
+
+	<script>
+	^ self new open
+]
+
 { #category : 'tools registry' }
 StTranscriptPresenter class >> registerToolsOn: aRegistry [
-	"Smalltalk tools register: self as: #newTranscript"
-	
+	"Smalltalk tools register: self as: #transcript"
+
 	aRegistry register: self as: #transcript
 ]
 
@@ -136,5 +143,5 @@ StTranscriptPresenter >> updateNewEntry [
 { #category : 'accessing' }
 StTranscriptPresenter >> windowTitle [
 
-	^ 'New basic transcript'
+	^ 'Transcript'
 ]


### PR DESCRIPTION
Add #open method + update title (the users do not need to know this is a new Transcript) + set the prefered extent to what was in the previous transcript