### PR TITLE
Better error message when accessing value throw an exception

### DIFF
--- a/src/NewTools-Inspector/StInspectorTempNode.class.st
+++ b/src/NewTools-Inspector/StInspectorTempNode.class.st
@@ -50,7 +50,7 @@ StInspectorTempNode >> rawValue [
 		"we use #tempNamed: to force a re-lookup of the variable"
 		self hostObject tempNamed: tempVariable name]
 		  on: Exception
-		  do: [ :err | 'cannot read ' , tempVariable name ]
+		  do: [ :err | 'Error: ' , err messageText ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Related to https://github.com/pharo-project/pharo/issues/18387. 
When debugger try to access value that throw an exception we change the message displayed in the debugger. 
<img width="427" height="87" alt="image" src="https://github.com/user-attachments/assets/cfca5556-8a3b-4fcb-b3eb-59d7b88b3a83" />
