### PR TITLE
Cleaning debugger action model: less dependencies on ast scope

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerActionModelTest.class.st
@@ -862,37 +862,6 @@ StDebuggerActionModelTest >> testProceedDebugSession [
 ]
 
 { #category : 'tests - actions' }
-StDebuggerActionModelTest >> testRecompileMethodToInBlockContext [
-
-	| contextChanged previousASTScope |
-	self newSessionWithBlockContext.
-
-	DebugSession contextModelClass: StDebugContextForTests.
-	contextChanged := debugActionModel topContext.
-	
-	"We stepped into a block for which the debugActionModel holds an ast scope:"
-	previousASTScope := debugActionModel previousASTScope.
-	self
-		assert: previousASTScope
-		identicalTo: contextChanged astScope.
-
-	debugActionModel
-		recompileMethodTo: contextChanged method sourceCode , '. ^self'
-		inContext: contextChanged
-		notifying: nil.
-	debugActionModel updateTopContext.
-
-	"After recompiling the method, the model holds an updated ast scope that is not the one of the block:"
-	self deny: previousASTScope identicalTo: debugActionModel previousASTScope.
-	
-	"The new ast scope is the one of the AST of the first interesting bytecode of the method,
-	that is the block declaration:"
-	self
-		assert: debugActionModel previousASTScope
-		identicalTo: (self class >> #methodWithBlockContext) ast statements first value scope
-]
-
-{ #category : 'tests - actions' }
 StDebuggerActionModelTest >> testRecompileMethodToInBlockContextWithDeadHome [
 
 	| contextChanged |

--- a/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextPredicateTest.class.st
@@ -51,14 +51,6 @@ StDebuggerContextPredicateTest >> testPrintDescription [
 ]
 
 { #category : 'tests' }
-StDebuggerContextPredicateTest >> testPrintHaltDescription [
-	|haltContext|
-	haltContext := (StTestDebuggerProvider new debuggerWithRunnableContext) interruptedContext.
-	predicate context: haltContext.
-	self assert: predicate printDescription equals: 'Halt in ', haltContext printString
-]
-
-{ #category : 'tests' }
 StDebuggerContextPredicateTest >> testPrintPostMortemDescription [
 	self skip.
 	predicate postMortem: true.

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -370,6 +370,7 @@ StDebuggerTest >> testContextTempVarListUpdatesAfterRestartingContext [
 
 	"We enter the inlined block (node `i + 1`)"
 	4 timesRepeat: [ dbg stepOver ].
+	dbg stepInto.
 
 	self assert: inspectorTable roots size equals: 9.
 
@@ -393,13 +394,14 @@ StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlined
 	inspectorTable := dbg inspector getRawInspectorPresenterOrNil
 		                  attributeTable.
 
-	"We stop on the node `i = 1` node"
+	"We stop on (before) the node `i = 1`"
 	3 timesRepeat: [ dbg stepOver ].
 
 	contextItems := inspectorTable roots copy.
 	self assert: contextItems size equals: 8.
 
-	"We enter inlined block"
+	"We step on the ifTrue:, then we enter it"
+	dbg stepOver.
 	dbg stepOver.
 
 	newContextItems := inspectorTable roots.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -87,7 +87,8 @@ Class {
 		'unsavedCodeChanges',
 		'programmaticallyClosed',
 		'stackAndCodeContainer',
-		'toolbarPresenter'
+		'toolbarPresenter',
+		'previousASTScope'
 	],
 	#classVars : [
 		'EnableStackColoring'
@@ -1607,11 +1608,9 @@ StDebugger >> updateStackFromSession: aSession [
 
 { #category : 'updating' }
 StDebugger >> updateStep [
-  | previousASTScope previousContext currentASTScope currentContext |
-	
-  	previousContext := self currentContext.
-	previousASTScope := debuggerActionModel previousASTScope. 
 
+	| previousContext currentASTScope currentContext |
+	previousContext := self currentContext.
 	self updateStackFromSession: self session.
 	self updateWindowTitle.
 	self updateExtensionsFromSession: self session.
@@ -1622,9 +1621,14 @@ StDebugger >> updateStep [
 		                    currentContext pc) scope.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
-		previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes." "Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."
-			p updateNodesFromScope: previousASTScope to: currentASTScope ].
-		p update ]
+			previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes.""Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."
+					p
+						updateNodesFromScope:
+						(previousASTScope ifNil: [ currentASTScope ])
+						to: currentASTScope ].
+			p update ].
+
+	previousASTScope := currentASTScope
 ]
 
 { #category : 'toolbar' }

--- a/src/NewTools-Debugger/StDebuggerActionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerActionModel.class.st
@@ -10,7 +10,6 @@ Class {
 		'topContext',
 		'filterStack',
 		'preventUpdate',
-		'previousASTScope',
 		'announcer'
 	],
 	#classVars : [
@@ -319,12 +318,6 @@ StDebuggerActionModel >> preventUpdatesDuring: aBlock [
 	self update ] ensure: [ preventUpdate := oldEventFlag ]
 ]
 
-{ #category : 'accessing' }
-StDebuggerActionModel >> previousASTScope [
-
-	^ previousASTScope
-]
-
 { #category : 'debug - execution' }
 StDebuggerActionModel >> proceedDebugSession [
 
@@ -355,10 +348,7 @@ StDebuggerActionModel >> recompileMethodTo: aString inContext: aContext notifyin
 
 	homePC := methodContext isDead
 		ifTrue: [ methodContext endPC ]
-		ifFalse: [ methodContext pc ].
-		
-	previousASTScope := (methodContext compiledCode sourceNodeForPC:
-		                     homePC) scope
+		ifFalse: [ methodContext pc ]
 ]
 
 { #category : 'context' }
@@ -401,8 +391,6 @@ StDebuggerActionModel >> removeActionsForSession: aSession [
 { #category : 'debug - execution' }
 StDebuggerActionModel >> restartContext: aContext [
 
-	previousASTScope := (aContext compiledCode sourceNodeForPC:
-		                     aContext pc) scope.
 	self session restart: aContext.
 	self updateTopContext
 ]
@@ -421,7 +409,6 @@ StDebuggerActionModel >> returnValueFromExpression: aString fromContext: aContex
 { #category : 'debug - execution' }
 StDebuggerActionModel >> runToSelection: aSelectionInterval inContext: aContext [
 
-	previousASTScope := aContext sourceNodeExecuted scope.
 	self preventUpdatesDuring: [
 		self session runToSelection: aSelectionInterval inContext: aContext ].
 	self updateTopContext
@@ -441,8 +428,6 @@ StDebuggerActionModel >> session [
 StDebuggerActionModel >> session: aDebugSession [
 	session ifNotNil: [ self removeActionsForSession: session ].
 	session := aDebugSession.
-  previousASTScope := aDebugSession interruptedContext
-		                    sourceNodeExecuted scope.
 	self registerActionsForSession: self session.
 
 	self updateIfAble
@@ -473,7 +458,6 @@ StDebuggerActionModel >> statusStringForContext [
 { #category : 'debug - stepping' }
 StDebuggerActionModel >> stepInto: aContext [
 
-	previousASTScope := aContext sourceNodeExecuted scope.
 	filterStack := false.
 	aContext stepIntoQuickMethod: true.
 	self session stepInto: aContext.
@@ -484,7 +468,6 @@ StDebuggerActionModel >> stepInto: aContext [
 { #category : 'debug - stepping' }
 StDebuggerActionModel >> stepOver: aContext [
 
-	previousASTScope := aContext sourceNodeExecuted scope.
 	filterStack := (self topContext method hasPragmaNamed:
 		                #debuggerCompleteToSender)
 		               ifTrue: [ false ]
@@ -496,7 +479,6 @@ StDebuggerActionModel >> stepOver: aContext [
 { #category : 'debug - stepping' }
 StDebuggerActionModel >> stepThrough: aContext [
 
-	previousASTScope := aContext sourceNodeExecuted scope.
 	self session stepThrough: aContext.
 	self updateTopContext
 ]

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -161,7 +161,7 @@ StDebuggerContext >> stackTopNode [
 { #category : 'nodes' }
 StDebuggerContext >> temporaryVariablesNodes [
 
-	^ self context astScope allTemps collect: [ :temp | 
+	^ self context temporaryVariables collect: [ :temp | 
 		  (StInspectorTempNode hostObject: self context) tempVariable: temp ]
 ]
 

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -161,7 +161,7 @@ StDebuggerContext >> stackTopNode [
 { #category : 'nodes' }
 StDebuggerContext >> temporaryVariablesNodes [
 
-	^ self context temporaryVariables collect: [ :temp | 
+	^ self context astScope allTemps collect: [ :temp | 
 		  (StInspectorTempNode hostObject: self context) tempVariable: temp ]
 ]
 

--- a/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
@@ -104,16 +104,7 @@ StDebuggerContextPredicate >> printDescription [
 { #category : 'printing' }
 StDebuggerContextPredicate >> printDescriptionPrefixOn: str [
 
-	self printPostMortemDescriptionOn: str.
-	self printHaltDescriptionOn: str
-]
-
-{ #category : 'printing' }
-StDebuggerContextPredicate >> printHaltDescriptionOn: str [
-
-	context sourceNodeExecuted isHaltNode ifFalse: [ ^ self ].
-	str << 'Halt in'.
-	str space
+	self printPostMortemDescriptionOn: str
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
Minimise dependencies to the compiler