### PR TITLE
Improving st pulse (fixed defaultKeyboardFocus not working and refactored tests)

### DIFF
--- a/src/NewTools-CodeCritiques/StRewriteCritiqueChangesBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StRewriteCritiqueChangesBrowserPresenter.class.st
@@ -72,7 +72,7 @@ StRewriteCritiqueChangesBrowserPresenter >> accept [
 	self okToChange
 		ifFalse: [ ^ self ].
 	self selectedChanges isEmptyOrNil ifTrue: [ ^self ].
-	[ ReChangeManager instance performChanges: self selectedChanges ] asJob
+	[ RBRefactoryChangeManager instance performChanges: self selectedChanges ] asJob
 		title: 'Refactoring';
 		run.
 	self window delete
@@ -277,7 +277,7 @@ StRewriteCritiqueChangesBrowserPresenter >> selectedChanges: anObject [
 StRewriteCritiqueChangesBrowserPresenter >> updateChanges [
 
 	| aCompositeChange |
-	aCompositeChange := ReChangeManager changeFactory compositeRefactoryChange.
+	aCompositeChange := RBRefactoryChangeManager changeFactory compositeRefactoryChange.
 	changes do: [ :each | aCompositeChange addChange: each ].
 
 	"Later we could filter the shown changes depending on the selected scope"

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -31,7 +31,7 @@ StPulseTest >> testDefaultKeyboardFocus [
 		self
 			assert: pulse defaultKeyboardFocus
 			equals: pulse listPresenter
-	 ] ensure: [ "window close "]
+	 ] ensure: [ window close ]
 ]
 
 { #category : 'running' }

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -16,6 +16,25 @@ StPulseTest >> setUp [
 ]
 
 { #category : 'running' }
+StPulseTest >> tearDown [
+	
+	pulse := nil.
+	super tearDown
+]
+
+{ #category : 'running' }
+StPulseTest >> testDefaultKeyboardFocus [
+
+	| window |
+	[ 
+		window := pulse open.
+		self
+			assert: pulse defaultKeyboardFocus
+			equals: pulse listPresenter
+	 ] ensure: [ "window close "]
+]
+
+{ #category : 'running' }
 StPulseTest >> testSearchingAllTypeOfCandidates [
 
 	| window candidates |	

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -19,27 +19,21 @@ StPulseTest >> setUp [
 StPulseTest >> testSearchingAllTypeOfCandidates [
 
 	| window candidates |	
-
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
 		
 		candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
 		
 		candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
 		
 		candidates := pulse model candidatesFor: '' inContext: pulse windowsContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
 		
 		candidates := pulse model candidatesFor: '' inContext: pulse toolsContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'menu'	
 	] ensure: [ window close ]
 ]
@@ -48,11 +42,9 @@ StPulseTest >> testSearchingAllTypeOfCandidates [
 StPulseTest >> testSearchingCandidates [
 
 	| window candidates |
-	
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: candidates size equals: 25.	
 	] ensure: [ window close ]
 ]
@@ -60,8 +52,7 @@ StPulseTest >> testSearchingCandidates [
 { #category : 'running' }
 StPulseTest >> testSearchingInexistentCandidate [
 
-	| window candidates |	
-
+	| window candidates |
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext.
@@ -73,9 +64,6 @@ StPulseTest >> testSearchingInexistentCandidate [
 StPulseTest >> testSmoke [
 
 	| window |
-	
-	
-	
 	[ self shouldnt: [ 
 		SpWindowForceOpenNonModal during: [  window := StPulse open ] ] raise: Error ] ensure: [ window close ].
 

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -84,11 +84,9 @@ StPulseTest >> testSmoke [
 
 	| window |
 	[ self shouldnt: [ 
-		SpWindowForceOpenNonModal during: [  window := StPulse open ] ] 
-		raise: Error ] ensure: [ window close ].
+		SpWindowForceOpenNonModal during: [  window := StPulse open ] ] raise: Error ] ensure: [ window close ].
 
-	[ self shouldnt: [ 
-		SpWindowForceOpenNonModal during: [ window := StPulse openWithTextOnEnvironment: '1' ] ] 
+	[ self shouldnt: [ SpWindowForceOpenNonModal during: [ window := StPulse openWithTextOnEnvironment: '1' ] ] 
 		raise: Error ] ensure: [ window close ].
 
 	[ self shouldnt: [ 
@@ -98,3 +96,4 @@ StPulseTest >> testSmoke [
 	[ self shouldnt: [ 
 		SpWindowForceOpenNonModal during: [ window := StPulse openWithTextOnCommands: '3' ] ] 
 		raise: Error ] ensure: [ window close ]
+]

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -472,8 +472,7 @@ StPulse >> connectPresenters [
 			action: [ self giveFocusToPreviousResultList ] ];
 		addShortcutWith: [ :action | action 
 			shortcutKey: Character arrowUp asKeyCombination;
-			action: [ self giveFocusToResultListAtLast ] ] ;
-		takeKeyboardFocus.
+			action: [ self giveFocusToResultListAtLast ] ].
 	listPresenter whenActivatedDo: [ self acceptSelection ].
 	self addKeyboardBehavior: listPresenter.
 	

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -764,6 +764,12 @@ StPulse >> isShowingPreview [
 ]
 
 { #category : 'private' }
+StPulse >> listPresenter [
+
+	^ listPresenter
+]
+
+{ #category : 'private' }
 StPulse >> mutex [ 
 
 	^ mutex ifNil: [ mutex := Mutex new ]

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -748,7 +748,9 @@ StPulse >> initializeWindow: aWindowPresenter [
 		title: 'Pulse';
 		withoutDecorations;
 		windowIcon: self windowIcon;
-		initialExtent: self preferredExtent ;
+		initialExtent: self preferredExtent;
+		"Force focus to be on the defaultKeyboardFocus presenter. This is needed because for some reason, the windows is trying to assign the focus before the DOM is completed, which in turn makes it so the focus is taken after being assigned"
+		whenOpenedDo: [ self defaultKeyboardFocus takeKeyboardFocus ];
 		whenClosedDo: [ 
 			self windowClosed. 
 			self class windowClosed ];

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -748,9 +748,7 @@ StPulse >> initializeWindow: aWindowPresenter [
 		title: 'Pulse';
 		withoutDecorations;
 		windowIcon: self windowIcon;
-		initialExtent: self preferredExtent;
-		"Force focus to be on the defaultKeyboardFocus presenter. This is needed because for some reason, the windows is trying to assign the focus before the DOM is completed, which in turn makes it so the focus is taken after being assigned"
-		whenOpenedDo: [ self defaultKeyboardFocus takeKeyboardFocus ];
+		initialExtent: self preferredExtent ;
 		whenClosedDo: [ 
 			self windowClosed. 
 			self class windowClosed ];

--- a/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
+++ b/src/NewTools-RewriterTools-Backend/StRewriterAbstractApplier.class.st
@@ -14,7 +14,7 @@ StRewriterAbstractApplier class >> applyTransformationChanges: changes [
 
 	| refactoringJob |
 	refactoringJob := [
-		changes do: [ :change | ReChangeManager instance performChange: change ] ] asJob.
+		changes do: [ :change | RBRefactoryChangeManager instance performChange: change ] ] asJob.
 	refactoringJob
 		title: 'Refactoring';
 		run

--- a/src/NewTools-Spotter/StClassEntry.class.st
+++ b/src/NewTools-Spotter/StClassEntry.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'Entries'
 }
 
-{ #category : 'spotter-extensions' }
-StClassEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
-
-	^ aHeaderPresenter prepareAsClasses
-]
-
 { #category : 'accessing' }
 StClassEntry >> accept: aSpotter [
 
@@ -43,12 +37,6 @@ StClassEntry >> categoryLabel [
 StClassEntry >> doEvaluate [
 
 	content browse
-]
-
-{ #category : 'spotter-extensions' }
-StClassEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
-
-	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StEntry.class.st
+++ b/src/NewTools-Spotter/StEntry.class.st
@@ -29,11 +29,6 @@ StEntry class >> on: aValue [
 		yourself
 ]
 
-{ #category : 'spotter-extensions' }
-StEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
-	"do nothing"
-]
-
 { #category : 'comparing' }
 StEntry >> = anEntry [
 
@@ -99,12 +94,6 @@ StEntry >> evaluateFor: aSpotter [
 StEntry >> hash [
 
 	^ self content hash
-]
-
-{ #category : 'spotter-extensions' }
-StEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
-
-	^ aSpotterPresenter headerCategoryFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StMethodEntry.class.st
+++ b/src/NewTools-Spotter/StMethodEntry.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'Entries'
 }
 
-{ #category : 'spotter-extensions' }
-StMethodEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
-
-	^ aHeaderPresenter prepareAsImplementors
-]
-
 { #category : 'accessing' }
 StMethodEntry >> accept: aSpotter [
 
@@ -43,12 +37,6 @@ StMethodEntry >> categoryLabel [
 StMethodEntry >> doEvaluate [
 
 	content browse
-]
-
-{ #category : 'spotter-extensions' }
-StMethodEntry >> headerCategoryForUnifiedProcessor: aLink on: aSpotterPresenter [
-
-	^ aSpotterPresenter headerCategoryUnifiedFor: aLink
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StPackageEntry.class.st
+++ b/src/NewTools-Spotter/StPackageEntry.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'Entries'
 }
 
-{ #category : 'spotter-extensions' }
-StPackageEntry class >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
-
-	^ aHeaderPresenter prepareAsPackages
-]
-
 { #category : 'converting' }
 StPackageEntry >> asHistoryEntry [
 
@@ -43,10 +37,4 @@ StPackageEntry >> doEvaluate [
 StPackageEntry >> iconName [
 
 	^ #package
-]
-
-{ #category : 'spotter-extensions' }
-StPackageEntry >> prepareUnifiedHeaderDescriptionFor: aHeaderPresenter [
-
-	^ aHeaderPresenter prepareAsPackages
 ]

--- a/src/NewTools-Window-Profiles-Tests/CavroisWindowManagerTest.class.st
+++ b/src/NewTools-Window-Profiles-Tests/CavroisWindowManagerTest.class.st
@@ -40,6 +40,7 @@ CavroisWindowManagerTest >> tearDown [
 { #category : 'tests' }
 CavroisWindowManagerTest >> testAddProfileFromWindows [
 
+	| profile |
 	profile := manager addProfileFromWindows: 'Profile'.
 
 	self assert: (manager profiles includesKey: 'Profile').
@@ -129,7 +130,7 @@ CavroisWindowManagerTest >> testRemovingLastProfileUpdateCurrentProfile [
 { #category : 'tests' }
 CavroisWindowManagerTest >> testSaveProfile [
 
-	| fileRef |
+	| profile fileRef |
 	profile := manager addProfileFromWindows: 'Test'.
 	fileRef := virtualFS / 'Profile:Test.ston'.
 

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -538,24 +538,6 @@ CavroisWindowManager class >> updateProfileItem: aBuilder [
 		iconName: #save
 ]
 
-{ #category : 'adding' }
-CavroisWindowManager >> addExtraWindowPlaceholders: placeholders [
-
-	placeholders do: [ :ph |
-			| validWindows |
-			validWindows := ph windows select: [ :window | window owner notNil ].
-			validWindows allButFirst do: [ :window |
-				self currentProfile add: (self placeHolderFromWindow: window) ] ]
-]
-
-{ #category : 'adding' }
-CavroisWindowManager >> addNewWindowPlaceholders: windowsInPlaceholders [
-
-	(self allCurrentWindows reject: [ :window |
-		 windowsInPlaceholders includes: window ]) do: [ :each |
-		self currentProfile add: (self placeHolderFromWindow: each) ]
-]
-
 { #category : 'recording' }
 CavroisWindowManager >> addProfileFromWindows: aProfileName [
 	"self new profileFromWindows"
@@ -899,18 +881,6 @@ CavroisWindowManager >> transitionToProfile [
 ]
 
 { #category : 'update' }
-CavroisWindowManager >> updatePlaceholderBounds: placeholders [
-
-	placeholders do: [ :ph |
-			ph windows
-				detect: [ :window | window owner notNil ]
-				ifFound: [ :firstValidWindow |
-						ph
-							extent: firstValidWindow extent;
-							position: firstValidWindow position ] ]
-]
-
-{ #category : 'update' }
 CavroisWindowManager >> updatePreviousCurrentProfile [
 
 	| oldProfile oldKey newKey |
@@ -926,24 +896,14 @@ CavroisWindowManager >> updatePreviousCurrentProfile [
 { #category : 'updating' }
 CavroisWindowManager >> updateProfile [
 
-	self updatePlaceholderBounds: self validPlaceholders.
-	self currentProfile reset.
-	self validPlaceholders do: [ :ph | self currentProfile add: ph ].
-	self addNewWindowPlaceholders:
-		(self windowsFromPlaceholders: self validPlaceholders).
-	self addExtraWindowPlaceholders: self validPlaceholders
-]
-
-{ #category : 'accessing' }
-CavroisWindowManager >> validPlaceholders [
-	^ self currentProfile placeHolders select: [ :ph |
-		ph windows anySatisfy: [ :window | window owner notNil ] ]
-
-]
-
-{ #category : 'filtering' }
-CavroisWindowManager >> windowsFromPlaceholders: placeholders [
-
-	^ placeholders flatCollect: [ :ph |
-		  ph windows select: [ :window | window owner notNil ] ]
+	| windowsInPlaceholders |
+	windowsInPlaceholders := OrderedCollection new.
+	self currentProfile placeHolders do: [ :ph |
+			windowsInPlaceholders addAll: ph windows.
+			ph windows do: [ :window |
+					ph extent: window extent.
+					ph position: window position ] ].
+	(self allCurrentWindows reject: [ :w |
+		 windowsInPlaceholders includes: w ]) do: [ :w |
+		self currentProfile add: (self placeHolderFromWindow: w) ]
 ]


### PR DESCRIPTION
-fixed defaultKeyboardFocus bug by using event whenOpenedDo: to do self defaultKeyboardFocus takeKeyboardFocus
this forces focus to be on the defaultKeyboardFocus presenter:  It is needed because for some reason, the windows is trying to assign the focus before the DOM is completed, which in turn makes it so the focus is taken after being assigned.
-Added a new test and tearDown Refactored tests  and it didn't seem needed to put wait as it is not asynch.
-Refactored the code a bit and added a getter for listPresenter to be used on testDefaultKeyboardFocus
