### PR TITLE
Implement viewing of MailMessage in Spec

### DIFF
--- a/src/NewTools-Utils/MailMessage.extension.st
+++ b/src/NewTools-Utils/MailMessage.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : 'MailMessage' }
+
+{ #category : '*NewTools-Utils' }
+MailMessage >> viewBody [
+	"open a viewer on the body of this message"
+
+	self containsViewableImage ifTrue: [ ^ self viewImageInBody ].
+
+	(MicTextPresenter new
+		 text: self bodyTextFormatted;
+		 asWindow)
+		title: (self name ifNil: [ '(a message part)' ]);
+		open
+]
+
+{ #category : '*NewTools-Utils' }
+MailMessage >> viewImageInBody [
+
+	| stream image |
+	stream := self body contentStream.
+	image := Form fromBinaryStream: stream.
+	SpImagePresenter new
+		image: image;
+		open
+]


### PR DESCRIPTION
MailMessage has some dependencies over Morphic and UIManager to be able to view a MailMessage content. 

I propose to move those methods to NewTools and to use Spec instead of Morphic to view the content.