### PR TITLE
1172 implementors in the new transcript

### DIFF
--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -472,8 +472,7 @@ StPulse >> connectPresenters [
 			action: [ self giveFocusToPreviousResultList ] ];
 		addShortcutWith: [ :action | action 
 			shortcutKey: Character arrowUp asKeyCombination;
-			action: [ self giveFocusToResultListAtLast ] ] ;
-		takeKeyboardFocus.
+			action: [ self giveFocusToResultListAtLast ] ].
 	listPresenter whenActivatedDo: [ self acceptSelection ].
 	self addKeyboardBehavior: listPresenter.
 	

--- a/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
+++ b/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'presenter',
 		'transcript',
-		'worker'
+		'backendForTest'
 	],
 	#category : 'NewTools-Transcript-Tests',
 	#package : 'NewTools-Transcript-Tests'
@@ -14,6 +14,7 @@ Class {
 StTranscriptPresenterTest >> setUp [ 
 
 	super setUp.
+	backendForTest := SpMorphicBackendForTest new.
 	presenter := StTranscriptPresenter new.
 	presenter transcript: (transcript := StThreadSafeTranscript createTestingInstance)
 ]
@@ -33,9 +34,9 @@ StTranscriptPresenterTest >> testAnnouncementIsWritten [
 	[
 		window := presenter open.
 		transcript show: 'test'.
-		self worker schedule: [ 
-			100 milliSeconds wait.
-			self assert: presenter text text equals: 'test' ] ]
+		100 milliSeconds wait.
+		self waitUntilUIRedrawed.
+		self assert: presenter textPresenter text equals: 'test' ]
 	ensure: [ window close ]
 ]
 
@@ -46,12 +47,12 @@ StTranscriptPresenterTest >> testClear [
 	[
 		window := presenter open.
 		transcript show: 'test'.
-		self worker schedule: [ 
-			100 milliSeconds wait.
-			self assert: presenter text text equals: 'test'.
-			presenter clear.
-			self assert: presenter text text equals: ''.
-			self assert: transcript contents equals: 'test' ] ]
+		100 milliSeconds wait.
+		self waitUntilUIRedrawed.
+		self assert: presenter textPresenter text equals: 'test'.
+		presenter clear.
+		self assert: presenter textPresenter text equals: ''.
+		self assert: transcript contents equals: 'test' ] 
 	ensure: [ window close ]
 ]
 
@@ -62,12 +63,12 @@ StTranscriptPresenterTest >> testFetchOld [
 	[
 		window := presenter open.
 		transcript show: 'test'.
-		self worker schedule: [ 
-		300 milliSeconds wait.
+		100 milliSeconds wait.
+		self waitUntilUIRedrawed.
 		presenter clear.
-		self assert: presenter text text equals: ''.
+		self assert: presenter textPresenter text equals: ''.
 		presenter fetchOld.
-		self assert: transcript contents equals: 'test' ] ]
+		self assert: transcript contents equals: 'test' ]
 	ensure: [ window close ]
 ]
 
@@ -78,13 +79,13 @@ StTranscriptPresenterTest >> testReset [
 	[
 		window := presenter open.
 		transcript show: 'test'.
-		self worker schedule: [ 
-			100 milliSeconds wait.
-			self assert: presenter text text equals: 'test'.
-			self assert: transcript contents equals: 'test'.
-			presenter reset.
-			self assert: presenter text text equals: ''.
-			self assert: transcript contents equals: '' ] ]
+		100 milliSeconds wait.
+		self waitUntilUIRedrawed.
+		self assert: presenter textPresenter text equals: 'test'.
+		self assert: transcript contents equals: 'test'.
+		presenter reset.
+		self assert: presenter textPresenter text equals: ''.
+		self assert: transcript contents equals: '' ]
 	ensure: [ window close ]
 ]
 
@@ -102,11 +103,7 @@ StTranscriptPresenterTest >> testSmoke [
 ]
 
 { #category : 'running' }
-StTranscriptPresenterTest >> worker [
-	
-	^ (worker ifNil: [ 
-			worker := TKTWorker new 
-			name: 'StTranscriptPresenterTest worker: ', UUID new asString]) 
-		ensureIsWorking
-		
+StTranscriptPresenterTest >> waitUntilUIRedrawed [
+
+	backendForTest waitUntilUIRedrawed
 ]

--- a/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
+++ b/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
@@ -20,6 +20,7 @@ StTranscriptPresenterTest >> setUp [
 { #category : 'running' }
 StTranscriptPresenterTest >> tearDown [ 
 
+	presenter reset.
 	presenter withWindowDo: #close.
 	super tearDown
 ]
@@ -32,8 +33,9 @@ StTranscriptPresenterTest >> testAnnouncementIsWritten [
 	[ 
 		window := presenter open.
 		transcript show: 'test'.
-		300 milliSeconds wait.
-		self assert: presenter text text equals: 'test' ]
+		[ 
+			100 milliSeconds wait.
+			self assert: presenter text text equals: 'test' ] fork ] 
 	ensure: [ window close ]
 ]
 
@@ -45,11 +47,12 @@ StTranscriptPresenterTest >> testClear [
 	[ 
 		window := presenter open.
 		transcript show: 'test'.
-		300 milliSeconds wait.
-		self assert: presenter text text equals: 'test'.
-		presenter clear.
-		self assert: presenter text text equals: ''.
-		self assert: transcript contents equals: 'test' ]
+		[ 
+			100 milliSeconds wait.
+			self assert: presenter text text equals: 'test'.
+			presenter clear.
+			self assert: presenter text text equals: ''.
+			self assert: transcript contents equals: 'test' ] fork ]
 	ensure: [ window close ]
 ]
 
@@ -77,12 +80,13 @@ StTranscriptPresenterTest >> testReset [
 	[ 
 		window := presenter open.
 		transcript show: 'test'.
-		300 milliSeconds wait.
-		self assert: presenter text text equals: 'test'.
-		self assert: transcript contents equals: 'test'.
-		presenter reset.
-		self assert: presenter text text equals: ''.
-		self assert: transcript contents equals: '' ]
+		[ 
+			100 milliSeconds wait.
+			self assert: presenter text text equals: 'test'.
+			self assert: transcript contents equals: 'test'.
+			presenter reset.
+			self assert: presenter text text equals: ''.
+			self assert: transcript contents equals: '' ] fork ]
 	ensure: [ window close ]
 ]
 

--- a/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
+++ b/src/NewTools-Transcript-Tests/StTranscriptPresenterTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'TestCase',
 	#instVars : [
 		'presenter',
-		'transcript'
+		'transcript',
+		'worker'
 	],
 	#category : 'NewTools-Transcript-Tests',
 	#package : 'NewTools-Transcript-Tests'
@@ -29,13 +30,12 @@ StTranscriptPresenterTest >> tearDown [
 StTranscriptPresenterTest >> testAnnouncementIsWritten [
 
 	| window |
-	
-	[ 
+	[
 		window := presenter open.
 		transcript show: 'test'.
-		[ 
+		self worker schedule: [ 
 			100 milliSeconds wait.
-			self assert: presenter text text equals: 'test' ] fork ] 
+			self assert: presenter text text equals: 'test' ] ]
 	ensure: [ window close ]
 ]
 
@@ -43,16 +43,15 @@ StTranscriptPresenterTest >> testAnnouncementIsWritten [
 StTranscriptPresenterTest >> testClear [
 
 	| window |
-	
-	[ 
+	[
 		window := presenter open.
 		transcript show: 'test'.
-		[ 
+		self worker schedule: [ 
 			100 milliSeconds wait.
 			self assert: presenter text text equals: 'test'.
 			presenter clear.
 			self assert: presenter text text equals: ''.
-			self assert: transcript contents equals: 'test' ] fork ]
+			self assert: transcript contents equals: 'test' ] ]
 	ensure: [ window close ]
 ]
 
@@ -60,15 +59,15 @@ StTranscriptPresenterTest >> testClear [
 StTranscriptPresenterTest >> testFetchOld [
 
 	| window |
-	
-	[ 
+	[
 		window := presenter open.
 		transcript show: 'test'.
+		self worker schedule: [ 
 		300 milliSeconds wait.
 		presenter clear.
 		self assert: presenter text text equals: ''.
 		presenter fetchOld.
-		self assert: transcript contents equals: 'test' ]
+		self assert: transcript contents equals: 'test' ] ]
 	ensure: [ window close ]
 ]
 
@@ -76,17 +75,16 @@ StTranscriptPresenterTest >> testFetchOld [
 StTranscriptPresenterTest >> testReset [
 
 	| window |
-	
-	[ 
+	[
 		window := presenter open.
 		transcript show: 'test'.
-		[ 
+		self worker schedule: [ 
 			100 milliSeconds wait.
 			self assert: presenter text text equals: 'test'.
 			self assert: transcript contents equals: 'test'.
 			presenter reset.
 			self assert: presenter text text equals: ''.
-			self assert: transcript contents equals: '' ] fork ]
+			self assert: transcript contents equals: '' ] ]
 	ensure: [ window close ]
 ]
 
@@ -101,4 +99,14 @@ StTranscriptPresenterTest >> testSmoke [
 	[ self shouldnt: [ window := StTranscriptPresenter exampleNonGlobalTranscript ] raise: Error ] ensure: [ window ifNotNil: [ window close ] ].
 
 	[ self shouldnt: [ window := presenter openDialog ] raise: Error ] ensure: [ window ifNotNil: [ window close ] ]
+]
+
+{ #category : 'running' }
+StTranscriptPresenterTest >> worker [
+	
+	^ (worker ifNil: [ 
+			worker := TKTWorker new 
+			name: 'StTranscriptPresenterTest worker: ', UUID new asString]) 
+		ensureIsWorking
+		
 ]

--- a/src/NewTools-Transcript/StTranscriptPresenter.class.st
+++ b/src/NewTools-Transcript/StTranscriptPresenter.class.st
@@ -145,10 +145,11 @@ StTranscriptPresenter >> initializeLeftToolbar [
 ]
 
 { #category : 'initialization' }
-StTranscriptPresenter >> initializePresenters [ 
+StTranscriptPresenter >> initializePresenters [
 
-
-	text := self newText.
+	text := self newCode.
+	text syntaxHighlight: false.
+	text lineNumbers: false.
 	text beEditable.
 	self initializeToolbars
 	

--- a/src/NewTools-Transcript/StTranscriptPresenter.class.st
+++ b/src/NewTools-Transcript/StTranscriptPresenter.class.st
@@ -8,7 +8,7 @@ Class {
 	#name : 'StTranscriptPresenter',
 	#superclass : 'StPresenter',
 	#instVars : [
-		'text',
+		'textPresenter',
 		'transcript',
 		'leftToolbar',
 		'rightToolBar',
@@ -93,7 +93,7 @@ StTranscriptPresenter class >> registerToolsOn: aRegistry [
 { #category : 'actions' }
 StTranscriptPresenter >> clear [
 	
-	text clearContent
+	textPresenter clearContent
 ]
 
 { #category : 'private' }
@@ -115,7 +115,7 @@ StTranscriptPresenter >> ensureTranscriptService [
 { #category : 'actions' }
 StTranscriptPresenter >> fetchOld [ 
 
-	text appendText: transcript contents
+	textPresenter appendText: transcript contents
 ]
 
 { #category : 'initialization' }
@@ -147,10 +147,10 @@ StTranscriptPresenter >> initializeLeftToolbar [
 { #category : 'initialization' }
 StTranscriptPresenter >> initializePresenters [
 
-	text := self newCode.
-	text syntaxHighlight: false.
-	text lineNumbers: false.
-	text beEditable.
+	textPresenter := self newCode.
+	textPresenter syntaxHighlight: false.
+	textPresenter lineNumbers: false.
+	textPresenter beEditable.
 	self initializeToolbars
 	
 	
@@ -192,7 +192,7 @@ StTranscriptPresenter >> initializeWindow: aWindowPresenter [
 		whenClosedDo: [ self unregister ]
 ]
 
-{ #category : 'layout' }
+{ #category : 'accessing' }
 StTranscriptPresenter >> layout [ 
 
 	^ SpBoxLayout newTopToBottom 
@@ -200,7 +200,7 @@ StTranscriptPresenter >> layout [
 			add: leftToolbar ;
 			add: rightToolBar expand: false ) 
 			expand: false;
-		add: text;
+		add: textPresenter;
 		yourself
 ]
 
@@ -240,7 +240,7 @@ StTranscriptPresenter >> processEntries [
 		| newText |
 		newText := String streamContents: [ :stream | 
 			entries do: [ :each | stream nextPutAll: each ] ].
-		text appendText: newText ]
+		textPresenter appendText: newText ]
 ]
 
 { #category : 'registration' }
@@ -260,9 +260,9 @@ StTranscriptPresenter >> reset [
 ]
 
 { #category : 'accessing' }
-StTranscriptPresenter >> text [
+StTranscriptPresenter >> textPresenter [
 
-	^ text
+	^ textPresenter
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
changed text variable from a SpTextPresenter to a SpCodePresenter and removed the syntaxHighlight and lineNumbers. This allows for things like for e.g  <meta> + p, etc.

fixed tests (they weren't always working due needing a wait to have the presenter updated outside of the main thread. This happens because of the structure of the new transcript: The new transcript has a main instance that sends entries via events, and the instances of the TranscriptPresenter recieve the event and update their text using it. Due to this, a wait is needed for the update to be done, and it needs to happen outside of the main thread.

'deleting extra takeKeyboardFocus' is a commit that I mistakenly put here but since it doesn't really matter because it just removes a dead line of code from the StPulse I will leave it here :)

https://github.com/pharo-spec/NewTools/issues/1172