### PR TITLE
Fix: window fails to open when message list is nil initially

### DIFF
--- a/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageBrowser.class.st
@@ -626,5 +626,5 @@ StMessageBrowser >> windowIsClosing [
 { #category : 'private' }
 StMessageBrowser >> windowTitle [
 
-	^ (title ifNil: [ 'Message Browser' ]), ' [' , messageList numberOfElements printString , ']'
+	^ (title ifNil: [ 'Message Browser' ]), ' [' , (messageList ifNotNil: [ messageList numberOfElements printString ] ifNil: ['']) , ']'
 ]


### PR DESCRIPTION
While fixing this: https://github.com/pharo-project/pharo/pull/18363
I had issues with this browser. Maybe this is not needed. This is how I used and it failed:

```smalltalk
ReRenameMethodDriver >> browseOverrides

	| overrides |
	overrides := refactoring violations.
	StMessageBrowser
		browse: (overrides collect: [ :ref | ref realClass lookupSelector: newMessage selector ])
		asImplementorsOf: newMessage selector
```