### PR TITLE
Enable "openOnListDirectory" of the file browser

### DIFF
--- a/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserAbstractPresenter.class.st
@@ -99,7 +99,7 @@ StFileBrowserAbstractPresenter >> defaultColumns [
 StFileBrowserAbstractPresenter >> defaultDirectory [
 	"See class side comment"
 
-	^ self model defaultDirectory.
+	^ self model defaultDirectory
 ]
 
 { #category : 'accessing - history' }

--- a/src/NewTools-FileBrowser/StFileBrowserSettings.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserSettings.class.st
@@ -24,8 +24,7 @@ Class {
 StFileBrowserSettings class >> defaultDirectory [
 	"Modified by settings File Browser self classSide >> #openOnDefaultDirectoryOn: "
 
-	^ DefaultDirectory
-		ifNil: [ DefaultDirectory := FileLocator imageDirectory ]
+	^ DefaultDirectory ifNil: [ DefaultDirectory := FileLocator home ]
 ]
 
 { #category : 'settings' }
@@ -108,8 +107,7 @@ StFileBrowserSettings class >> macTerminalProgramOn: aBuilder [
 StFileBrowserSettings class >> openOnLastDirectory [
 	"Modified by settings File Browser self classSide >> #openOnLastDirectoryOn: "
 
-	^ OpenOnLastDirectory
-		ifNil: [ OpenOnLastDirectory := false ]
+	^ OpenOnLastDirectory ifNil: [ OpenOnLastDirectory := true ]
 ]
 
 { #category : 'settings' }
@@ -121,15 +119,13 @@ StFileBrowserSettings class >> openOnLastDirectory: aBoolean [
 
 { #category : 'settings' }
 StFileBrowserSettings class >> openOnLastDirectoryOn: aBuilder [
-	<systemsettings>
 
+	<systemsettings>
 	(aBuilder setting: #openOnLastDirectory)
 		parent: #fileBrowser;
-		default: true;
 		label: 'Open on last visited directory';
 		description: 'Open a new instance on the last visited directory';
 		target: self
-
 ]
 
 { #category : 'settings' }

--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -45,17 +45,6 @@ StFileSystemPresenter class >> defaultPreferredExtent [
 	^ (1100 @ 700)
 ]
 
-{ #category : 'defaults' }
-StFileSystemPresenter class >> lastVisitedDirectory [
-
-	(LastVisitedDirectory isNotNil and: [ 
-		 [ LastVisitedDirectory exists ]
-			 on: ResolutionRequest
-			 do: [ false ] ]) ifFalse: [ 
-		LastVisitedDirectory := StFileBrowserSettings defaultDirectory ].
-	^ LastVisitedDirectory 
-]
-
 { #category : 'hooks' }
 StFileSystemPresenter class >> navigationSystemClass [
 


### PR DESCRIPTION
This change is:
- cleaning some duplication
- enabling by default the openOnListDirectory because this is the behavior of most file browsers and this is really useful
- Update the default location from image directory to home. The image directory is cool for a pharo dev. But most people will build applications that are not related to Pharo image