### PR TITLE
Correct bug on swich profile functionnality

### DIFF
--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -365,6 +365,8 @@ CavroisWindowManager class >> startUp: isImageStarting [
 CavroisWindowManager class >> switchToProfile: profileKey [
 
 	| oldProfile newProfile oldKey newKey baseName presenter |
+	self current currentProfile = (self current profiles at: profileKey)
+		ifTrue: [ ^ self ].
 	presenter := SpConfirmDialog new
 		             title: 'Switch Profile';
 		             label: profileKey , 'will become the current profile';
@@ -373,8 +375,6 @@ CavroisWindowManager class >> switchToProfile: profileKey [
 		             onAccept: [ :dialog |
 				             oldProfile := self current currentProfile.
 				             newProfile := self current profiles at: profileKey.
-
-				             oldProfile = newProfile ifTrue: [ ^ self ].
 				             oldKey := self current profiles keyAtValue:
 						                       oldProfile.
 				             baseName := oldKey


### PR DESCRIPTION
Opened the dialog when clicking on the current profile ( so there is no switch to do in that case)