### PR TITLE
Allow columns sorting of AbstractFileReference inspector tab

### DIFF
--- a/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
+++ b/src/NewTools-Inspector-Extensions/AbstractFileReference.extension.st
@@ -101,47 +101,50 @@ AbstractFileReference >> inspectionGifContext: aContext [
 
 { #category : '*NewTools-Inspector-Extensions' }
 AbstractFileReference >> inspectionItems: aBuilder [
+
 	<inspectorPresentationOrder: 0 title: 'Items'>
 	| items |
+	items := self directories , self files.
+	self isRoot ifFalse: [ items := items copyWithFirst: self parent ].
 
-	items := 	self directories, self files.
-	self isRoot ifFalse: [ 
-		items := items copyWithFirst: self parent ]. 
-
-	^  aBuilder newTable 
-		addStyle: 'stList';
-		beResizable;
-		items: items;
-		addColumn: (SpCompositeTableColumn new 
-			title: 'Name';
-			width: 300;
-			addColumn: (SpImageTableColumn evaluated: [ :each |
-				each isDirectory 
-					ifTrue: [ self iconNamed: #folder ] 
-					ifFalse: [ self iconNamed: #browse ] ]) 
-				beNotExpandable;
-			addColumn: (SpStringTableColumn evaluated: [ :each | 
-				(self isChildOf: each) 
-					ifTrue: [ '..' ] 
-					ifFalse: [ each basename ] ]);
-			yourself);
-		addColumn: (SpStringTableColumn new 
-			title: 'Size';
-			width: 100;
-			evaluated: [ :each | 
-				[ each humanReadableSize ]
-					on: Error 
-					do: [ 'N/A' translated ] ]);
-		addColumn: (SpStringTableColumn 
-			title: 'Creation'
-			evaluated: [ :each | 
-				[ String streamContents: [ :s | 
-					each creationTime printYMDOn: s.
-					s nextPut: Character space.
-					each creationTime printHMSOn: s ] ]
-				on: Error 
-				do: [ 'N/A' translated  ] ]);
-		yourself
+	^ aBuilder newTable
+		  addStyle: 'stList';
+		  beResizable;
+		  items: items;
+		  addColumn: (SpCompositeTableColumn new
+				   title: 'Name';
+				   width: 300;
+				   addColumn: ((SpImageTableColumn evaluated: [ :each |
+								     each isDirectory
+									     ifTrue: [ self iconNamed: #folder ]
+									     ifFalse: [ self iconNamed: #browse ] ])
+						    beNotExpandable;
+						    yourself);
+				   addColumn: (SpStringTableColumn evaluated: [ :each |
+							    (self isChildOf: each)
+								    ifTrue: [ '..' ]
+								    ifFalse: [ each basename ] ]);
+				   sortFunction: [ :each | each basename ] ascending;
+				   yourself);
+		  addColumn: (SpStringTableColumn new
+				   title: 'Size';
+				   width: 100;
+				   beSortable;
+				   evaluated: [ :each |
+						   [ each humanReadableSize ]
+							   on: Error
+							   do: [ 'N/A' translated ] ]);
+		  addColumn: ((SpStringTableColumn title: 'Creation' evaluated: [ :each |
+						    [
+							    String streamContents: [ :s |
+										    each creationTime printYMDOn: s.
+										    s nextPut: Character space.
+										    each creationTime printHMSOn: s ] ]
+							    on: Error
+							    do: [ 'N/A' translated ] ])
+				   beSortable;
+				   yourself);
+		  yourself
 ]
 
 { #category : '*NewTools-Inspector-Extensions' }


### PR DESCRIPTION
This change allows to sort the table columns of the AbstractFileReference inspector tabs in order to sort the files by name, date or size.