### PR TITLE
Fixpopup

### DIFF
--- a/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
@@ -16,3 +16,22 @@ CompiledMethod >> inspectionPragmasContext: aContext [
 	
 	aContext active: self hasPragmas
 ]
+
+{ #category : '*NewTools-Inspector-Extensions' }
+CompiledMethod >> inspectionSource: aBuilder [
+	<inspectorPresentationOrder: 20 title: 'Method Source'>
+	
+	^ aBuilder newMethod
+		addStyle: 'stCode';
+		beForMethod: self method;
+		text: self sourceCode;
+		contextMenu: (SpMenuPresenter new addGroup: [ :group | group 
+			addItem: [ :item | item 
+				name: 'Browse method class'; 
+				action: [ self methodClass browse ] ] ]);
+		whenSubmitDo: [ :text | 
+			self isInstalled 
+				ifFalse: [ self inform: 'can not edit methods that are not installed' ]
+				ifTrue: [ self methodClass compile: text ]];
+		yourself
+]

--- a/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/CompiledMethod.extension.st
@@ -21,7 +21,7 @@ CompiledMethod >> inspectionPragmasContext: aContext [
 CompiledMethod >> inspectionSource: aBuilder [
 	<inspectorPresentationOrder: 20 title: 'Method Source'>
 	
-	^ aBuilder newMethod
+	^ aBuilder newCode
 		addStyle: 'stCode';
 		beForMethod: self method;
 		text: self sourceCode;

--- a/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'OCIRMethod' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+OCIRMethod >> inpectionIr: aBuilder [
+	<inspectorPresentationOrder: 40 title: 'Symbolic'>
+
+	^ aBuilder newCode
+		withoutSyntaxHighlight;
+		text: (self ir longPrintString trimmed);
+		yourself
+]

--- a/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
@@ -24,7 +24,7 @@ CavPopUpStrategy >> findSameKindWindowAs: aWidget [
 						  each model notNil and: [
 								  (each model presenter
 									   ifNotNil: [ each model presenter class = aWidget class ]
-									   ifNil: [ each model class = aWidget model class ]) and: [
+									   ifNil: [ each model class = aWidget class ]) and: [
 									  each ~= aWidget ] ] ] ]
 		  ifNone: [ ^ nil ]
 ]


### PR DESCRIPTION
Some tools were crashing during verification of pop up strategy  like ```DrTests``` because they have no model.
@Ducasse 