### PR TITLE
Profile windows gets resized with the world 

### DIFF
--- a/src/NewTools-Window-Profiles/CavAbstractWindowPlaceHolder.class.st
+++ b/src/NewTools-Window-Profiles/CavAbstractWindowPlaceHolder.class.st
@@ -5,6 +5,7 @@ Class {
 	#name : 'CavAbstractWindowPlaceHolder',
 	#superclass : 'Object',
 	#instVars : [
+		'windows',
 		'extent',
 		'kind',
 		'position',
@@ -102,14 +103,14 @@ CavAbstractWindowPlaceHolder >> increment [
 { #category : 'initialization' }
 CavAbstractWindowPlaceHolder >> initialize [
 
-	super initialize. 
+	super initialize.
 	strategy := CavStackingStrategy new.
 	strategy placeHolder: self.
+	windows := OrderedCollection new.
 	"count is counting the number of opened window.
 	not really nice but let us get started."
 	kind := 'empty'.
-	count := 1.	
-
+	count := 1
 ]
 
 { #category : 'accessing' }
@@ -170,6 +171,12 @@ CavAbstractWindowPlaceHolder >> widthPercentage [
 CavAbstractWindowPlaceHolder >> widthPercentage: anObject [
 
 	widthPercentage := anObject
+]
+
+{ #category : 'accessing' }
+CavAbstractWindowPlaceHolder >> windows [
+
+	^ windows
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Window-Profiles/CavAbstractWindowPlaceHolder.class.st
+++ b/src/NewTools-Window-Profiles/CavAbstractWindowPlaceHolder.class.st
@@ -34,6 +34,12 @@ CavAbstractWindowPlaceHolder class >> exampleTranscript [
 	
 ]
 
+{ #category : 'ston-core' }
+CavAbstractWindowPlaceHolder class >> stonAllInstVarNames [
+
+	^ super stonAllInstVarNames copyWithout: #windows
+]
+
 { #category : 'initialization' }
 CavAbstractWindowPlaceHolder >> configureStrategy [
 

--- a/src/NewTools-Window-Profiles/CavExactOnTopStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavExactOnTopStrategy.class.st
@@ -19,7 +19,7 @@ CavExactOnTopStrategy class >> title [
 { #category : 'positioning' }
 CavExactOnTopStrategy >> placePresenter: aWindow [
 
+	super placePresenter: aWindow.
 	aWindow position: placeHolder position.
 	aWindow extent: placeHolder extent
-	
 ]

--- a/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavPopUpStrategy.class.st
@@ -33,6 +33,7 @@ CavPopUpStrategy >> findSameKindWindowAs: aWidget [
 CavPopUpStrategy >> placePresenter: aWindow [
 
 	| sameKindWindow windowToDelete |
+	super placePresenter: aWindow.
 	aWindow position: placeHolder position.
 	aWindow extent: placeHolder extent.
 

--- a/src/NewTools-Window-Profiles/CavReplaceStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavReplaceStrategy.class.st
@@ -21,15 +21,18 @@ CavReplaceStrategy class >> title [
 { #category : 'positioning' }
 CavReplaceStrategy >> placePresenter: aPresenter [
 
+	super placePresenter: aPresenter.
 	aPresenter position: placeHolder position.
 	aPresenter extent: placeHolder extent.
 	"do we keep a reference to the window from the placeholder?
 	this way we could avoid to scan all the window."
-	
+
 	(SystemWindow allInstances select: [ :each |
-		 each position = placeHolder position 
-			and: [ placeHolder kind = aPresenter class ]]) do: [ :each | each delete ].
+			 each position = placeHolder position and: [
+				 placeHolder kind = aPresenter class ] ]) do: [ :each |
+		each delete ].
 	(SpWindowMorph allInstances select: [ :each |
-		 each position = placeHolder position 
-				and: [ placeHolder kind = aPresenter class ]]) do: [ :each | each delete ]
+			 each position = placeHolder position and: [
+				 placeHolder kind = aPresenter class ] ]) do: [ :each |
+		each delete ]
 ]

--- a/src/NewTools-Window-Profiles/CavStackingStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavStackingStrategy.class.st
@@ -20,6 +20,7 @@ CavStackingStrategy class >> title [
 { #category : 'positioning' }
 CavStackingStrategy >> placePresenter: aPresenter [
 
+	super placePresenter: aPresenter.
 	aPresenter extent: placeHolder extent.
 
 	aPresenter position:

--- a/src/NewTools-Window-Profiles/CavWindowStrategy.class.st
+++ b/src/NewTools-Window-Profiles/CavWindowStrategy.class.st
@@ -24,5 +24,5 @@ CavWindowStrategy >> placeHolder: anObject [
 { #category : 'positioning' }
 CavWindowStrategy >> placePresenter: aPresenter [
 
-	
+	self placeHolder windows add: aPresenter
 ]

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -540,6 +540,26 @@ CavroisWindowManager >> allCurrentWindows [
 				  (w isCollapsed not and: (w isKindOf: SpDialogWindowMorph) not) ]
 ]
 
+{ #category : 'actions' }
+CavroisWindowManager >> applyWorldResize [
+
+	self currentProfile placeHolders do: [ :ph |
+			((SystemWindow allInstances union: SpWindowMorph allInstances)
+				 select: [ :window |
+						 window position = ph position and: [
+								 ph kind = window model class or: [
+									 ph kind = window model presenter class ] ] ]) do: [ :window |
+					window extent:
+						ph widthPercentage / 100 * self currentWorld bounds width
+						@ (ph heightPercentage / 100 * self currentWorld bounds height).
+
+					window position:
+						ph xPercentage / 100 * self currentWorld bounds width
+						@ (ph yPercentage / 100 * self currentWorld bounds height).
+					ph position: window position.
+					ph extent: window extent ] ]
+]
+
 { #category : 'display' }
 CavroisWindowManager >> cellDisplay [
 
@@ -677,20 +697,20 @@ CavroisWindowManager >> initialize [
 CavroisWindowManager >> initializeBlocks [
 
 	WorldMorph resizeActionBlock: [
-			CavroisWindowManager current cellSize ifNotNil: [ :size |
-					CavroisWindowManager current resetCells.
-					CavroisWindowManager current createPlaceHolderGrid: size ] ].
+			self cellSize ifNotNil: [ :size |
+					self resetCells.
+					self createPlaceHolderGrid: size ].
+			self applyWorldResize ].
 
 	WorldMorph dragActionBlock: [ :aClient |
 			((aClient isKindOf: SystemWindow) or:
 				 (aClient isKindOf: SpWindowMorph)) ifTrue: [
-					CavroisWindowManager current cellSize ifNotNil: [
-							| dragProcess manager |
-							manager := CavroisWindowManager current.
-							manager cellDisplay.
+					self cellSize ifNotNil: [
+							| dragProcess |
+							self cellDisplay.
 							dragProcess := [
 								               [ aClient owner notNil ] whileTrue: [
-										               manager
+										               self
 											               handleWindowDrag: aClient
 											               at: aClient position.
 										               (Delay forMilliseconds: 2) wait ] ] forkAt:
@@ -698,17 +718,16 @@ CavroisWindowManager >> initializeBlocks [
 							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
 
 	WorldMorph dropActionBlock: [ :anEvent |
-			| manager dragProcess |
-			manager := CavroisWindowManager current.
+			| dragProcess |
 			dragProcess := anEvent contents
 				               valueOfProperty: #cavroisDragProcess
 				               ifAbsent: nil.
 			dragProcess ifNotNil: [
 					dragProcess terminate.
 					anEvent contents removeProperty: #cavroisDragProcess ].
-			manager cellSize ifNotNil: [
-					manager removeVisualPlaceholders.
-					manager
+			self cellSize ifNotNil: [
+					self removeVisualPlaceholders.
+					self
 						handleCellWindowDrop: anEvent contents
 						at: anEvent contents position ] ]
 ]

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -543,21 +543,20 @@ CavroisWindowManager >> allCurrentWindows [
 { #category : 'actions' }
 CavroisWindowManager >> applyWorldResize [
 
-	self currentProfile placeHolders do: [ :ph |
-			((SystemWindow allInstances union: SpWindowMorph allInstances)
-				 select: [ :window |
-						 window position = ph position and: [
-								 ph kind = window model class or: [
-									 ph kind = window model presenter class ] ] ]) do: [ :window |
-					window extent:
-						ph widthPercentage / 100 * self currentWorld bounds width
-						@ (ph heightPercentage / 100 * self currentWorld bounds height).
-
-					window position:
-						ph xPercentage / 100 * self currentWorld bounds width
-						@ (ph yPercentage / 100 * self currentWorld bounds height).
-					ph position: window position.
-					ph extent: window extent ] ]
+	self currentProfile ifNotNil: [
+			self currentProfile placeHolders do: [ :ph |
+					((SystemWindow allInstances union: SpWindowMorph allInstances)
+						 select: [ :window | ph windows includes: window ]) do: [
+							:window |
+							window extent:
+								ph widthPercentage / 100 * self currentWorld bounds width
+								@
+								(ph heightPercentage / 100 * self currentWorld bounds height).
+							window position:
+								ph xPercentage / 100 * self currentWorld bounds width
+								@ (ph yPercentage / 100 * self currentWorld bounds height).
+							ph position: window position.
+							ph extent: window extent ] ] ]
 ]
 
 { #category : 'display' }
@@ -778,6 +777,7 @@ CavroisWindowManager >> placeHolderFromWindow: aWindowPresenter [
 		               yPercentage:
 			               aWindowPresenter bounds origin y
 			               / self currentWorld bounds height * 100.
+	placeHolder windows add: aWindowPresenter.
 	placeHolder configureStrategy.
 	aWindowPresenter configurePlaceHolder: placeHolder.
 	^ placeHolder


### PR DESCRIPTION
Whenever the world is resized, the windows linked to a profile too meaning the user don't have to touch anything if he changes screen or resizing its world.
- Very good looking functionality that avoid a loss of time for the user by searching windows.
- Gave the placeholders a collection of windows so each of them (if still open) is resized with the world
@Ducasse this looks good :)