### PR TITLE
[Backport] Improve folder selection in the File Browser

### DIFF
--- a/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
+++ b/src/NewTools-FileBrowser/StOpenFileOrDirectoryPresenter.class.st
@@ -40,13 +40,12 @@ StOpenFileOrDirectoryPresenter >> selectFiles: aCollectionOfFiles [
 
 { #category : 'menu - accessing' }
 StOpenFileOrDirectoryPresenter >> selectedEntries [
-	"Answer a <Collection> of user's selected <FileReference>s "
+	"Answer a <Collection> of user's selected <FileReference>s.
+	
+	When the user do not select any file reference and we allow to select a folder, return the current folder as in any other file browser."
 
-	| entries |
-	((entries := self fileNavigationSystem selectedEntries) 
-		anySatisfy: [ : entry | (entry exists not and: [ entry isDirectory ]) ])
-			ifTrue: [ 
-				self inform: 'Only files could be selected (no directories)'.
-				^ nil ].
-	^ entries
+	^ self fileNavigationSystem selectedEntries ifEmpty: [
+			  self allowsChooseDirectoryIfNoFilename
+				  ifTrue: [ { self fileNavigationSystem currentDirectory } ]
+				  ifFalse: [ {  } ] ]
 ]


### PR DESCRIPTION
The method returning the selected entries of the file browser has some problems.  First the code suggest that we are filtering folders to not return them, but an #and: was used instead of a #or: so this code is not effective. And this method is used also in the #OpenFolder variant of the file browser so the code should not be here. Second, in a traditional file browser, if we allow to select a folder and we press confirm with no folder selected, then we get the current folder. I'm adapting NewTools FileBrowser to act in the same way.

Fixes #1229