### PR TITLE
Fix for okbutton rename protocol

### DIFF
--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -179,7 +179,8 @@ StProtocolNameChooserPresenter >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter title: 'New protocol name'.
-	aWindowPresenter whenOpenedDo: [ protocolNameField takeKeyboardFocus ]
+	aWindowPresenter whenOpenedDo: [ protocolNameField takeKeyboardFocus ].
+	aWindowPresenter okAction: [ :text | self doAcceptFromTextInput ] 
 ]
 
 { #category : 'private - accessing' }


### PR DESCRIPTION
The rename wasnt working using the ok button.
@jecisc fix https://github.com/pharo-project/pharo/issues/18277