### PR TITLE
Removing Dead Code

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -78,7 +78,6 @@ Class {
 		'code',
 		'stackTable',
 		'inspector',
-		'breakpointInspector',
 		'stackHeader',
 		'extensionTools',
 		'extensionToolsNotebook',
@@ -808,13 +807,6 @@ StDebugger >> initialize [
 	self subscribeToSettingsChangesAnnouncements.
 
 	programmaticallyClosed := false
-]
-
-{ #category : 'initialization' }
-StDebugger >> initializeBreakpointInspector [
-	breakpointInspector := self
-		instantiate: StDebuggerBreakpointInspection
-		on: (StInspectorModel on: nil).
 ]
 
 { #category : 'code pane' }


### PR DESCRIPTION
This method is never call and it is used a class that has been removed.
Removing the instance variable that is not used anymore