### PR TITLE
Can remove a placeholder from current profile

### DIFF
--- a/src/NewTools-Window-Profiles/CavVisualPlaceHolderMorph.class.st
+++ b/src/NewTools-Window-Profiles/CavVisualPlaceHolderMorph.class.st
@@ -34,6 +34,14 @@ CavVisualPlaceHolderMorph >> changeStrategy [
 	presenter openDialog
 ]
 
+{ #category : 'event handling' }
+CavVisualPlaceHolderMorph >> handleClick: anEvent [
+
+	anEvent yellowButtonPressed
+		ifTrue: [ self remove ]
+		ifFalse: [ self changeStrategy ]
+]
+
 { #category : 'initialization' }
 CavVisualPlaceHolderMorph >> initialize [
 
@@ -42,11 +50,41 @@ CavVisualPlaceHolderMorph >> initialize [
 	self borderColor: UITheme current selectionColor.
 	self color: (UITheme current lightSelectionColor alpha: 0.2).
 	self eventHandler: MorphicEventHandler new.
-	self eventHandler on: #click send: #changeStrategy to: self.
+	self eventHandler on: #mouseDown send: #handleClick: to: self.
+	
+]
+
+{ #category : 'accessing' }
+CavVisualPlaceHolderMorph >> placeHolder [
+
+	^ placeHolder
 ]
 
 { #category : 'accessing' }
 CavVisualPlaceHolderMorph >> placeHolder: aPlaceHolder [
 
 	placeHolder := aPlaceHolder
+]
+
+{ #category : 'removing' }
+CavVisualPlaceHolderMorph >> remove [
+
+	| presenter class key |
+	presenter := SpConfirmDialog new
+		             title: 'Remove placeholder';
+		             label: 'Are you sure you want to remove it ?';
+		             onAccept: [ :dialog |
+			             class := Smalltalk at:
+					                      self submorphs first contents asString
+						                      asSymbol.
+			             key := CavroisWindowManager current currentProfile
+				                    placeHolderDictionnary at: class.
+			             (CavroisWindowManager current currentProfile
+				              placeHoldersFor: class) do: [ :p |
+					             p = self placeHolder ifTrue: [ key remove: p ] ].
+			             key ifEmpty: [
+					             CavroisWindowManager current currentProfile
+						             placeHolderDictionnary removeKey: class ].
+			             self delete ].
+	presenter openDialog
 ]

--- a/src/NewTools-Window-Profiles/CavWindowProfile.class.st
+++ b/src/NewTools-Window-Profiles/CavWindowProfile.class.st
@@ -52,6 +52,12 @@ CavWindowProfile >> named: aString [
 ]
 
 { #category : 'accessing' }
+CavWindowProfile >> placeHolderDictionnary [
+
+	^ placeHolderDictionary
+]
+
+{ #category : 'accessing' }
 CavWindowProfile >> placeHolders [
 	| res |
 	res := OrderedCollection new.


### PR DESCRIPTION
-Handled the click so left click is only for strategies and right for deletion -Added accessors so `remove` can clean properly the placeholder dictionnary of the profile