### PR TITLE
ProtocolChooser: Disable "Add protocol" button when the text field is empty

### DIFF
--- a/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
@@ -18,6 +18,16 @@ StProtocolNameChooserPresenterTest >> setUp [
 	presenter := StProtocolNameChooserPresenter new
 ]
 
+{ #category : 'running' }
+StProtocolNameChooserPresenterTest >> testAddButtonIsDiabledWhenTextFieldIsEmpty [
+
+	self assertEmpty: presenter protocolName.
+	self deny: presenter newProtocolButton isEnabled.
+
+	presenter protocolName: 'ANewProtocol'.
+	self assert: presenter newProtocolButton isEnabled
+]
+
 { #category : 'tests' }
 StProtocolNameChooserPresenterTest >> testSmokeTest [
 

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -115,8 +115,6 @@ StProtocolNameChooserPresenter >> initializeDialogWindow: aDialogWindowPresenter
 	super initializeDialogWindow: aDialogWindowPresenter.
 	protocolNameField whenSubmitDo: [ :protocolName | aDialogWindowPresenter triggerOkAction ].
 
-
-
 	newProtocolButton action: [ "If we click on the + we should add the content of the input field in the list, select it and validate"
 		suggestionList
 			items: { protocolNameField text };
@@ -204,6 +202,8 @@ StProtocolNameChooserPresenter >> selectedItem [
 
 { #category : 'initialization' }
 StProtocolNameChooserPresenter >> updatePresenter [
+
+	newProtocolButton enabled: self protocolName isNotEmpty.
 
 	suggestionList
 		items: self protocolsToSuggest;

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -160,7 +160,13 @@ StProtocolNameChooserPresenter >> initializeWindow: aWindowPresenter [
 	aWindowPresenter whenOpenedDo: [ protocolNameField takeKeyboardFocus ]
 ]
 
-{ #category : 'accessing - defaults' }
+{ #category : 'accessing' }
+StProtocolNameChooserPresenter >> newProtocolButton [
+
+	^ newProtocolButton
+]
+
+{ #category : 'accessing' }
 StProtocolNameChooserPresenter >> protocolName [
 	^ protocolNameField text asSymbol
 ]


### PR DESCRIPTION
Fixes https://github.com/pharo-project/pharo/issues/17940