### PR TITLE
restore extension lost when renamed IRMethod to OCIRMethod

### DIFF
--- a/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'OCIRMethod' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+OCIRMethod >> inpectionIr: aBuilder [
+	<inspectorPresentationOrder: 40 title: 'Symbolic'>
+
+	^ aBuilder newCode
+		withoutSyntaxHighlight;
+		text: (self ir longPrintString trimmed);
+		yourself
+]


### PR DESCRIPTION
Fixes https://github.com/pharo-spec/NewTools/issues/1123