### PR TITLE
Refactor: rename Refactory* classes in Pharo

### DIFF
--- a/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
@@ -14,7 +14,7 @@ StRewriterAbstractApplier class >> applyTransformationChanges: changes [
 
 	| refactoringJob |
 	refactoringJob := [
-		changes do: [ :change | RBRefactoryChangeManager instance performChange: change ] ] asJob.
+		changes do: [ :change | ReChangeManager instance performChange: change ] ] asJob.
 	refactoringJob
 		title: 'Refactoring';
 		run


### PR DESCRIPTION
We've renamed these classes in Pharo, so they need to be updated here as well.