### PR TITLE
Adding a save content button when modifying file

### DIFF
--- a/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
@@ -51,33 +51,58 @@ AbstractFileReference >> inspectionCompressedItemsContext: aContext [
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }
-AbstractFileReference >> inspectionContents [
-	<inspectorPresentationOrder: 0 title: 'Contents'> 
-	| maxBytes buffer atEnd stringContents displayStream displayString |
-	
-	maxBytes := 10000.
-	
-	self binaryReadStreamDo: [ :stream | 
-		buffer := stream next: maxBytes.
-		atEnd := stream atEnd ].
-				
-	displayString := [ 
-			stringContents := ZnCharacterEncoder utf8 decodeBytes: buffer.
-			atEnd 
-				ifTrue: [ stringContents ]
-				ifFalse: [ stringContents, '  ... truncated ...' ] ]
-		on: Error 
-		do: [ 
-			displayStream := (String new: maxBytes * 5) writeStream.
-			buffer hexDumpOn: displayStream max: maxBytes.
-			displayString := displayStream contents ].
-	
-	^ SpCodePresenter new
-		withoutSyntaxHighlight;
-		text: displayString;
-		whenSubmitDo: [ :text | 
-			self writeStreamDo: [ :s | s nextPutAll: text string ] ];
-		yourself
+AbstractFileReference >> inspectionContents: aBuilder [
+    <inspectorPresentationOrder: 0 title: 'Contents'> 
+    | maxBytes buffer atEnd stringContents displayStream displayString contentPresenter toolbarPresenter |
+     
+    maxBytes := 10000.
+    
+    self binaryReadStreamDo: [ :stream | 
+        buffer := stream next: maxBytes.
+        atEnd := stream atEnd ].
+                
+    displayString := [ 
+            stringContents := ZnCharacterEncoder utf8 decodeBytes: buffer.
+            atEnd 
+                ifTrue: [ stringContents ]
+                ifFalse: [ stringContents, '  ... truncated ...' ] ]
+        on: Error 
+        do: [ 
+            displayStream := (String new: maxBytes * 5) writeStream.
+            buffer hexDumpOn: displayStream max: maxBytes.
+            displayString := displayStream contents ].
+    
+    contentPresenter := aBuilder newCode
+        withoutSyntaxHighlight;
+        text: displayString;
+        whenSubmitDo: [ :text | 
+            self 
+                ensureDelete;
+                writeStreamDo: [ :s | s nextPutAll: text asString ] ];
+        yourself.
+        
+    toolbarPresenter := aBuilder newToolbar.
+    toolbarPresenter displayMode: aBuilder application toolbarDisplayMode.
+    toolbarPresenter add: (toolbarPresenter newToolbarButton 
+        icon: (aBuilder application iconNamed: #smallSave);
+        label: 'Save contents';
+        help: 'Save contents of file';
+        action: [ 
+            self 
+                ensureDelete;
+                writeStreamDo: [ :s | s nextPutAll: contentPresenter text asString ] ];
+        yourself).
+        
+    ^ aBuilder newPresenter
+        layout: (SpBoxLayout newTopToBottom 
+            add: (SpBoxLayout newLeftToRight 
+                    hAlignEnd;
+                    add: toolbarPresenter;
+                    yourself) 
+                expand: false;
+            add: contentPresenter;
+            yourself);
+        yourself
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }


### PR DESCRIPTION
Pharo13.0.0: #feat: Needed to have a good save button, for example when people give Pharo lessons and want to modify directly the preferences file. Thanks to @estebanlm work :) !