### PR TITLE
Removed a UIManager dependency

### DIFF
--- a/src/NewTools-ProfilerUI/StProfilerResultsPresenter.class.st
+++ b/src/NewTools-ProfilerUI/StProfilerResultsPresenter.class.st
@@ -127,17 +127,21 @@ StProfilerResultsPresenter >> handleTreeRootChanged: event [
 { #category : 'initialization' }
 StProfilerResultsPresenter >> initializeActions [
 
+	| pres |
 	treeTable
 		whenSelectedItemChangedSend: #handleSelectionChanged
 		to: self.
 
 	"Report"
 	reportButton action: [
-		UIManager default edit: viewModel report label: 'Profiling Report' ].
-	"Configuration section actions"
+		pres := SpTextPresenter new
+			        text: viewModel report;
+			        open.
+		pres withWindowDo: [ :w | w title: 'Profiling Report' ] ].
 	collapseAllButton action: [
 		treeTable collapseAll.
 		treeTable takeKeyboardFocus ].
+	"Configuration section actions"
 
 	expandAllButton action: [
 		treeTable expandAll.


### PR DESCRIPTION
-The code was just opening the report of profile action in a TextMorph,  called a Presenter instead to remove dependency
-Fixes #14596 on pharo repo, @Ducasse if you want to check