### PR TITLE
New debugger extension to have meta-information about the debugging session

### DIFF
--- a/src/NewTools-Debugger/StDebuggerMetaSession.class.st
+++ b/src/NewTools-Debugger/StDebuggerMetaSession.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'StDebuggerMetaSession',
+	#superclass : 'Object',
+	#instVars : [
+		'debugger'
+	],
+	#category : 'NewTools-Debugger-Model',
+	#package : 'NewTools-Debugger',
+	#tag : 'Model'
+}
+
+{ #category : 'instance creation' }
+StDebuggerMetaSession class >> forDebugger: aStDebugger [
+	^self new forDebugger: aStDebugger
+]
+
+{ #category : 'accessing' }
+StDebuggerMetaSession >> allInspectorNodes [
+	"Answer a list of attributes as nodes"
+
+	^ OrderedCollection new
+		  addAll: debugger debuggerActionModel inspectorNodes;
+		  add: (StInspectorDynamicNode
+				   hostObject: debugger
+				   label: 'debugger'
+				   value: debugger);
+		  yourself
+]
+
+{ #category : 'instance creation' }
+StDebuggerMetaSession >> forDebugger: aStDebugger [
+
+	debugger := aStDebugger
+]

--- a/src/NewTools-Debugger/StDebuggerSessionPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerSessionPresenter.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'StDebuggerSessionPresenter',
+	#superclass : 'SpPresenter',
+	#traits : 'TStDebuggerExtension',
+	#classTraits : 'TStDebuggerExtension classTrait',
+	#instVars : [
+		'sessionInspector'
+	],
+	#category : 'NewTools-Debugger-View',
+	#package : 'NewTools-Debugger',
+	#tag : 'View'
+}
+
+{ #category : 'debugger extension' }
+StDebuggerSessionPresenter >> debuggerExtensionToolName [
+	^'Session'
+]
+
+{ #category : 'layout' }
+StDebuggerSessionPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: #sessionInspector;
+		  yourself
+]
+
+{ #category : 'layout' }
+StDebuggerSessionPresenter >> initializePresenters [
+	sessionInspector := (StDebuggerMetaSession forDebugger: debugger) inspectionRaw
+]


### PR DESCRIPTION
This is important for tool building, debugger and interpreter problems/questions exploration, and for some bugs where we want to access information held by the debugger or its session, but not necessarily exposed.

![Capture d’écran 2025-03-26 à 17 46 04](https://github.com/user-attachments/assets/60a7c6fe-e2a1-42a7-830d-57578ae96360)
