### PR TITLE
Clean bookmarks initialization

### DIFF
--- a/src/NewTools-FileBrowser/StFileSystemModel.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemModel.class.st
@@ -33,7 +33,9 @@ StFileSystemModel class >> addBookmarkNamed: aString location: aLocation iconNam
 { #category : 'accessing - bookmarks' }
 StFileSystemModel class >> bookmarks [
 
-	^ Bookmarks
+	^ Bookmarks ifNil: [
+			  self initializeBookmarks.
+			  Bookmarks ]
 ]
 
 { #category : 'defaults' }
@@ -77,9 +79,7 @@ StFileSystemModel >> addBookmark: aFileReference [
 StFileSystemModel >> bookmarks [
 	"Answer the receiver's <Collection> of bookmarks, each one an instance of a subclass of <StFileBrowserAbstractBookMark>"
 
-	Bookmarks 
-		ifNil: [ self class initializeBookmarks ].
-	^ Bookmarks
+	^ self class bookmarks
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
We have a class and instance side accessor for bookmarks but only instance side accessor initialize bookmarks which prevent us from adding our own before instantiating a StFileSystemModel. 

This change fixes this to initialize the bookmarks on the class side accessor too and making the instance side method call the class side one