### PR TITLE
small fix on NewTools-Spotter-Processors -> stQuery >> updatefromContext

### DIFF
--- a/src/NewTools-Spotter-Processors/StQuery.class.st
+++ b/src/NewTools-Spotter-Processors/StQuery.class.st
@@ -112,7 +112,7 @@ StQuery >> updateFromContext: aSpotterContext [
 
 	modifiers removeAll.
 	texts := (aSpotterContext search ifNil:[ '' ]) trimBoth.
-	textParts := texts substrings: { Character space. Character tab }.
+	textParts := texts asString substrings: { Character space. Character tab }.
 	query := ''.
 	
 	textParts do: [ :aPart | 


### PR DESCRIPTION
sometimes, aSpotterContext search can give back a Text object insteaad of a string, which doesn't understand the substrings: message, so I'm making sure that in textParts he always uses texts asString to make sure it doesn't happen :)