### PR TITLE
Fixing focus bug on st pulse and tests

### DIFF
--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -31,7 +31,7 @@ StPulseTest >> testDefaultKeyboardFocus [
 		self
 			assert: pulse defaultKeyboardFocus
 			equals: pulse listPresenter
-	 ] ensure: [ "window close "]
+	 ] ensure: [ window close ]
 ]
 
 { #category : 'running' }

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -16,6 +16,25 @@ StPulseTest >> setUp [
 ]
 
 { #category : 'running' }
+StPulseTest >> tearDown [
+	
+	pulse := nil.
+	super tearDown
+]
+
+{ #category : 'running' }
+StPulseTest >> testDefaultKeyboardFocus [
+
+	| window |
+	[ 
+		window := pulse open.
+		self
+			assert: pulse defaultKeyboardFocus
+			equals: pulse listPresenter
+	 ] ensure: [ "window close "]
+]
+
+{ #category : 'running' }
 StPulseTest >> testSearchingAllTypeOfCandidates [
 
 	| window candidates |	

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -19,27 +19,21 @@ StPulseTest >> setUp [
 StPulseTest >> testSearchingAllTypeOfCandidates [
 
 	| window candidates |	
-
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'class'.
 		
 		candidates := pulse model candidatesFor: 'test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'method'.
 		
 		candidates := pulse model candidatesFor: 'NewTools' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'package'.
 		
 		candidates := pulse model candidatesFor: '' inContext: pulse windowsContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'window'.
 		
 		candidates := pulse model candidatesFor: '' inContext: pulse toolsContext.
-		100 milliSeconds wait.
 		self assert: (candidates atWrap: 1) categoryLabel equals: 'menu'	
 	] ensure: [ window close ]
 ]
@@ -48,11 +42,9 @@ StPulseTest >> testSearchingAllTypeOfCandidates [
 StPulseTest >> testSearchingCandidates [
 
 	| window candidates |
-	
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'Test' inContext: pulse environmentContext.
-		100 milliSeconds wait.
 		self assert: candidates size equals: 25.	
 	] ensure: [ window close ]
 ]
@@ -60,8 +52,7 @@ StPulseTest >> testSearchingCandidates [
 { #category : 'running' }
 StPulseTest >> testSearchingInexistentCandidate [
 
-	| window candidates |	
-
+	| window candidates |
 	[ 
 		window := pulse open.
 		candidates := pulse model candidatesFor: 'ClassThatDoesntExist' inContext: pulse environmentContext.
@@ -73,9 +64,6 @@ StPulseTest >> testSearchingInexistentCandidate [
 StPulseTest >> testSmoke [
 
 	| window |
-	
-	
-	
 	[ self shouldnt: [ 
 		SpWindowForceOpenNonModal during: [  window := StPulse open ] ] raise: Error ] ensure: [ window close ].
 

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -472,8 +472,7 @@ StPulse >> connectPresenters [
 			action: [ self giveFocusToPreviousResultList ] ];
 		addShortcutWith: [ :action | action 
 			shortcutKey: Character arrowUp asKeyCombination;
-			action: [ self giveFocusToResultListAtLast ] ] ;
-		takeKeyboardFocus.
+			action: [ self giveFocusToResultListAtLast ] ].
 	listPresenter whenActivatedDo: [ self acceptSelection ].
 	self addKeyboardBehavior: listPresenter.
 	

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -764,6 +764,12 @@ StPulse >> isShowingPreview [
 ]
 
 { #category : 'private' }
+StPulse >> listPresenter [
+
+	^ listPresenter
+]
+
+{ #category : 'private' }
 StPulse >> mutex [ 
 
 	^ mutex ifNil: [ mutex := Mutex new ]

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -748,7 +748,9 @@ StPulse >> initializeWindow: aWindowPresenter [
 		title: 'Pulse';
 		withoutDecorations;
 		windowIcon: self windowIcon;
-		initialExtent: self preferredExtent ;
+		initialExtent: self preferredExtent;
+		"Force focus to be on the defaultKeyboardFocus presenter. This is needed because for some reason, the windows is trying to assign the focus before the DOM is completed, which in turn makes it so the focus is taken after being assigned"
+		whenOpenedDo: [ self defaultKeyboardFocus takeKeyboardFocus ];
 		whenClosedDo: [ 
 			self windowClosed. 
 			self class windowClosed ];


### PR DESCRIPTION
-fixed defaultKeyboardFocus bug by using event whenOpenedDo: to do self defaultKeyboardFocus takeKeyboardFocus
this forces focus to be on the defaultKeyboardFocus presenter: It is needed because for some reason, the windows is trying to assign the focus before the DOM is completed, which in turn makes it so the focus is taken after being assigned.
-Added a new test and tearDown Refactored tests and it didn't seem needed to put wait as it is not asynch.
-Refactored the code a bit and added a getter for listPresenter to be used on testDefaultKeyboardFocus