### PR TITLE
Fixes https://github.com/pharo-spec/NewTools/issues/1034

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -9,8 +9,7 @@ Class {
 		'shouldFilterStack',
 		'oldMethodToSourceDictionary',
 		'lastUserPreservation',
-		'lastUserPosition',
-		'lastUserExtent'
+		'lastUserPosition'
 	],
 	#category : 'NewTools-Debugger-Tests-Presenters',
 	#package : 'NewTools-Debugger-Tests',

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -98,7 +98,7 @@ StDebuggerTest >> setUp [
 	"Save the user position (test running should not modify user changes)"
 	lastUserPosition := self settings lastKnownPosition.
 	"Save the user extent (test running should not modify user changes)"
-	lastUserExtent := self settings lastKnownExtent.
+	
 ]
 
 { #category : 'tests - context inspector' }
@@ -811,20 +811,6 @@ StDebuggerTest >> testNewDebuggerContextFor [
 ]
 
 { #category : 'tests - context inspector' }
-StDebuggerTest >> testOpenDebuggerWithLastKnownExtent [
-
-	self settings preserveWindowPositionAndExtent: true.
-	dbg := (self debuggerOn: session) open.
-	"Check window is opened with the saved extent"
-	self 
-		assert: self settings lastKnownExtent 
-		equals: dbg window window extent.
-
-	dbg close.
-
-]
-
-{ #category : 'tests - context inspector' }
 StDebuggerTest >> testOpenDebuggerWithLastKnownPosition [
 
 	self settings preserveWindowPositionAndExtent: true.
@@ -835,26 +821,6 @@ StDebuggerTest >> testOpenDebuggerWithLastKnownPosition [
 		equals: dbg window window position.
 
 	dbg close.
-
-]
-
-{ #category : 'tests - context inspector' }
-StDebuggerTest >> testPreserveLastKnownExtentIsFalse [
-
-	| newDbgExtent |
-
-	self settings preserveWindowPositionAndExtent: false.
-	dbg := (self debuggerOn: session) open.
-
-	newDbgExtent := 100 @ 200.
-	"Programmatically change the extent of debugger window"
-	dbg window window extent: newDbgExtent.
-	"New extent is saved when the window is closed"
-	dbg close.
-
-	self 
-		deny: self settings lastKnownExtent 
-		equals: newDbgExtent.
 
 ]
 

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -94,7 +94,7 @@ StDebuggerTest >> setUp [
 	shouldFilterStack := StDebuggerActionModel shouldFilterStack.
 	oldMethodToSourceDictionary := Dictionary new.
 	
-	lastUserPreservation := self settings preserveWindowPositionAndExtent.
+	lastUserPreservation := self settings preserveWindowPosition.
 	"Save the user position (test running should not modify user changes)"
 	lastUserPosition := self settings lastKnownPosition.
 	"Save the user extent (test running should not modify user changes)"
@@ -142,11 +142,10 @@ StDebuggerTest >> tearDown [
 			classified: assoc key protocolName ].
 		
 	"Restore the original preservation setting"		
-	self settings preserveWindowPositionAndExtent: lastUserPreservation.
+	self settings preserveWindowPosition: lastUserPreservation.
 	"Restore the original position"		
 	self settings lastKnownPosition: lastUserPosition.
 	"Restore the original extent"		
-	self settings lastKnownExtent: lastUserExtent.
 
 	super tearDown
 ]
@@ -813,7 +812,6 @@ StDebuggerTest >> testNewDebuggerContextFor [
 { #category : 'tests - context inspector' }
 StDebuggerTest >> testOpenDebuggerWithLastKnownPosition [
 
-	self settings preserveWindowPositionAndExtent: true.
 	dbg := (self debuggerOn: session) open.
 	"Check window is opened with the saved position"
 	self 
@@ -848,7 +846,7 @@ StDebuggerTest >> testPreserveLastKnownPositionIsFalse [
 
 	| newDbgPosition |
 
-	self settings preserveWindowPositionAndExtent: false.
+	self settings preserveWindowPosition: false.
 	dbg := (self debuggerOn: session) open.
 
 	newDbgPosition := 100 @ 200.

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -823,25 +823,6 @@ StDebuggerTest >> testOpenDebuggerWithLastKnownPosition [
 ]
 
 { #category : 'tests - context inspector' }
-StDebuggerTest >> testPreserveLastKnownExtentIsTrue [
-
-	| newDbgExtent |
-
-	dbg := (self debuggerOn: session) open.
-
-	newDbgExtent := 100 @ 200.
-	"Programmatically change the extent of debugger window"
-	dbg window window extent: newDbgExtent.
-	"New extent is saved when the window is closed"
-	dbg close.
-
-	self 
-		assert: self settings lastKnownExtent 
-		equals: newDbgExtent.
-
-]
-
-{ #category : 'tests - context inspector' }
 StDebuggerTest >> testPreserveLastKnownPositionIsFalse [
 
 	| newDbgPosition |
@@ -856,7 +837,7 @@ StDebuggerTest >> testPreserveLastKnownPositionIsFalse [
 	dbg close.
 
 	self 
-		deny: self settings lastKnownExtent 
+		deny: self settings lastKnownPosition
 		equals: newDbgPosition
 ]
 
@@ -1343,25 +1324,6 @@ StDebuggerTest >> testUpdateSourceCodeFor [
 	
 	dbg updateSourceCodeFor: (self class>>#testUpdateSourceCodeFor).
 	self assert: dbg code text equals: (self class>>#testUpdateSourceCodeFor) sourceCode.
-]
-
-{ #category : 'tests - context inspector' }
-StDebuggerTest >> testValueOfLastKnownExtentIsChangedWhenWindowIsClosed [
-
-	| newDbgExtent |
-
-	dbg := (self debuggerOn: session) open.
-
-	newDbgExtent := 500 @ 100.
-	"Programmatically change the position of debugger window"
-	dbg window window extent: newDbgExtent.
-	"New position is saved when the window is closed"
-	dbg close.
-
-	self 
-		assert: self settings lastKnownExtent
-		equals: newDbgExtent.
-
 ]
 
 { #category : 'tests - context inspector' }

--- a/src/NewTools-Debugger-Tests/TStDebuggerExtensionTestClass.class.st
+++ b/src/NewTools-Debugger-Tests/TStDebuggerExtensionTestClass.class.st
@@ -8,6 +8,12 @@ Class {
 	#tag : 'Model'
 }
 
+{ #category : 'testing' }
+TStDebuggerExtensionTestClass class >> acceptsPredicate: aStDebuggerContextPredicate [
+
+	^ true
+]
+
 { #category : 'layout' }
 TStDebuggerExtensionTestClass class >> defaultLayout [
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -200,7 +200,8 @@ StDebugger class >> defaultDebuggerRank [
 { #category : 'accessing' }
 StDebugger class >> defaultPreferredExtent [
 
-	^ self settings defaultPreferredExtent 
+	^ (850 @ 650)
+
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Debugger/StDebuggerSettings.class.st
+++ b/src/NewTools-Debugger/StDebuggerSettings.class.st
@@ -30,9 +30,7 @@ Class {
 	#name : 'StDebuggerSettings',
 	#superclass : 'Object',
 	#classVars : [
-		'LastKnownExtent',
-		'LastKnownPosition',
-		'PreserveWindowPositionAndExtent'
+		'LastKnownPosition'
 	],
 	#category : 'NewTools-Debugger-Model',
 	#package : 'NewTools-Debugger',
@@ -46,18 +44,11 @@ StDebuggerSettings class >> defaultPosition [
 
 ]
 
-{ #category : 'accessing' }
-StDebuggerSettings class >> defaultPreferredExtent [
-
-	^ (850 @ 650)
-
-]
-
 { #category : 'class initialization' }
 StDebuggerSettings class >> initialize [
 
 	LastKnownPosition := self defaultPosition.
-	LastKnownExtent := self defaultPreferredExtent.
+	
 ]
 
 { #category : 'initialization' }
@@ -65,26 +56,9 @@ StDebuggerSettings class >> initializeWindow: aWindowPresenter [
 	"Set global window position and extent using window data in aStDebugger"
 	"Pay attention this is not a presenter so the method name is misleading."
 	
-	self preserveWindowPositionAndExtent ifFalse: [ ^ self ].
 	aWindowPresenter whenClosedDo: [
 		self
-			lastKnownPosition: (aWindowPresenter window ifNotNil: [ : wnd | wnd position ]);
-			lastKnownExtent: (aWindowPresenter window ifNotNil: [ : wnd | wnd extent ]) ]
-]
-
-{ #category : 'accessing' }
-StDebuggerSettings class >> lastKnownExtent [
-	"Answer a <Point> specifying the last window known extent in the screen"
-
-	^ LastKnownExtent
-		ifNil: [ LastKnownExtent := self defaultPreferredExtent ]
-]
-
-{ #category : 'accessing' }
-StDebuggerSettings class >> lastKnownExtent: aPoint [
-	"Set a <Point> as the last window known extent in the screen"
-
-	LastKnownExtent := aPoint
+			lastKnownPosition: (aWindowPresenter window ifNotNil: [ : wnd | wnd position ]) ]
 ]
 
 { #category : 'accessing' }
@@ -100,29 +74,4 @@ StDebuggerSettings class >> lastKnownPosition: aPoint [
 	"Set a <Point> as the last window known position in the screen"
 
 	LastKnownPosition := aPoint
-]
-
-{ #category : 'accessing' }
-StDebuggerSettings class >> preserveWindowPositionAndExtent [
-
-	^ PreserveWindowPositionAndExtent
-		ifNil: [ PreserveWindowPositionAndExtent := true ]
-]
-
-{ #category : 'accessing' }
-StDebuggerSettings class >> preserveWindowPositionAndExtent: aBoolean [
-
-	PreserveWindowPositionAndExtent := aBoolean
-]
-
-{ #category : 'accessing' }
-StDebuggerSettings class >> preserveWindowPositionAndExtentOn: aBuilder [
-	<systemsettings>
-	
-	(aBuilder setting: #preserveWindowPositionAndExtent)
-		label: 'Preserve window position and extent';
-		target: self;
-		parent: #debugging;
-		default: true;
-		description: 'If enabled, the debugger will preserve the last known window position and extent, and it will open new debugger windows in that configuration'.
 ]

--- a/src/NewTools-Debugger/StDebuggerSettings.class.st
+++ b/src/NewTools-Debugger/StDebuggerSettings.class.st
@@ -30,7 +30,8 @@ Class {
 	#name : 'StDebuggerSettings',
 	#superclass : 'Object',
 	#classVars : [
-		'LastKnownPosition'
+		'LastKnownPosition',
+		'PreserveWindowPosition'
 	],
 	#category : 'NewTools-Debugger-Model',
 	#package : 'NewTools-Debugger',
@@ -56,6 +57,7 @@ StDebuggerSettings class >> initializeWindow: aWindowPresenter [
 	"Set global window position and extent using window data in aStDebugger"
 	"Pay attention this is not a presenter so the method name is misleading."
 	
+	self preserveWindowPosition ifFalse: [ ^ self ].
 	aWindowPresenter whenClosedDo: [
 		self
 			lastKnownPosition: (aWindowPresenter window ifNotNil: [ : wnd | wnd position ]) ]
@@ -74,4 +76,28 @@ StDebuggerSettings class >> lastKnownPosition: aPoint [
 	"Set a <Point> as the last window known position in the screen"
 
 	LastKnownPosition := aPoint
+]
+
+{ #category : 'accessing' }
+StDebuggerSettings class >> preserveWindowPosition [
+
+	^ PreserveWindowPosition ifNil: [ PreserveWindowPosition := true ]
+]
+
+{ #category : 'accessing' }
+StDebuggerSettings class >> preserveWindowPosition: aBoolean [
+
+	PreserveWindowPosition := aBoolean
+]
+
+{ #category : 'initialization' }
+StDebuggerSettings class >> preserveWindowPositionAndExtentOn: aBuilder [
+	<systemsettings>
+	
+	(aBuilder setting: #preserveWindowPosition)
+		label: 'Preserve window position';
+		target: self;
+		parent: #debugging;
+		default: true;
+		description: 'If enabled, the debugger will preserve the last known window position, and it will open new debugger windows in that configuration'.
 ]


### PR DESCRIPTION
Remove the lastKnownExtent since now this is done by spec by default