### PR TITLE
st-pulse-refactoring-list-counter

### DIFF
--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -873,7 +873,6 @@ StPulse >> processAddedCandidates [
 StPulse >> processFullAddedCandidates [
 "We candidatesAddedList removeAll to evade it updating the list again after the whole result is added to the list"
 	| candidates |
-	
 	candidatesFullSearchList ifNil: [ ^ self ].
 	candidatesAddedList removeAll.
 	candidates := candidatesFullSearchList.
@@ -1028,7 +1027,9 @@ StPulse >> updateResultListWith: aCollection [
 								self historyEntries ]
 						ifFalse: [ aCollection ].
 				emptyPresenter visible: list isEmpty.
-				listPresenter disableActivationDuring: [ listPresenter items: list ].
+				listPresenter disableActivationDuring: [
+					listPresenter items: list.
+					self calculateListCounterPresenter ].
 				list isNotEmpty
 					ifTrue: [ listPresenter selectFirst ] ] ]
 ]

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -452,11 +452,14 @@ StPulse >> addToPaginator: aPresenter [
 { #category : 'private - actions' }
 StPulse >> calculateListCounterPresenter [
 
-	listCounterPresenter label: 
-		listPresenter selectedIndex asString, 
-		'/', 
+	| selectedIndex |
+	selectedIndex := listPresenter selectedIndex.
+	(selectedIndex < 10 and: [ listPresenter items size > 10 ])
+		ifTrue: [ selectedIndex := '0', (selectedIndex asString) ].
+	listCounterPresenter label:
+		selectedIndex asString,
+		'/',
 		listPresenter items size asString
-
 ]
 
 { #category : 'private - updating' }


### PR DESCRIPTION
-Made it so now when the selectedIndex is less than 10 and when there is less than 10 objects in the list, it adds a 0 to the selected Index. this was made to evade the layout constantly resizing when the selectedIndex amount of digits changes.
-Fixed a small bug that made it so in some changes the listCounter would not update when changing tabs