### PR TITLE
StOpenFileOrDirectoryPresenter cannot open a directory

### DIFF
--- a/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenDirectoryPresenter.class.st
@@ -39,12 +39,6 @@ StOpenDirectoryPresenter class >> navigationSystemClass [
 	^ StDirectoryNavigationSystemPresenter 
 ]
 
-{ #category : 'hooks' }
-StOpenDirectoryPresenter >> allowsChooseDirectoryIfNoFilename [
-
-	^ true
-]
-
 { #category : 'accessing' }
 StOpenDirectoryPresenter >> selectedEntry [
 

--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
@@ -10,6 +10,12 @@ Class {
 	#tag : 'UI'
 }
 
+{ #category : 'hooks' }
+StOpenFileOrDirectoryPresenter >> allowsChooseDirectoryIfNoFilename [
+
+	^ true
+]
+
 { #category : 'api' }
 StOpenFileOrDirectoryPresenter >> beMultipleSelection [
 	"Allow the user to select multiple files or directories in open dialogs"

--- a/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFilePresenter.class.st
@@ -109,6 +109,12 @@ StOpenFilePresenter class >> examplePreviewer [
 		open
 ]
 
+{ #category : 'hooks' }
+StOpenFilePresenter >> allowsChooseDirectoryIfNoFilename [
+
+	^ false
+]
+
 { #category : 'testing' }
 StOpenFilePresenter >> isMultipleSelection [
 	"Answer <true> if the receiver was set to enable multiple selections"


### PR DESCRIPTION
Currently StOpenFileOrDirectoryPresenter cannot open a directory, which is in contradiction with its name. 

I need it for a Moose interface so here is the fix. I'll also propose a backport because Moose is mostly on P13 and this is a nice feature to just let the user select a file or folder.