### PR TITLE
Check if there is already a current profile when loading one

### DIFF
--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -168,17 +168,20 @@ CavroisWindowManager class >> loadProfile [
 				ifTrue: [
 						file := fileReference.
 						profile := STON fromString: file.
-						oldProfile := self current currentProfile.
-						self current profiles at: profile name put: profile.
-						oldKey := self current profiles keyAtValue: oldProfile.
-						baseName := oldKey copyReplaceAll: '(Current)' with: ''.
+						self current currentProfile ifNotNil: [
+								oldProfile := self current currentProfile.
+								oldKey := self current profiles keyAtValue: oldProfile.
+								baseName := oldKey copyReplaceAll: '(Current)' with: ''.
+								self current profiles
+									at: baseName put: oldProfile;
+									removeKey: oldKey ].
 						self current profiles
-							at: baseName put: oldProfile;
-							removeKey: oldKey.
+							at: profile name , ' (Current)'
+							put: profile.
 						self current currentProfile: profile.
 						MenubarMorph reset ]
 				ifFalse: [ self inform: ' File selected is not a profile' ] ].
-	presenter open
+	presenter openDialog
 ]
 
 { #category : 'open' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -155,6 +155,12 @@ CavroisWindowManager class >> deleteProfile [
 		             openDialog
 ]
 
+{ #category : 'class initialization' }
+CavroisWindowManager class >> initialize [
+
+	SessionManager default registerUserClassNamed: self name
+]
+
 { #category : 'action' }
 CavroisWindowManager class >> loadProfile [
 
@@ -323,6 +329,12 @@ CavroisWindowManager class >> saveProfile: aLocation [
 	file := aLocation / fileName.
 	file writeStreamDo: [ :stream | stream nextPutAll: fileString ].
 	self inform: 'Profile saved !'
+]
+
+{ #category : 'system startup' }
+CavroisWindowManager class >> startUp: isImageStarting [
+
+	isImageStarting ifTrue: [ self reset ]
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
- So the ```CavroisWindowManager``` make the appropriate changes if there was a profile before or not
- Also reset the manager when image starts because the default location was wrong when launching a new one, thanks to @jecisc 