### PR TITLE
Reverted deleted stEntry methods that were removed when moving the class

### DIFF
--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'StPulseTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'pulse'
+		'pulse',
+		'mutex'
 	],
 	#category : 'NewTools-Pulse-Tests',
 	#package : 'NewTools-Pulse-Tests'
@@ -12,7 +13,8 @@ Class {
 StPulseTest >> setUp [
 	
 	super setUp.
-	pulse := StPulse new
+	pulse := StPulse new.
+	mutex := Mutex new.
 ]
 
 { #category : 'running' }
@@ -21,26 +23,27 @@ StPulseTest >> testSearchingAllTypeOfCandidates [
 	| window candidates |	
 
 	[ 
-		window := pulse open.
-		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
-		self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
+		mutex critical: [
+			window := pulse open.
+			candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext ].
 		
-		candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
-		self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
+		mutex critical: [ 
+			self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
+			candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext ].
 		
-		candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext.
-		100 milliSeconds wait.
-		self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
+		mutex critical: [ 
+			self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
+			candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext ].
 		
-		candidates := pulse model candidatesFor: '' inContext: pulse windowsContext.
-		100 milliSeconds wait.
-		self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
+		mutex critical: [ 
+			self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
+			candidates := pulse model candidatesFor: '' inContext: pulse windowsContext ].
+
+		mutex critical: [ 
+			self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
+			candidates := pulse model candidatesFor: '' inContext: pulse toolsContext ].
 		
-		candidates := pulse model candidatesFor: '' inContext: pulse toolsContext.
-		100 milliSeconds wait.
-		self assert: (candidates atWrap: 1) categoryLabel equals: 'menu'	
+		mutex critical: [ self assert: (candidates atWrap: 1) categoryLabel equals: 'menu' ]	
 	] ensure: [ window close ]
 ]
 
@@ -50,10 +53,10 @@ StPulseTest >> testSearchingCandidates [
 	| window candidates |
 	
 	[ 
-		window := pulse open.
-		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
-		self assert: candidates size equals: 25.	
+		mutex critical: [ 
+			window := pulse open.
+			candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext ].
+		mutex critical: [ self assert: candidates size equals: 25 ]	
 	] ensure: [ window close ]
 ]
 
@@ -63,9 +66,10 @@ StPulseTest >> testSearchingInexistentCandidate [
 	| window candidates |	
 
 	[ 
-		window := pulse open.
-		candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext.
-		self assert: candidates size equals: 0.	
+		mutex critical: [ 
+			window := pulse open.
+			candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext ].
+		self assert: candidates size equals: 0
 	] ensure: [ window close ]
 ]
 
@@ -73,8 +77,6 @@ StPulseTest >> testSearchingInexistentCandidate [
 StPulseTest >> testSmoke [
 
 	| window |
-	
-	
 	
 	[ self shouldnt: [ 
 		SpWindowForceOpenNonModal during: [  window := StPulse open ] ] raise: Error ] ensure: [ window close ].

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : 'StPulseTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'pulse',
-		'mutex'
+		'pulse'
 	],
 	#category : 'NewTools-Pulse-Tests',
 	#package : 'NewTools-Pulse-Tests'
@@ -13,8 +12,7 @@ Class {
 StPulseTest >> setUp [
 	
 	super setUp.
-	pulse := StPulse new.
-	mutex := Mutex new.
+	pulse := StPulse new
 ]
 
 { #category : 'running' }
@@ -23,27 +21,26 @@ StPulseTest >> testSearchingAllTypeOfCandidates [
 	| window candidates |	
 
 	[ 
-		mutex critical: [
-			window := pulse open.
-			candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext ].
+		window := pulse open.
+		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
+		100 milliSeconds wait.
+		self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
 		
-		mutex critical: [ 
-			self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
-			candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext ].
+		candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext.
+		100 milliSeconds wait.
+		self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
 		
-		mutex critical: [ 
-			self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
-			candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext ].
+		candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext.
+		100 milliSeconds wait.
+		self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
 		
-		mutex critical: [ 
-			self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
-			candidates := pulse model candidatesFor: '' inContext: pulse windowsContext ].
-
-		mutex critical: [ 
-			self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
-			candidates := pulse model candidatesFor: '' inContext: pulse toolsContext ].
+		candidates := pulse model candidatesFor: '' inContext: pulse windowsContext.
+		100 milliSeconds wait.
+		self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
 		
-		mutex critical: [ self assert: (candidates atWrap: 1) categoryLabel equals: 'menu' ]	
+		candidates := pulse model candidatesFor: '' inContext: pulse toolsContext.
+		100 milliSeconds wait.
+		self assert: (candidates atWrap: 1) categoryLabel equals: 'menu'	
 	] ensure: [ window close ]
 ]
 
@@ -53,10 +50,10 @@ StPulseTest >> testSearchingCandidates [
 	| window candidates |
 	
 	[ 
-		mutex critical: [ 
-			window := pulse open.
-			candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext ].
-		mutex critical: [ self assert: candidates size equals: 25 ]	
+		window := pulse open.
+		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
+		100 milliSeconds wait.
+		self assert: candidates size equals: 25.	
 	] ensure: [ window close ]
 ]
 
@@ -66,10 +63,9 @@ StPulseTest >> testSearchingInexistentCandidate [
 	| window candidates |	
 
 	[ 
-		mutex critical: [ 
-			window := pulse open.
-			candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext ].
-		self assert: candidates size equals: 0
+		window := pulse open.
+		candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext.
+		self assert: candidates size equals: 0.	
 	] ensure: [ window close ]
 ]
 

--- a/src/NewTools-Spotter/StClassEntry.class.st
+++ b/src/NewTools-Spotter/StClassEntry.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'Entries'
 }
 
+{ #category : 'spotter-extensions' }
+StClassEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsClasses
+]
+
 { #category : 'accessing' }
 StClassEntry >> accept: aSpotter [
 
@@ -37,6 +43,12 @@ StClassEntry >> categoryLabel [
 StClassEntry >> doEvaluate [
 
 	content browse
+]
+
+{ #category : 'spotter-extensions' }
+StClassEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StEntry.class.st
+++ b/src/NewTools-Spotter/StEntry.class.st
@@ -29,6 +29,11 @@ StEntry class >> on: aValue [
 		yourself
 ]
 
+{ #category : 'spotter-extensions' }
+StEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+	"do nothing"
+]
+
 { #category : 'comparing' }
 StEntry >> = anEntry [
 
@@ -94,6 +99,12 @@ StEntry >> evaluateFor: aSpotter [
 StEntry >> hash [
 
 	^ self content hash
+]
+
+{ #category : 'spotter-extensions' }
+StEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StMethodEntry.class.st
+++ b/src/NewTools-Spotter/StMethodEntry.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'Entries'
 }
 
+{ #category : 'spotter-extensions' }
+StMethodEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsImplementors
+]
+
 { #category : 'accessing' }
 StMethodEntry >> accept: aSpotter [
 
@@ -37,6 +43,12 @@ StMethodEntry >> categoryLabel [
 StMethodEntry >> doEvaluate [
 
 	content browse
+]
+
+{ #category : 'spotter-extensions' }
+StMethodEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
+
+	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StPackageEntry.class.st
+++ b/src/NewTools-Spotter/StPackageEntry.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'Entries'
 }
 
+{ #category : 'spotter-extensions' }
+StPackageEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsPackages
+]
+
 { #category : 'converting' }
 StPackageEntry >> asHistoryEntry [
 
@@ -37,4 +43,10 @@ StPackageEntry >> doEvaluate [
 StPackageEntry >> iconName [
 
 	^ #package
+]
+
+{ #category : 'spotter-extensions' }
+StPackageEntry >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
+
+	^ aHeaderPresenter prepareAsPackages
 ]


### PR DESCRIPTION
When moving the entries to another package, it seems some methods were deleted. Reverting those changes to evade failing ReleaseTests (these methods are used in old spotter and not pulse, but we are keeping them for compatibility with old Spotter)