### PR TITLE
fixed the code for the CavReplaceStrategy

### DIFF
--- a/src/NewTools-Window-Profiles/CavReplaceStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavReplaceStrategy.class.st
@@ -28,8 +28,8 @@ CavReplaceStrategy >> placePresenter: aPresenter [
 	
 	(SystemWindow allInstances select: [ :each |
 		 each position = placeHolder position 
-			and: [ each kind = aPresenter class ]]) do: [ :each | each delete ].
+			and: [ placeHolder kind = aPresenter class ]]) do: [ :each | each delete ].
 	(SpWindow allInstances select: [ :each |
 		 each position = placeHolder position 
-				and: [ each kind = aPresenter class ]]) do: [ :each | each delete ]
+				and: [ placeHolder kind = aPresenter class ]]) do: [ :each | each delete ]
 ]


### PR DESCRIPTION
Replaces ```each``` by the placeHolder because it si it that has the informations about the window class.
@Ducasse 