### PR TITLE
Adding a Delete Contents button in inspector 

### DIFF
--- a/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
@@ -98,7 +98,7 @@ AbstractFileReference >> inspectionContents: aBuilder [
 			 yourself).
 	toolbarPresenter add: (toolbarPresenter newToolbarButton
 			 icon: (aBuilder application iconNamed: #smallDelete);
-			 label: 'Delete contents';
+			 label: 'Delete file';
 			 help: 'Delete the file';
 			 action: [
 					 self ensureDelete.

--- a/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
@@ -52,57 +52,69 @@ AbstractFileReference >> inspectionCompressedItemsContext: aContext [
 
 { #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionContents: aBuilder [
-    <inspectorPresentationOrder: 0 title: 'Contents'> 
-    | maxBytes buffer atEnd stringContents displayStream displayString contentPresenter toolbarPresenter |
-     
-    maxBytes := 10000.
-    
-    self binaryReadStreamDo: [ :stream | 
-        buffer := stream next: maxBytes.
-        atEnd := stream atEnd ].
-                
-    displayString := [ 
-            stringContents := ZnCharacterEncoder utf8 decodeBytes: buffer.
-            atEnd 
-                ifTrue: [ stringContents ]
-                ifFalse: [ stringContents, '  ... truncated ...' ] ]
-        on: Error 
-        do: [ 
-            displayStream := (String new: maxBytes * 5) writeStream.
-            buffer hexDumpOn: displayStream max: maxBytes.
-            displayString := displayStream contents ].
-    
-    contentPresenter := aBuilder newCode
-        withoutSyntaxHighlight;
-        text: displayString;
-        whenSubmitDo: [ :text | 
-            self 
-                ensureDelete;
-                writeStreamDo: [ :s | s nextPutAll: text asString ] ];
-        yourself.
-        
-    toolbarPresenter := aBuilder newToolbar.
-    toolbarPresenter displayMode: aBuilder application toolbarDisplayMode.
-    toolbarPresenter add: (toolbarPresenter newToolbarButton 
-        icon: (aBuilder application iconNamed: #smallSave);
-        label: 'Save contents';
-        help: 'Save contents of file';
-        action: [ 
-            self 
-                ensureDelete;
-                writeStreamDo: [ :s | s nextPutAll: contentPresenter text asString ] ];
-        yourself).
-        
-    ^ aBuilder newPresenter
-        layout: (SpBoxLayout newTopToBottom 
-            add: (SpBoxLayout newLeftToRight 
-                    hAlignEnd;
-                    add: toolbarPresenter;
-                    yourself) 
-                expand: false;
-            add: contentPresenter;
-            yourself);
-        yourself
+
+	<inspectorPresentationOrder: 0 title: 'Contents'>
+	| maxBytes buffer atEnd stringContents displayStream displayString contentPresenter toolbarPresenter |
+	maxBytes := 10000.
+
+	self binaryReadStreamDo: [ :stream |
+			buffer := stream next: maxBytes.
+			atEnd := stream atEnd ].
+
+	displayString := [
+		                 stringContents := ZnCharacterEncoder utf8
+			                                   decodeBytes: buffer.
+		                 atEnd
+			                 ifTrue: [ stringContents ]
+			                 ifFalse: [ stringContents , '  ... truncated ...' ] ]
+		                 on: Error
+		                 do: [
+				                 displayStream := (String new: maxBytes * 5)
+					                                  writeStream.
+				                 buffer hexDumpOn: displayStream max: maxBytes.
+				                 displayString := displayStream contents ].
+
+	contentPresenter := aBuilder newCode
+		                    withoutSyntaxHighlight;
+		                    text: displayString;
+		                    whenSubmitDo: [ :text |
+				                    self
+					                    ensureDelete;
+					                    writeStreamDo: [ :s |
+						                    s nextPutAll: text asString ] ];
+		                    yourself.
+
+	toolbarPresenter := aBuilder newToolbar.
+	toolbarPresenter displayMode: aBuilder application toolbarDisplayMode.
+	toolbarPresenter add: (toolbarPresenter newToolbarButton
+			 icon: (aBuilder application iconNamed: #smallSave);
+			 label: 'Save contents';
+			 help: 'Save contents of file';
+			 action: [
+					 self
+						 ensureDelete;
+						 writeStreamDo: [ :s |
+							 s nextPutAll: contentPresenter text asString ] ];
+			 yourself).
+	toolbarPresenter add: (toolbarPresenter newToolbarButton
+			 icon: (aBuilder application iconNamed: #smallDelete);
+			 label: 'Delete contents';
+			 help: 'Delete the file';
+			 action: [
+					 self ensureDelete.
+					 contentPresenter delete ];
+			 yourself).
+
+	^ aBuilder newPresenter
+		  layout: (SpBoxLayout newTopToBottom
+				   add: (SpBoxLayout newLeftToRight
+						    hAlignEnd;
+						    add: toolbarPresenter;
+						    yourself)
+				   expand: false;
+				   add: contentPresenter;
+				   yourself);
+		  yourself
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }


### PR DESCRIPTION
To be able to delete files from Pharo, especially when creating a file that a user potentially didn't want to