### PR TITLE
changing pulse service step delay

### DIFF
--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -579,7 +579,7 @@ StPulse >> ensurePulseService [
 	
 	service := TKTParameterizableService new.
 	service name: 'Pulse service: ', UUID new asString.
-	service stepDelay: 50 milliSeconds.
+	service stepDelay: 200 milliSeconds.
 	service step: [ self processSearch ].
 	service start.
 	


### PR DESCRIPTION
based on some feedback, I decided to change the step delay of the service to make it slower, in order to make it so when you are serching for something, the search results don't update so much when writing