### PR TITLE
Pop up strategy fix

### DIFF
--- a/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
@@ -24,7 +24,7 @@ CavPopUpStrategy >> findSameKindWindowAs: aWidget [
 						  each model notNil and: [
 								  (each model presenter
 									   ifNotNil: [ each model presenter class = aWidget class ]
-									   ifNil: [ each model class = aWidget model class ]) and: [
+									   ifNil: [ each model class = aWidget class ]) and: [
 									  each ~= aWidget ] ] ] ]
 		  ifNone: [ ^ nil ]
 ]


### PR DESCRIPTION
Some tools were crashing during verification of pop up strategy like DrTests because they have no model.

@Ducasse