### PR TITLE
Addition of cellMode to position Window

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -12,280 +12,270 @@ Class {
 BaselineOfNewTools >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ 
-		spec preLoadDoIt: #preload:package:.
-		spec postLoadDoIt: #postload:package:.
+	spec for: #common do: [
+			spec preLoadDoIt: #preload:package:.
+			spec postLoadDoIt: #postload:package:.
 
-		self sindarin: spec.
-		self chest: spec.
-		self graphAlgorithms: spec.
+			self sindarin: spec.
+			self chest: spec.
+			self graphAlgorithms: spec.
 
-		spec
-			package: 'NewTools-Core';
-			package: 'NewTools-Core-Tests' with: [  spec requires: #('NewTools-Core') ];
-			package: 'NewTools-Morphic';
-			package: 'NewTools-Gtk';
-			
-			"Basic tools (inherited from Spec)"
-			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
-			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
-			
-			"inspector"
-			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector-Extensions' ) ];
-			package: 'NewTools-Inspector-Extensions' with: [ spec requires: #( 'NewTools-Core' ) ];
-			package: 'NewTools-Inspector-Tests' with: [ spec requires: #( 'NewTools-Inspector' ) ];
-			
-			"debugger"
-			package: 'NewTools-Debugger' with: [ 
-					spec requires: #( 'NewTools-Core' 
-									'NewTools-Inspector' 
-									'NewTools-Debugger-Commands' 
-									'NewTools-Debugger-Extensions' 
-									'NewTools-SpTextPresenterDecorators' ) ];
-			package: 'NewTools-Debugger-Commands';
-			package: 'NewTools-Debugger-Extensions';
-			package: 'NewTools-Debugger-Morphic';
-			package: 'NewTools-Debugger-Tests' with: [ spec requires: #( 'NewTools-Debugger' ) ];
-		
-			"playground"
-			package: 'NewTools-Playground' with: [ spec requires: #( 'NewTools-Core'  'NewTools-Inspector' ) ];
-			package: 'NewTools-Playground-Tests' with: [ spec requires: #( 'NewTools-Playground' ) ];
-		
-			"closed windows"
-			package: 'NewTools-WindowManager';
-			package: 'NewTools-WindowManager-Tests' with: [  spec requires: #( 'NewTools-Core' 'NewTools-WindowManager') ];
-	
-			"browser"
-			package: 'NewTools-SystemBrowser' with: [ spec requires: #('NewTools-Core' 'NewTools-Inspector' ) ];
-	
-			"system reporter"
-			package: 'NewTools-SystemReporter' with: [ spec requires: #( 'NewTools-Core' ) ];
-	
-			"spotter"
-			package: 'NewTools-Spotter-Processors';
-			package: 'NewTools-Spotter' with: [ spec requires: #( 'NewTools-Core' 'NewTools-Spotter-Processors' ) ];
-			package: 'NewTools-Spotter-Extensions' with: [ spec requires: #( 'NewTools-Spotter' ) ];
-			package: 'NewTools-Spotter-Processors-Tests' with: [ spec requires: #( 'NewTools-Spotter-Processors' ) ];
-			package: 'NewTools-Spotter-Tests' with: [ spec requires: #( 'NewTools-Spotter' ) ];
-			package: 'NewTools-Morphic-Spotter' with: [ spec requires: #( 'NewTools-Morphic' ) ];
-	
-			"file browser"
-			package: 'NewTools-FileBrowser' with: [ spec requires: #( 'NewTools-Core' ) ];
-			package: 'NewTools-FileBrowser-Morphic' with: [ spec requires: #( 'NewTools-FileBrowser' ) ];
-			package: 'NewTools-FileBrowser-Tests' with: [ spec requires: #( 'NewTools-FileBrowser' ) ];
-	
-			"dependency analyser"
-			package: 'NewTools-DependencyAnalyser' with: [ spec requires: #('AIGraphAlgorithms') ];
-			package: 'NewTools-DependencyAnalyser-Tests' with: [ spec
-					requires: #( 'NewTools-DependencyAnalyser' 'NewTools-DependencyAnalyser-Tests-Data' ) ];
-			package: 'NewTools-DependencyAnalyser-Tests-Data';
-			package: 'NewTools-DependencyAnalyser-UI' with: [ spec requires: #( 'NewTools-Core' 'NewTools-DependencyAnalyser' ) ];
-	
-			"extras"
-			package: 'HelpCenter' with: [ spec requires: #( 'NewTools-Core' ) ];
-			
-			package: 'NewTools-FlagBrowser' with: [ spec requires: #( 'NewTools-Core' ) ];
-			package: 'NewTools-FlagBrowser-Tests' with: [ spec requires: #( 'NewTools-FlagBrowser' ) ];			
-			package: 'NewTools-FontChooser' with: [ spec requires: #( 'NewTools-Core' ) ];
-			package: 'NewTools-FontChooser-Tests' with: [ spec requires: #( 'NewTools-FontChooser' ) ];
-			package: 'NewTools-SpTextPresenterDecorators';
-	
-			"Debug points"
-			package: 'NewTools-DebugPointsBrowser' with: [spec requires: #( 'NewTools-Core' 'NewTools-SpTextPresenterDecorators' )];
-			package: 'NewTools-ObjectCentricDebugPoints' with: [ spec requires: #( 'NewTools-DebugPointsBrowser' 'NewTools-Inspector' 'NewTools-Debugger' )];
-			package: 'NewTools-ProjectLoader' with: [ spec requires: #( 'NewTools-Core') ] ;
-			package: 'NewTools-ProjectLoader-Microdown';
-	
-			"Object-centric breakpoints"
-			package: 'NewTools-ObjectCentricBreakpoints'  with: [ spec requires: #( 'NewTools-Inspector') ] ;
-	
-			"Sindarin"
-			package: 'NewTools-Sindarin-Commands';
-			package: 'NewTools-Sindarin-Commands-Tests' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
-			package: 'NewTools-Sindarin-Tools' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
-	
-			"package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];""Debugger Selector"
-			package: 'NewTools-DebuggerSelector' with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];
-			package: 'NewTools-DebuggerSelector-Tests' with: [ spec requires: #( 'NewTools-DebuggerSelector' ) ];
-	
-			"CritiqueBrowser"
-			package: 'NewTools-CodeCritiques' with: [ spec requires: #( 'NewTools-Core' ) ];
-			package: 'NewTools-CodeCritiques-Tests';
-			
-			"Window Profile"
-			package: 'NewTools-Window-Profiles' with: [ spec requires: #('NewTools-Core')] ;
-			
-			
-			"Fuel"
-			package: 'NewTools-Debugger-Fuel';
-			package: 'NewTools-Debugger-Fuel-Tests' with: [ spec requires: #( 'NewTools-Debugger-Fuel' ) ];
-   
-	  		"Rewriter Tools"
-			package: 'NewTools-RewriterTools-Backend';
-			package: 'NewTools-RewriterTools' with: [ spec requires: #( 'NewTools-Core' 'NewTools-RewriterTools-Backend') ];
-			package: 'NewTools-RewriterTools-Backend-Tests' with: [ spec requires: #('NewTools-RewriterTools-Backend') ];
-			package: 'NewTools-RewriterTools-Tests' with: [ spec requires: #('NewTools-RewriterTools') ];
-			
-			"Profiler"
-			package: 'NewTools-ProfilerUI'  with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators') ];
-			
-			"Scopes Editor"
-			package: 'NewTools-Scopes';
-			package: 'NewTools-Scopes-Editor' with: [ spec requires: #('NewTools-Core' 'NewTools-Scopes') ];
-			package: 'NewTools-Scopes-Tests' with: [ spec requires: #('NewTools-Scopes' 'NewTools-Scopes-Resources-A-Tests'
-			 'NewTools-Scopes-Resources-B-Tests'
-			 'NewTools-Scopes-Resources-C-Tests' )];
-			package: 'NewTools-Scopes-Resources-A-Tests';
-			package: 'NewTools-Scopes-Resources-B-Tests';
-			package: 'NewTools-Scopes-Resources-C-Tests';
-			package: 'NewTools-Scopes-Tests';
-			"Finder"			
-			package: 'NewTools-Finder'  with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-Finder-Tests' with: [ spec requires: #('NewTools-Finder') ];
-			
-			package: 'NewTools-SettingsBrowser' with: [ spec requires: #('ColorPicker') ];
-			package: 'NewTools-SettingsBrowser-Tests' with: [ spec requires: #('NewTools-SettingsBrowser') ];
-			
-			package: 'NewTools-Utils' with: [ spec requires: #('NewTools-FileBrowser') ];
+			spec
+				package: 'NewTools-Core';
+				package: 'NewTools-Core-Tests'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-Morphic';
+				package: 'NewTools-Gtk';
+				"Basic tools (inherited from Spec)"package:
+					'NewTools-MethodBrowsers'
+				with: [
+						spec requires:
+								#( 'NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
+				package: 'NewTools-MethodBrowsers-Tests'
+				with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
+				"inspector"package: 'NewTools-Inspector'
+				with: [
+					spec requires:
+							#( 'NewTools-Core' 'NewTools-Inspector-Extensions' ) ];
+				package: 'NewTools-Inspector-Extensions'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-Inspector-Tests'
+				with: [ spec requires: #( 'NewTools-Inspector' ) ];
+				"debugger"package: 'NewTools-Debugger' with: [
+						spec requires:
+								#( 'NewTools-Core' 'NewTools-Inspector' 'NewTools-Debugger-Commands'
+								   'NewTools-Debugger-Extensions'
+								   'NewTools-SpTextPresenterDecorators' ) ];
+				package: 'NewTools-Debugger-Commands';
+				package: 'NewTools-Debugger-Extensions';
+				package: 'NewTools-Debugger-Morphic';
+				package: 'NewTools-Debugger-Tests'
+				with: [ spec requires: #( 'NewTools-Debugger' ) ];
+				"playground"package: 'NewTools-Playground'
+				with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector' ) ];
+				package: 'NewTools-Playground-Tests'
+				with: [ spec requires: #( 'NewTools-Playground' ) ];
+				"closed windows"package: 'NewTools-WindowManager';
+				package: 'NewTools-WindowManager-Tests'
+				with: [
+					spec requires: #( 'NewTools-Core' 'NewTools-WindowManager' ) ];
+				"browser"package: 'NewTools-SystemBrowser'
+				with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector' ) ];
+				"system reporter"package: 'NewTools-SystemReporter'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				"spotter"package: 'NewTools-Spotter-Processors';
+				package: 'NewTools-Spotter'
+				with: [
+					spec requires: #( 'NewTools-Core' 'NewTools-Spotter-Processors' ) ];
+				package: 'NewTools-Spotter-Extensions'
+				with: [ spec requires: #( 'NewTools-Spotter' ) ];
+				package: 'NewTools-Spotter-Processors-Tests'
+				with: [ spec requires: #( 'NewTools-Spotter-Processors' ) ];
+				package: 'NewTools-Spotter-Tests'
+				with: [ spec requires: #( 'NewTools-Spotter' ) ];
+				package: 'NewTools-Morphic-Spotter'
+				with: [ spec requires: #( 'NewTools-Morphic' ) ];
+				"file browser"package: 'NewTools-FileBrowser'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-FileBrowser-Morphic'
+				with: [ spec requires: #( 'NewTools-FileBrowser' ) ];
+				package: 'NewTools-FileBrowser-Tests'
+				with: [ spec requires: #( 'NewTools-FileBrowser' ) ];
+				"dependency analyser"package: 'NewTools-DependencyAnalyser'
+				with: [ spec requires: #( 'AIGraphAlgorithms' ) ];
+				package: 'NewTools-DependencyAnalyser-Tests' with: [
+						spec requires:
+								#( 'NewTools-DependencyAnalyser' 'NewTools-DependencyAnalyser-Tests-Data' ) ];
+				package: 'NewTools-DependencyAnalyser-Tests-Data';
+				package: 'NewTools-DependencyAnalyser-UI'
+				with: [
+					spec requires: #( 'NewTools-Core' 'NewTools-DependencyAnalyser' ) ];
+				"extras"package: 'HelpCenter'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-FlagBrowser'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-FlagBrowser-Tests'
+				with: [ spec requires: #( 'NewTools-FlagBrowser' ) ];
+				package: 'NewTools-FontChooser'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-FontChooser-Tests'
+				with: [ spec requires: #( 'NewTools-FontChooser' ) ];
+				package: 'NewTools-SpTextPresenterDecorators';
+				"Debug points"package: 'NewTools-DebugPointsBrowser' with: [
+						spec requires:
+								#( 'NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
+				package: 'NewTools-ObjectCentricDebugPoints' with: [
+						spec requires:
+								#( 'NewTools-DebugPointsBrowser' 'NewTools-Inspector'
+								   'NewTools-Debugger' ) ];
+				package: 'NewTools-ProjectLoader'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-ProjectLoader-Microdown';
+				"Object-centric breakpoints"package:
+					'NewTools-ObjectCentricBreakpoints'
+				with: [ spec requires: #( 'NewTools-Inspector' ) ];
+				"Sindarin"package: 'NewTools-Sindarin-Commands';
+				package: 'NewTools-Sindarin-Commands-Tests' with: [
+						spec requires: #( 'NewTools-Sindarin-Commands'
+							   'Sindarin' ) ];
+				package: 'NewTools-Sindarin-Tools' with: [
+						spec requires: #( 'NewTools-Sindarin-Commands'
+							   'Sindarin' ) ];
+				"package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];""Debugger Selector"
+				package: 'NewTools-DebuggerSelector'
+				with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];
+				package: 'NewTools-DebuggerSelector-Tests'
+				with: [ spec requires: #( 'NewTools-DebuggerSelector' ) ];
+				"CritiqueBrowser"package: 'NewTools-CodeCritiques'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-CodeCritiques-Tests';
+				"Window Profile"package: 'NewTools-Window-Profiles'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-Window-Profiles-Tests'
+				with: [
+					spec requires: #( 'NewTools-Core' 'NewTools-Window-Profiles' ) ];
+				"Fuel"package: 'NewTools-Debugger-Fuel';
+				package: 'NewTools-Debugger-Fuel-Tests'
+				with: [ spec requires: #( 'NewTools-Debugger-Fuel' ) ];
+				"Rewriter Tools"package: 'NewTools-RewriterTools-Backend';
+				package: 'NewTools-RewriterTools' with: [
+					spec requires:
+							#( 'NewTools-Core' 'NewTools-RewriterTools-Backend' ) ];
+				package: 'NewTools-RewriterTools-Backend-Tests'
+				with: [ spec requires: #( 'NewTools-RewriterTools-Backend' ) ];
+				package: 'NewTools-RewriterTools-Tests'
+				with: [ spec requires: #( 'NewTools-RewriterTools' ) ];
+				"Profiler"package: 'NewTools-ProfilerUI' with: [
+						spec requires:
+								#( 'NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
+				"Scopes Editor"package: 'NewTools-Scopes';
+				package: 'NewTools-Scopes-Editor'
+				with: [ spec requires: #( 'NewTools-Core' 'NewTools-Scopes' ) ];
+				package: 'NewTools-Scopes-Tests' with: [
+						spec requires:
+								#( 'NewTools-Scopes' 'NewTools-Scopes-Resources-A-Tests'
+								   'NewTools-Scopes-Resources-B-Tests'
+								   'NewTools-Scopes-Resources-C-Tests' ) ];
+				package: 'NewTools-Scopes-Resources-A-Tests';
+				package: 'NewTools-Scopes-Resources-B-Tests';
+				package: 'NewTools-Scopes-Resources-C-Tests';
+				package: 'NewTools-Scopes-Tests';
+				"Finder"package: 'NewTools-Finder'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-Finder-Tests'
+				with: [ spec requires: #( 'NewTools-Finder' ) ];
+				package: 'NewTools-SettingsBrowser'
+				with: [ spec requires: #( 'ColorPicker' ) ];
+				package: 'NewTools-SettingsBrowser-Tests'
+				with: [ spec requires: #( 'NewTools-SettingsBrowser' ) ];
+				package: 'NewTools-Utils'
+				with: [ spec requires: #( 'NewTools-FileBrowser' ) ];
+				package: 'NewTools-WelcomeBrowser'
+				with: [ spec requires: #( 'NewTools-Core' 'NewTools-Morphic' ) ];
+				package: 'NewTools-ShortcutsBrowser'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-ObjectTranscript'
+				with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector' ) ];
+				package: 'NewTools-Transcript'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'NewTools-Transcript-Tests'
+				with: [ spec requires: #( 'NewTools-Transcript' ) ];
+				"Shout UI"package: 'NewTools-Shout-UI'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				"Houston we have a bug, ColorPicker depends on roassal! "package:
+					'ColorPicker'
+				with: [ spec requires: #( 'NewTools-Core' ) ];
+				package: 'ColorPicker-Tests'
+				with: [ spec requires: #( ColorPicker ) ];
+				package: 'NewTools-ProcessBrowser'
+				with: [ spec requires: #( 'NewTools-Core' ) ].
 
-			package: 'NewTools-WelcomeBrowser'  with: [ spec requires: #('NewTools-Core' 'NewTools-Morphic') ];
-			
-			package: 'NewTools-ShortcutsBrowser'  with: [ spec requires: #('NewTools-Core' ) ];
-			
-			package: 'NewTools-ObjectTranscript'  with: [ spec requires: #('NewTools-Core' 'NewTools-Inspector') ];
-			package: 'NewTools-Transcript'  with: [ spec requires: #('NewTools-Core') ];
-			package: 'NewTools-Transcript-Tests' with: [ spec requires: #( 'NewTools-Transcript' ) ];
-			
-			"Shout UI"
-			package: 'NewTools-Shout-UI'  with: [ spec requires: #('NewTools-Core') ];
-		
-			"Houston we have a bug, ColorPicker depends on roassal! "
-			package: 'ColorPicker'  with: [ spec requires: #('NewTools-Core' ) ];
-			package: 'ColorPicker-Tests' with: [ spec requires: #( ColorPicker ) ];
-			
-			package: 'NewTools-ProcessBrowser' with: [ spec requires: #('NewTools-Core') ].
-
-		spec
-			group: 'Core' with: #( 'NewTools-Core' 'NewTools-Core-Tests' 'NewTools-Morphic' );
-
-			group: 'Playground' with: #( 'NewTools-Playground' 'NewTools-Playground-Tests' );
-
-			group: 'Inspector' with: #( 'Core' 'NewTools-Inspector' 'NewTools-Inspector-Tests' );
-
-			group: 'ClosedWindows' with: #( 'Core' 'NewTools-WindowManager' 'NewTools-WindowManager-Tests' );
-			
-			group: 'Profile' with: #( 'NewTools-Window-Profiles' );
-			
-			group: 'Transcript' with: #( 'Core' 'NewTools-Transcript-Tests' 'NewTools-ObjectTranscript' );
-			
-			
-			group: 'Debugger' with: #( 
-					 	'Core' 
-					 	'Inspector' 
-					 	'NewTools-Debugger-Commands'
-				    	'NewTools-Debugger-Extensions' 
-					 	'NewTools-Debugger'
-
-						'NewTools-Debugger-Morphic'
-				    	'NewTools-ObjectCentricBreakpoints'
-				    	'NewTools-Sindarin-Tools' 
-
-					 	'NewTools-Sindarin-Commands'
-				    	'NewTools-Sindarin-Commands-Tests'
-				    	'NewTools-Debugger-Tests' 
-					 	'NewTools-Debugger-Fuel'
-				    	'NewTools-Debugger-Fuel-Tests' 
-					 	'NewTools-Utils'
-						'NewTools-DebugPointsBrowser'
-						'NewTools-ObjectCentricDebugPoints' );
-
-			group: 'Spotter' with: #( 
-						'NewTools-Morphic-Spotter' 
-						'NewTools-Spotter-Processors'
-				   		'NewTools-Spotter' 
-						'NewTools-Spotter-Extensions'
-				   		'NewTools-Spotter-Tests' 
-						'NewTools-Spotter-Processors-Tests' );
-
-			group: 'SystemReporter' with: #( 'Core' 'NewTools-SystemReporter' );
-
-			group: 'Methods' with: #( 'Core' 'NewTools-SpTextPresenterDecorators' 'NewTools-MethodBrowsers' );
-			"Not in the image for the moment, we need a pass on them"
-
-			group: 'CritiqueBrowser' with: #( 'NewTools-CodeCritiques' 'NewTools-CodeCritiques-Tests' );
-
-			group: 'FontChooser' with: #( 'Core' 'NewTools-FontChooser' 'NewTools-FontChooser-Tests' );
-
-			group: 'FlagBrowser' with: #( 
-						'Core' 
-						'NewTools-FlagBrowser' 
-						'NewTools-FlagBrowser-Tests' );
-			
-			group: 'development' with: #( 'default' 
-						'NewTools-DebuggerSelector'
-				   		'NewTools-DebuggerSelector-Tests' );
-			
-			group: 'FileBrowser' with: #( 
-						'NewTools-FileBrowser'
-						'NewTools-FileBrowser-Morphic'
-						'NewTools-FileBrowser-Tests' );
-      		
-			group: 'RewriterTools' with: #(
-				    		'NewTools-RewriterTools-Backend'
-				    		'NewTools-RewriterTools'
-				    		'NewTools-RewriterTools-Backend-Tests'
-				    		'NewTools-RewriterTools-Tests' );
-			
-			group: 'Profiler' with: #( 'NewTools-ProfilerUI' );
-	
-			"ScopesEditor"
-			group: 'ScopesEditor' with: #(
-						'NewTools-Scopes' 
-						'NewTools-Scopes-Editor' 
-						'NewTools-Scopes-Resources-A-Tests' 
-						'NewTools-Scopes-Resources-B-Tests' 
-						'NewTools-Scopes-Resources-C-Tests' 
-						'NewTools-Scopes-Tests');
-			
-			"Finder"
-			group: 'Finder' with: #(
-						'NewTools-Finder'
-						'NewTools-Finder-Tests');
-			"Settings Browser"
-			group: 'SettingsBrowser' with: #(
-						'NewTools-SettingsBrowser'
-						'NewTools-SettingsBrowser-Tests');
-						
-			group: 'WelcomeBrowser' with: #( 'NewTools-WelcomeBrowser' );
-			group: 'ShortcutsBrowser' with: #( 'NewTools-ShortcutsBrowser' );	
-			group: 'ColorPickerGroup' with: #('ColorPicker' 'ColorPicker-Tests');
-			group: 'ProcessBrowser' with: #('NewTools-ProcessBrowser');
-			group: 'DependencyAnalyser' with: #('NewTools-DependencyAnalyser-UI' 'NewTools-DependencyAnalyser-Tests');
-			
-
-			group: 'default' with: #( 
-			         'Profile'
-						'Playground'
-						'Transcript'
-						'Inspector' 
-						'ClosedWindows'
-						'CritiqueBrowser' 
-						'Debugger'
-				   		'SystemReporter' 
-						'FontChooser' 
-						'Methods'
-				   		'Spotter'
-		            	'RewriterTools'
-						'ScopesEditor'
-						'FileBrowser'
-						'Finder'
-						'Profiler'
-						'SettingsBrowser'
-						'WelcomeBrowser'
-						'ShortcutsBrowser'
-						'ColorPickerGroup'
-						'ProcessBrowser'
-						'DependencyAnalyser' ) ]
+			spec
+				group: 'Core'
+				with:
+					#( 'NewTools-Core' 'NewTools-Core-Tests' 'NewTools-Morphic' );
+				group: 'Playground'
+				with: #( 'NewTools-Playground' 'NewTools-Playground-Tests' );
+				group: 'Inspector'
+				with: #( 'Core' 'NewTools-Inspector' 'NewTools-Inspector-Tests' );
+				group: 'ClosedWindows'
+				with:
+					#( 'Core' 'NewTools-WindowManager' 'NewTools-WindowManager-Tests' );
+				group: 'Profile'
+				with:
+					#( 'NewTools-Window-Profiles' 'NewTools-Window-Profiles-Tests' );
+				group: 'Transcript'
+				with:
+					#( 'Core' 'NewTools-Transcript-Tests' 'NewTools-ObjectTranscript' );
+				group: 'Debugger'
+				with: #( 'Core' 'Inspector' 'NewTools-Debugger-Commands'
+					   'NewTools-Debugger-Extensions' 'NewTools-Debugger'
+					   'NewTools-Debugger-Morphic' 'NewTools-ObjectCentricBreakpoints'
+					   'NewTools-Sindarin-Tools' 'NewTools-Sindarin-Commands'
+					   'NewTools-Sindarin-Commands-Tests'
+					   'NewTools-Debugger-Tests' 'NewTools-Debugger-Fuel'
+					   'NewTools-Debugger-Fuel-Tests' 'NewTools-Utils'
+					   'NewTools-DebugPointsBrowser' 'NewTools-ObjectCentricDebugPoints' );
+				group: 'Spotter'
+				with: #( 'NewTools-Morphic-Spotter' 'NewTools-Spotter-Processors'
+					   'NewTools-Spotter' 'NewTools-Spotter-Extensions'
+					   'NewTools-Spotter-Tests' 'NewTools-Spotter-Processors-Tests' );
+				group: 'SystemReporter'
+				with: #( 'Core' 'NewTools-SystemReporter' );
+				group: 'Methods'
+				with: #( 'Core' 'NewTools-SpTextPresenterDecorators'
+					   'NewTools-MethodBrowsers' );
+				"Not in the image for the moment, we need a pass on them"group:
+					'CritiqueBrowser'
+				with: #( 'NewTools-CodeCritiques' 'NewTools-CodeCritiques-Tests' );
+				group: 'FontChooser'
+				with:
+					#( 'Core' 'NewTools-FontChooser' 'NewTools-FontChooser-Tests' );
+				group: 'FlagBrowser'
+				with:
+					#( 'Core' 'NewTools-FlagBrowser' 'NewTools-FlagBrowser-Tests' );
+				group: 'development'
+				with:
+					#( 'default' 'NewTools-DebuggerSelector'
+					   'NewTools-DebuggerSelector-Tests' );
+				group: 'FileBrowser'
+				with: #( 'NewTools-FileBrowser' 'NewTools-FileBrowser-Morphic'
+					   'NewTools-FileBrowser-Tests' );
+				group: 'RewriterTools'
+				with:
+					#( 'NewTools-RewriterTools-Backend'
+					   'NewTools-RewriterTools' 'NewTools-RewriterTools-Backend-Tests'
+					   'NewTools-RewriterTools-Tests' );
+				group: 'Profiler' with: #( 'NewTools-ProfilerUI' );
+				"ScopesEditor"group: 'ScopesEditor'
+				with:
+					#( 'NewTools-Scopes' 'NewTools-Scopes-Editor'
+					   'NewTools-Scopes-Resources-A-Tests'
+					   'NewTools-Scopes-Resources-B-Tests'
+					   'NewTools-Scopes-Resources-C-Tests'
+					   'NewTools-Scopes-Tests' );
+				"Finder"group: 'Finder'
+				with: #( 'NewTools-Finder' 'NewTools-Finder-Tests' );
+				"Settings Browser"group: 'SettingsBrowser'
+				with:
+					#( 'NewTools-SettingsBrowser' 'NewTools-SettingsBrowser-Tests' );
+				group: 'WelcomeBrowser' with: #( 'NewTools-WelcomeBrowser' );
+				group: 'ShortcutsBrowser' with: #( 'NewTools-ShortcutsBrowser' );
+				group: 'ColorPickerGroup'
+				with: #( 'ColorPicker' 'ColorPicker-Tests' );
+				group: 'ProcessBrowser' with: #( 'NewTools-ProcessBrowser' );
+				group: 'DependencyAnalyser'
+				with:
+					#( 'NewTools-DependencyAnalyser-UI'
+					   'NewTools-DependencyAnalyser-Tests' );
+				group: 'default'
+				with:
+					#( 'Profile' 'Playground' 'Transcript' 'Inspector' 'ClosedWindows'
+					   'CritiqueBrowser' 'Debugger' 'SystemReporter' 'FontChooser'
+					   'Methods' 'Spotter' 'RewriterTools' 'ScopesEditor'
+					   'FileBrowser' 'Finder' 'Profiler' 'SettingsBrowser'
+					   'WelcomeBrowser' 'ShortcutsBrowser' 'ColorPickerGroup'
+					   'ProcessBrowser' 'DependencyAnalyser' ) ]
 ]
 
 { #category : 'external projects' }

--- a/src/NewTools-Window-Profiles-Tests/CavWindowProfileTest.class.st
+++ b/src/NewTools-Window-Profiles-Tests/CavWindowProfileTest.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : 'CavWindowProfileTest',
 	#superclass : 'TestCase',
 	#category : 'NewTools-Window-Profiles-Tests',
-	#package : 'NewTools-Window-Profiles',
-	#tag : 'Tests'
+	#package : 'NewTools-Window-Profiles-Tests'
 }
 
 { #category : 'tests' }

--- a/src/NewTools-Window-Profiles-Tests/CavWindowStrategyTest.class.st
+++ b/src/NewTools-Window-Profiles-Tests/CavWindowStrategyTest.class.st
@@ -6,8 +6,7 @@ Class {
 		'placeHolder'
 	],
 	#category : 'NewTools-Window-Profiles-Tests',
-	#package : 'NewTools-Window-Profiles',
-	#tag : 'Tests'
+	#package : 'NewTools-Window-Profiles-Tests'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Window-Profiles-Tests/CavroisWindowManagerTest.class.st
+++ b/src/NewTools-Window-Profiles-Tests/CavroisWindowManagerTest.class.st
@@ -6,8 +6,7 @@ Class {
 		'virtualFS'
 	],
 	#category : 'NewTools-Window-Profiles-Tests',
-	#package : 'NewTools-Window-Profiles',
-	#tag : 'Tests'
+	#package : 'NewTools-Window-Profiles-Tests'
 }
 
 { #category : 'running' }

--- a/src/NewTools-Window-Profiles-Tests/CavroisWindowPlaceHolderTest.class.st
+++ b/src/NewTools-Window-Profiles-Tests/CavroisWindowPlaceHolderTest.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : 'CavroisWindowPlaceHolderTest',
 	#superclass : 'TestCase',
 	#category : 'NewTools-Window-Profiles-Tests',
-	#package : 'NewTools-Window-Profiles',
-	#tag : 'Tests'
+	#package : 'NewTools-Window-Profiles-Tests'
 }
 
 { #category : 'tests' }
@@ -20,7 +19,7 @@ CavroisWindowPlaceHolderTest >> testHolderStrategyBackLinkIsKeptOnSetter [
 
 
 	| h |
-	h := CavWindowPlaceHolder new.
+	h := CavWindowPlaceHolder new. 
 	h strategy: CavReplaceStrategy new. 
 	self assert: h strategy placeHolder equals: h 
 ]

--- a/src/NewTools-Window-Profiles-Tests/package.st
+++ b/src/NewTools-Window-Profiles-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Window-Profiles-Tests' }

--- a/src/NewTools-Window-Profiles/CavVisualPlaceHolderMorph.class.st
+++ b/src/NewTools-Window-Profiles/CavVisualPlaceHolderMorph.class.st
@@ -25,8 +25,10 @@ CavVisualPlaceHolderMorph >> changeStrategy [
 		             items: CavWindowStrategy subclasses;
 		             display: [ :each | each title ];
 		             onAccept: [ :dialog |
-			             placeHolder strategy:
-					             dialog presenter selectedItem new ].
+				             placeHolder strategy:
+						             dialog presenter selectedItem new.
+				             CavroisWindowManager toggleProfilePlaceholders.
+				             CavroisWindowManager toggleProfilePlaceholders ].
 	description := presenter newText text:
 		               presenter list selectedItem comment.
 	presenter layout add: description.

--- a/src/NewTools-Window-Profiles/CavWindowStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavWindowStrategy.class.st
@@ -23,4 +23,6 @@ CavWindowStrategy >> placeHolder: anObject [
 
 { #category : 'positioning' }
 CavWindowStrategy >> placePresenter: aPresenter [
+
+	
 ]

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -481,6 +481,7 @@ CavroisWindowManager class >> updateCurrentProfileAfterDeletion: deletedProfileK
 { #category : 'updating' }
 CavroisWindowManager class >> updateProfile [
 
+	self removeGrid.
 	self current updateProfile
 ]
 

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -36,7 +36,8 @@ Class {
 		'defaultLocation',
 		'placeHolderIndices',
 		'cellSize',
-		'cells'
+		'cells',
+		'previousClosestPlaceholder'
 	],
 	#classVars : [
 		'Current'
@@ -632,6 +633,32 @@ CavroisWindowManager >> handleCellWindowDrop: aWindow at: aPoint [
 		closestPlaceHolder placePresenter: aWindow ]
 ]
 
+{ #category : 'handling' }
+CavroisWindowManager >> handleWindowDrag: aWindow at: aPoint [
+
+	| closestPlaceHolder closestDistance |
+	closestPlaceHolder := nil.
+	closestDistance := Float infinity.
+	World submorphs do: [ :morph |
+			(morph isKindOf: CavVisualPlaceHolderMorph) ifTrue: [
+					| distance |
+					distance := morph position distanceTo: aPoint.
+					distance < closestDistance ifTrue: [
+							closestPlaceHolder := morph.
+							closestDistance := distance ] ] ].
+
+	previousClosestPlaceholder ifNotNil: [
+			previousClosestPlaceholder ~= closestPlaceHolder ifTrue: [
+					previousClosestPlaceholder color:
+						(Smalltalk ui theme lightSelectionColor alpha: 0.4) ] ].
+
+	closestPlaceHolder ifNotNil: [
+			closestPlaceHolder color:
+				(Smalltalk ui theme lightSelectionColor alpha: 0.7) ].
+
+	previousClosestPlaceholder := closestPlaceHolder
+]
+
 { #category : 'initialization' }
 CavroisWindowManager >> initialize [
 
@@ -649,23 +676,41 @@ CavroisWindowManager >> initialize [
 { #category : 'initialization' }
 CavroisWindowManager >> initializeBlocks [
 
-	WorldMorph cavroisDropBlock: [ :anEvent |
-			| manager |
-			manager := CavroisWindowManager current.
-			manager cellSize ifNotNil: [
-					manager removeVisualPlaceholders.
-					manager
-						handleCellWindowDrop: anEvent contents
-						at: anEvent contents position ] ].
 	WorldMorph cavroisResizeBlock: [
 			CavroisWindowManager current cellSize ifNotNil: [ :size |
 					CavroisWindowManager current resetCells.
 					CavroisWindowManager current createPlaceHolderGrid: size ] ].
+
 	WorldMorph cavroisDragBlock: [ :aClient |
 			((aClient isKindOf: SystemWindow) or:
 				 (aClient isKindOf: SpWindowMorph)) ifTrue: [
 					CavroisWindowManager current cellSize ifNotNil: [
-						CavroisWindowManager current cellDisplay ] ] ]
+							| dragProcess manager |
+							manager := CavroisWindowManager current.
+							manager cellDisplay.
+							dragProcess := [
+								               [ aClient owner notNil ] whileTrue: [
+										               manager
+											               handleWindowDrag: aClient
+											               at: aClient position.
+										               (Delay forMilliseconds: 1) wait ] ] forkAt:
+								               Processor userBackgroundPriority.
+							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
+
+	WorldMorph cavroisDropBlock: [ :anEvent |
+			| manager dragProcess |
+			manager := CavroisWindowManager current.
+			dragProcess := anEvent contents
+				               valueOfProperty: #cavroisDragProcess
+				               ifAbsent: nil.
+			dragProcess ifNotNil: [
+					dragProcess terminate.
+					anEvent contents removeProperty: #cavroisDragProcess ].
+			manager cellSize ifNotNil: [
+					manager removeVisualPlaceholders.
+					manager
+						handleCellWindowDrop: anEvent contents
+						at: anEvent contents position ] ]
 ]
 
 { #category : 'internals' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -573,19 +573,17 @@ CavroisWindowManager >> cells [
 { #category : 'creation' }
 CavroisWindowManager >> createPlaceHolderGrid: aSize [
 
-	| world createdCellSize existingWindows |
+	| world createdCellSize |
 	aSize ifNil: [ ^ self ].
-	existingWindows := self allCurrentWindows.
 	world := self currentWorld bounds.
 	createdCellSize := world width // aSize
 	                   @ (world height - 45 // aSize).
 	0 to: aSize - 1 do: [ :row |
 			0 to: aSize - 1 do: [ :col |
-					| origin randomWindow placeHolder |
+					| origin placeHolder |
 					origin := col * createdCellSize x
 					          @ (row * createdCellSize + 18) y.
-					randomWindow := existingWindows atRandom.
-					placeHolder := self placeHolderFromWindow: randomWindow.
+					placeHolder := self placeHolderFromWindow: SystemWindow new.
 					placeHolder strategy: CavExactOnTopStrategy new.
 					placeHolder position: origin.
 					placeHolder extent: createdCellSize.

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -678,12 +678,12 @@ CavroisWindowManager >> initialize [
 { #category : 'initialization' }
 CavroisWindowManager >> initializeBlocks [
 
-	WorldMorph cavroisResizeBlock: [
+	WorldMorph resizeActionBlock: [
 			CavroisWindowManager current cellSize ifNotNil: [ :size |
 					CavroisWindowManager current resetCells.
 					CavroisWindowManager current createPlaceHolderGrid: size ] ].
 
-	WorldMorph cavroisDragBlock: [ :aClient |
+	WorldMorph dragActionBlock: [ :aClient |
 			((aClient isKindOf: SystemWindow) or:
 				 (aClient isKindOf: SpWindowMorph)) ifTrue: [
 					CavroisWindowManager current cellSize ifNotNil: [
@@ -699,7 +699,7 @@ CavroisWindowManager >> initializeBlocks [
 								               Processor userBackgroundPriority.
 							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
 
-	WorldMorph cavroisDropBlock: [ :anEvent |
+	WorldMorph dropActionBlock: [ :anEvent |
 			| manager dragProcess |
 			manager := CavroisWindowManager current.
 			dragProcess := anEvent contents

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -650,7 +650,7 @@ CavroisWindowManager >> handleWindowDrag: aWindow at: aPoint [
 	previousClosestPlaceholder ifNotNil: [
 			previousClosestPlaceholder ~= closestPlaceHolder ifTrue: [
 					previousClosestPlaceholder color:
-						(Smalltalk ui theme lightSelectionColor alpha: 0.4) ] ].
+						(Smalltalk ui theme lightSelectionColor alpha: 0.2) ] ].
 
 	closestPlaceHolder ifNotNil: [
 			closestPlaceHolder color:
@@ -693,7 +693,7 @@ CavroisWindowManager >> initializeBlocks [
 										               manager
 											               handleWindowDrag: aClient
 											               at: aClient position.
-										               (Delay forMilliseconds: 1) wait ] ] forkAt:
+										               (Delay forMilliseconds: 0.2) wait ] ] forkAt:
 								               Processor userBackgroundPriority.
 							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
 

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -34,7 +34,9 @@ Class {
 		'classToolMapping',
 		'currentProfile',
 		'defaultLocation',
-		'placeHolderIndices'
+		'placeHolderIndices',
+		'cellSize',
+		'cells'
 	],
 	#classVars : [
 		'Current'
@@ -130,6 +132,50 @@ CavroisWindowManager class >> addProfileVisibilityItem: aBuilder [
 		iconName: #haloView
 ]
 
+{ #category : 'adding' }
+CavroisWindowManager class >> cellModeItem: aBuilder [
+
+	(aBuilder item: #'Cell Layout Mode')
+		parent: #ProfileAction;
+		order: 7;
+		help:
+			'Layout mode creating cells to help you position your window(s) ';
+		iconName: #table;
+		with: [
+				(aBuilder item: #'Choose Cell Size')
+					parent: #'Cell Layout Mode';
+					order: 0;
+					help: 'Define a size x size grid with cells';
+					iconName: #edit;
+					action: [ self chooseGridSize ].
+
+				(aBuilder item: #'Remove mode')
+					parent: #'Cell Layout Mode';
+					order: 2;
+					help: 'Turn off the cell mode';
+					iconName: #delete;
+					action: [ self removeGrid ] ]
+]
+
+{ #category : 'api' }
+CavroisWindowManager class >> chooseGridSize [
+
+	| presenter |
+	presenter := SpRequestDialog new
+		             title: 'Grid ';
+		             label: 'What is the size of the grid ?';
+		             text: '';
+		             acceptLabel: 'Confirm';
+		             cancelLabel: 'Cancel';
+		             onAccept: [ :dialog |
+				             self current resetCells.
+				             self current cellSize: dialog presenter text asNumber.
+				             self current createPlaceHolderGrid:
+						             dialog presenter text asNumber.
+				             MenubarMorph reset ];
+		             openDialog
+]
+
 { #category : 'instance creation' }
 CavroisWindowManager class >> createProfile [
 
@@ -141,6 +187,7 @@ CavroisWindowManager class >> createProfile [
 		             acceptLabel: 'Confirm';
 		             cancelLabel: 'Cancel';
 		             onAccept: [ :dialog |
+				             self current resetCells.
 				             self current updatePreviousCurrentProfile.
 				             self current addProfileFromWindows:
 						             dialog presenter text , ' (Current)'.
@@ -261,7 +308,14 @@ CavroisWindowManager class >> profileMenuItems: aBuilder [
 		renameProfileItem: aBuilder;
 		resetWindowsToCurrentProfileItem: aBuilder;
 		addProfileImportExportItems: aBuilder;
-		addProfileHelpItem: aBuilder
+		addProfileHelpItem: aBuilder;
+		cellModeItem:aBuilder 
+]
+
+{ #category : 'removing' }
+CavroisWindowManager class >> removeGrid [
+
+	self current resetCells
 ]
 
 { #category : 'removing' }
@@ -482,6 +536,58 @@ CavroisWindowManager >> allCurrentWindows [
 				  (w isCollapsed not and: (w isKindOf: SpDialogWindowMorph) not) ]
 ]
 
+{ #category : 'display' }
+CavroisWindowManager >> cellDisplay [
+
+	| visualPlaceHolder |
+	cells do: [ :each |
+			visualPlaceHolder := CavVisualPlaceHolderMorph new
+				                     extent: each extent;
+				                     position: each position.
+
+			visualPlaceHolder openInWorld ]
+]
+
+{ #category : 'accessing' }
+CavroisWindowManager >> cellSize [
+
+	^ cellSize
+]
+
+{ #category : 'accessing' }
+CavroisWindowManager >> cellSize: anObject [
+
+	cellSize := anObject
+]
+
+{ #category : 'accessing' }
+CavroisWindowManager >> cells [
+
+	^ cells
+]
+
+{ #category : 'creation' }
+CavroisWindowManager >> createPlaceHolderGrid: aSize [
+
+	| world createdCellSize existingWindows |
+	aSize ifNil: [ ^ self ].
+	existingWindows := self allCurrentWindows.
+	world := self currentWorld bounds.
+	createdCellSize := world width // aSize
+	                   @ (world height - 45 // aSize).
+	0 to: aSize - 1 do: [ :row |
+			0 to: aSize - 1 do: [ :col |
+					| origin randomWindow placeHolder |
+					origin := col * createdCellSize x
+					          @ (row * createdCellSize + 18) y.
+					randomWindow := existingWindows atRandom.
+					placeHolder := self placeHolderFromWindow: randomWindow.
+					placeHolder strategy: CavExactOnTopStrategy new.
+					placeHolder position: origin.
+					placeHolder extent: createdCellSize.
+					cells add: placeHolder ] ]
+]
+
 { #category : 'accessing' }
 CavroisWindowManager >> currentProfile [
 
@@ -506,6 +612,25 @@ CavroisWindowManager >> defaultLocation: aLocation [
 	defaultLocation := aLocation
 ]
 
+{ #category : 'handling' }
+CavroisWindowManager >> handleCellWindowDrop: aWindow at: aPoint [
+
+	| closestPlaceHolder closestDistance |
+	((aWindow isKindOf: SystemWindow) or:
+		 (aWindow isKindOf: SpWindowMorph)) ifFalse: [ ^ self ].
+	closestPlaceHolder := nil.
+	closestDistance := Float infinity.
+
+	cells do: [ :placeHolder |
+			| distance |
+			distance := placeHolder position distanceTo: aPoint.
+			distance < closestDistance ifTrue: [
+					closestPlaceHolder := placeHolder.
+					closestDistance := distance ] ].
+	closestPlaceHolder ifNotNil: [
+		closestPlaceHolder placePresenter: aWindow ]
+]
+
 { #category : 'initialization' }
 CavroisWindowManager >> initialize [
 
@@ -513,8 +638,33 @@ CavroisWindowManager >> initialize [
 	classToolMapping := Dictionary new.
 	defaultLocation := FileLocator preferences asFileReference / 'pharo'.
 	placeHolderIndices := Dictionary new.
+	cells := OrderedCollection new.
 	ClyBrowserMorph postOpeningBlock: [ :w | self placePresenter: w ].
-	self resetProfiles
+	self resetProfiles.
+	self initializeBlocks 
+	
+]
+
+{ #category : 'initialization' }
+CavroisWindowManager >> initializeBlocks [
+
+	WorldMorph cavroisDropBlock: [ :anEvent |
+			| manager |
+			manager := CavroisWindowManager current.
+			manager cellSize ifNotNil: [
+					manager removeVisualPlaceholders.
+					manager
+						handleCellWindowDrop: anEvent contents
+						at: anEvent contents position ] ].
+	WorldMorph cavroisResizeBlock: [
+			CavroisWindowManager current cellSize ifNotNil: [ :size |
+					CavroisWindowManager current resetCells.
+					CavroisWindowManager current createPlaceHolderGrid: size ] ].
+	WorldMorph cavroisDragBlock: [ :aClient |
+			((aClient isKindOf: SystemWindow) or:
+				 (aClient isKindOf: SpWindowMorph)) ifTrue: [
+					CavroisWindowManager current cellSize ifNotNil: [
+						CavroisWindowManager current cellDisplay ] ] ]
 ]
 
 { #category : 'internals' }
@@ -617,6 +767,12 @@ CavroisWindowManager >> removeVisualPlaceholders [
 		select: [ :morph |
 			morph visible = false and: (morph hasProperty: #isClosed) not ]
 		thenDo: [ :morph | morph visible: true ]
+]
+
+{ #category : 'initialization' }
+CavroisWindowManager >> resetCells [
+
+	cells := OrderedCollection new
 ]
 
 { #category : 'internals' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -483,7 +483,9 @@ CavroisWindowManager class >> updateCurrentProfileAfterDeletion: deletedProfileK
 CavroisWindowManager class >> updateProfile [
 
 	self removeGrid.
-	self current updateProfile
+	self toggleProfilePlaceholders.
+	self current updateProfile.
+	self toggleProfilePlaceholders
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -693,7 +693,7 @@ CavroisWindowManager >> initializeBlocks [
 										               manager
 											               handleWindowDrag: aClient
 											               at: aClient position.
-										               (Delay forMilliseconds: 0.2) wait ] ] forkAt:
+										               (Delay forMilliseconds: 2) wait ] ] forkAt:
 								               Processor userBackgroundPriority.
 							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
 

--- a/src/NewTools-Window-Profiles/CavroisWindowManagerTest.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManagerTest.class.st
@@ -61,24 +61,18 @@ CavroisWindowManagerTest >> testDeleteProfile [
 { #category : 'tests' }
 CavroisWindowManagerTest >> testGridCellsInitialization [
 
-	| profile |
-	profile := CavWindowProfile new.
-	manager currentProfile: profile.
-	profile cellSize: 4.
-	manager createPlaceHolderGrid: profile cellSize.
-	self assert: manager currentProfile placeHolders size equals: 16
+	manager cellSize: 4.
+	manager createPlaceHolderGrid: manager cellSize.
+	self assert: manager cells size equals: 16
 ]
 
 { #category : 'tests' }
 CavroisWindowManagerTest >> testRemoveGridDeletePlaceholders [
 
-	| profile |
-	profile := CavWindowProfile new.
-	manager currentProfile: profile.
-	profile cellSize: 4.
-	manager createPlaceHolderGrid: profile cellSize.
+	manager cellSize: 4.
+	manager createPlaceHolderGrid: manager cellSize.
 	manager class removeGrid.
-	self assert: manager currentProfile placeHolders size equals: 0
+	self assert: manager cells size equals: 0
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManagerTest.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManagerTest.class.st
@@ -59,6 +59,29 @@ CavroisWindowManagerTest >> testDeleteProfile [
 ]
 
 { #category : 'tests' }
+CavroisWindowManagerTest >> testGridCellsInitialization [
+
+	| profile |
+	profile := CavWindowProfile new.
+	manager currentProfile: profile.
+	profile cellSize: 4.
+	manager createPlaceHolderGrid: profile cellSize.
+	self assert: manager currentProfile placeHolders size equals: 16
+]
+
+{ #category : 'tests' }
+CavroisWindowManagerTest >> testRemoveGridDeletePlaceholders [
+
+	| profile |
+	profile := CavWindowProfile new.
+	manager currentProfile: profile.
+	profile cellSize: 4.
+	manager createPlaceHolderGrid: profile cellSize.
+	manager class removeGrid.
+	self assert: manager currentProfile placeHolders size equals: 0
+]
+
+{ #category : 'tests' }
 CavroisWindowManagerTest >> testRemovingCurrentProfileUpdateCurrentProfile [
 
 	manager addProfileFromWindows: 'Profile1'.


### PR DESCRIPTION
In Cavrois theres now new functionnality so the user can place its windows more precisely using cells
- Initialized morphic blocks in the manager to remove cavrois code from Morphic 
-Added methods to handle cells creation, window drop and drag, world resize 
-New tests related to cells
-Edited the profiles menu to have cells, and linked it to profile creation
-Separated test package to have a clean structure
-Updating the profile preview if an user update its profile/strategies while in preview to avoid an extra step
