### PR TITLE
Improve new transcript

### DIFF
--- a/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
+++ b/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
@@ -24,7 +24,7 @@ StTranscriptPresenterTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : 'running' }
+{ #category : 'tests' }
 StTranscriptPresenterTest >> testAnnouncementIsWritten [
 
 	| window |
@@ -37,7 +37,7 @@ StTranscriptPresenterTest >> testAnnouncementIsWritten [
 	ensure: [ window close ]
 ]
 
-{ #category : 'running' }
+{ #category : 'tests' }
 StTranscriptPresenterTest >> testClear [
 
 	| window |
@@ -53,7 +53,7 @@ StTranscriptPresenterTest >> testClear [
 	ensure: [ window close ]
 ]
 
-{ #category : 'running' }
+{ #category : 'tests' }
 StTranscriptPresenterTest >> testFetchOld [
 
 	| window |
@@ -69,7 +69,7 @@ StTranscriptPresenterTest >> testFetchOld [
 	ensure: [ window close ]
 ]
 
-{ #category : 'running' }
+{ #category : 'tests' }
 StTranscriptPresenterTest >> testReset [
 
 	| window |
@@ -86,12 +86,15 @@ StTranscriptPresenterTest >> testReset [
 	ensure: [ window close ]
 ]
 
-{ #category : 'running' }
-StTranscriptPresenterTest >> testSmoke [ 
+{ #category : 'tests' }
+StTranscriptPresenterTest >> testSmoke [
 
 	| window |
-	
 	[ self shouldnt: [ window := presenter open ] raise: Error ] ensure: [ window close ].
+
+	[ self shouldnt: [ window := StTranscriptPresenter exampleDefault ] raise: Error ] ensure: [ window close ].
+
+	[ self shouldnt: [ window := StTranscriptPresenter exampleNonGlobalTranscript ] raise: Error ] ensure: [ window close ].
 
 	[ self shouldnt: [ window := presenter openDialog ] raise: Error ] ensure: [ window close ]
 ]

--- a/src/NewTools-Transcript/StThreadSafeTranscript.class.st
+++ b/src/NewTools-Transcript/StThreadSafeTranscript.class.st
@@ -18,7 +18,7 @@ Class {
 		'worker'
 	],
 	#classVars : [
-		'UniqueInstance'
+		'Default'
 	],
 	#category : 'NewTools-Transcript',
 	#package : 'NewTools-Transcript'
@@ -31,6 +31,13 @@ StThreadSafeTranscript class >> createTestingInstance [
 	^ super new.
 ]
 
+{ #category : 'instance creation' }
+StThreadSafeTranscript class >> defaultInstance [
+
+	<script>
+	^ Default ifNil: [ Default := super new ]
+]
+
 { #category : 'declare' }
 StThreadSafeTranscript class >> install [
 
@@ -39,22 +46,16 @@ StThreadSafeTranscript class >> install [
 
 { #category : 'declare' }
 StThreadSafeTranscript class >> installThreadSafeAsTranscript [
+
 	<script>
-
-	Smalltalk globals at: #Transcript put: self uniqueInstance
-]
-
-{ #category : 'instance creation' }
-StThreadSafeTranscript class >> new [
-
-	self error: 'You cannot create instances of this class. Use Singleton instead'
+	Smalltalk globals at: #Transcript put: self defaultInstance
 ]
 
 { #category : 'declare' }
 StThreadSafeTranscript class >> reset [
 	<script>
 
-	UniqueInstance := nil
+	Default := nil
 ]
 
 { #category : 'icons' }
@@ -66,10 +67,9 @@ StThreadSafeTranscript class >> taskbarIconName [
 
 { #category : 'instance creation' }
 StThreadSafeTranscript class >> uniqueInstance [
-	
-	<script>
-	^ UniqueInstance ifNil: [
-		UniqueInstance := super new ]
+
+	self deprecated: 'Use #defaultInstance' transformWith: '`@rcv uniqueInstance' -> '`@rcv defaultInstance'.
+	^ self defaultInstance
 ]
 
 { #category : 'streaming' }

--- a/src/NewTools-Transcript/StTranscriptPresenter.class.st
+++ b/src/NewTools-Transcript/StTranscriptPresenter.class.st
@@ -28,24 +28,24 @@ StTranscriptPresenter class >> defaultPreferredExtent [
 ]
 
 { #category : 'accessing' }
-StTranscriptPresenter class >> example [
+StTranscriptPresenter class >> exampleDefault [
 	"this example shows that we can use a different instance than the singleton."
+
 	<script>
-	
-	| t tr |
-	t := self new. 
-	tr := StThreadSafeTranscript new.
-	tr show: 'Hello Pharo I''m a new textual transcript'.
-	t transcript: tr.
-	t open. 
+	^ self new open
 ]
 
 { #category : 'accessing' }
-StTranscriptPresenter class >> exampleDefault [
+StTranscriptPresenter class >> exampleNonGlobalTranscript [
 	"this example shows that we can use a different instance than the singleton."
+
 	<script>
-	
-	self new open
+	| presenter transcript |
+	presenter := self new.
+	transcript := StThreadSafeTranscript new.
+	transcript show: 'Hello Pharo I''m a new textual transcript'.
+	presenter transcript: transcript.
+	^ presenter open
 ]
 
 { #category : 'tools registry' }
@@ -119,11 +119,11 @@ StTranscriptPresenter >> fetchOld [
 ]
 
 { #category : 'initialization' }
-StTranscriptPresenter >> initialize [ 
+StTranscriptPresenter >> initialize [
 
 	super initialize.
-	self registerToAnnouncer. 
-	transcript := StThreadSafeTranscript uniqueInstance.
+	self registerToAnnouncer.
+	transcript := StThreadSafeTranscript defaultInstance.
 	keepServiceAliveStep := 0
 ]
 


### PR DESCRIPTION
- Fix example
- Add smoke test on examples
- Allow to have a non global transcript (and rename the singleton accessor from #uniqueInstance to #defaultInstance)

Fixes #1160