### PR TITLE
Fix package selection in the new Finder

### DIFF
--- a/src/NewTools-Finder/StFinderEnvironmentBar.class.st
+++ b/src/NewTools-Finder/StFinderEnvironmentBar.class.st
@@ -14,20 +14,6 @@ Class {
 	#tag : 'Widgets'
 }
 
-{ #category : 'updating - widgets' }
-StFinderEnvironmentBar >> activateAllPackages [
-
-	allPackagesButton iconName: #radioButtonSelected.
-	chosenPackagesButton iconName: #radioButtonUnselected
-]
-
-{ #category : 'updating - widgets' }
-StFinderEnvironmentBar >> activateChosenPackages [
-
-	allPackagesButton iconName: #radioButtonUnselected.
-	chosenPackagesButton iconName: #radioButtonSelected
-]
-
 { #category : 'layout' }
 StFinderEnvironmentBar >> defaultLayout [
 
@@ -48,27 +34,59 @@ StFinderEnvironmentBar >> initializePresenters [
 	chosenPackagesButton := self newButton
 		                        label: 'Packages…';
 		                        iconName: #radioButtonUnselected;
+		                        action: [ self openPackageChooserDialog ];
 		                        yourself.
 	allPackagesButton := self newButton
 		                     label: 'All Packages';
 		                     iconName: #radioButtonSelected;
-		                     yourself
+		                     action: [ self searchInAllPackages ];
+		                     yourself.
+
+	self updateStatus
 ]
 
-{ #category : 'instance creation' }
-StFinderEnvironmentBar >> status: aString [
+{ #category : 'accessing' }
+StFinderEnvironmentBar >> model [
 
-	statusLabel label: aString
+	^ self owner model
 ]
 
-{ #category : 'events' }
-StFinderEnvironmentBar >> whenAllPackagesSelectedDo: aBlock [
+{ #category : 'private' }
+StFinderEnvironmentBar >> openPackageChooserDialog [
+	"Opens a `SpChooserPresenter` dialog to allow the user to choose the packages to search in."
 
-	allPackagesButton action: aBlock
+	((SpChooserPresenter sourceItems: self model unselectedPackages chosenItems: self model selectedPackages)
+		 sourceLabel: 'Available packages';
+		 targetLabel: 'Selected packages';
+		 openDialog)
+		title: 'Select packages for searching';
+		okAction: [ :dialog | self searchInPackages: dialog presenter chosenItems ]
 ]
 
-{ #category : 'events' }
-StFinderEnvironmentBar >> whenPackagesSelectedDo: aBlock [
+{ #category : 'private' }
+StFinderEnvironmentBar >> searchInAllPackages [
+	"Selects all packages for searching."
 
-	chosenPackagesButton action: aBlock
+	self model selectAllPackages.
+	"Maybe we could use a real radio button?"
+	allPackagesButton iconName: #radioButtonSelected.
+	chosenPackagesButton iconName: #radioButtonUnselected.
+	self updateStatus
+]
+
+{ #category : 'private' }
+StFinderEnvironmentBar >> searchInPackages: aCollection [
+	"Sets the search environment in the model to the package names given in aCollection."
+
+	self model selectedPackagesByName: aCollection.
+	"Maybe this should use a real radio button?"
+	allPackagesButton iconName: #radioButtonUnselected.
+	chosenPackagesButton iconName: #radioButtonSelected.
+	self updateStatus
+]
+
+{ #category : 'updating - widgets' }
+StFinderEnvironmentBar >> updateStatus [
+
+	statusLabel label: self model selectedPackages size asString , ' Packages selected'
 ]

--- a/src/NewTools-Finder/StFinderModel.class.st
+++ b/src/NewTools-Finder/StFinderModel.class.st
@@ -65,9 +65,9 @@ StFinderModel >> application: anApplication [
 StFinderModel >> availablePackages [
 	"Returns for searching available packages by name."
 
-	^ searchEnvironment packages
-		  collect: [ :package | package name ]
-		  as: OrderedCollection
+	| globalEnv |
+	globalEnv := RBBrowserEnvironment new.
+	^ (globalEnv forPackages: globalEnv packages) packages collect: [ :package | package name ] as: OrderedCollection
 ]
 
 { #category : 'accessing' }
@@ -279,10 +279,9 @@ StFinderModel >> time [
 
 { #category : 'information' }
 StFinderModel >> unselectedPackages [
-
 	"Returns for searching unselected packages by name."
 
-	^ self availablePackages removeAllFoundIn: self selectedPackages
+	^ self availablePackages \ self selectedPackages
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -298,10 +298,6 @@ StFinderPresenter >> connectPresenters [
 	self connectSearchOptions.
 	searchOptions substringBox click.
 
-	environmentBar
-		whenAllPackagesSelectedDo: [ self searchInAllPackages ];
-		whenPackagesSelectedDo: [ self openPackageChooserDialog ].
-
 	resultTree 
 		whenSelectedItemChangedDo: [ :newResult |
 			newResult 
@@ -423,7 +419,6 @@ StFinderPresenter >> initializePresenters [
 	searchOptions := self instantiate: StFinderSearchOptions.
 
 	environmentBar := self instantiate: StFinderEnvironmentBar.
-	self updateEnvironmentStatusFor: self model selectedPackages.
 
 	self initializeResultTree.
 		
@@ -460,20 +455,6 @@ StFinderPresenter >> notifySearchStarted [
 
 ]
 
-{ #category : 'private' }
-StFinderPresenter >> openPackageChooserDialog [
-	"Opens a `SpChooserPresenter` dialog to allow the user to choose the packages to search in."
-
-	((SpChooserPresenter
-		  sourceItems: self model unselectedPackages
-		  chosenItems: self model selectedPackages)
-		 sourceLabel: 'Available packages';
-		 targetLabel: 'Selected packages';
-		 openDialog)
-		title: 'Select packages for searching';
-		okAction: [ :dialog | self searchInPackages: dialog presenter chosenItems ]
-]
-
 { #category : 'accessing' }
 StFinderPresenter >> resultButtonBar [
 
@@ -499,21 +480,10 @@ StFinderPresenter >> searchBy: aString [
 ]
 
 { #category : 'private' }
-StFinderPresenter >> searchInAllPackages [
-	"Selects all packages for searching."
-
-	self model selectAllPackages.
-	environmentBar activateAllPackages.
-	self updateEnvironmentStatusFor: self model selectedPackages
-]
-
-{ #category : 'private' }
 StFinderPresenter >> searchInPackages: aCollection [
 	"Sets the search environment in the model to the package names given in aCollection."
 
-	self model selectedPackagesByName: aCollection.
-	environmentBar activateChosenPackages.
-	self updateEnvironmentStatusFor: aCollection
+	environmentBar searchInPackages: aCollection
 ]
 
 { #category : 'accessing' }
@@ -567,12 +537,6 @@ StFinderPresenter >> subscribeToAnnouncements [
 	self model whenSearchStarted: [ self notifySearchStarted ].
 	self model whenSearchEnded: [ :results : time | self updateResultsWith: results time: time ].
 	self model whenSearchTypesChanged: [ self searchBar updateSearchModes ]
-]
-
-{ #category : 'updating - widgets' }
-StFinderPresenter >> updateEnvironmentStatusFor: packages [
-
-	environmentBar status: packages size asString , ' Packages selected'
 ]
 
 { #category : 'updating - widgets' }


### PR DESCRIPTION
Fixes #1126

Now we can select a package we did not select originaly

I also did a refeactoring so that all of the environment search behavior is in StFinderEnvironmentBar and not in StFinderPresenter. This should make the code simpler and not mix the management of the environment in two classes