### PR TITLE
Fix bug in file presenter in case a folder is empty

### DIFF
--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -76,7 +76,7 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 
 	"The Morphic `configureScrolling` is executed **AFTER** the desired scroll was configured from the `StDirectoryTreePresenter`. Furthermore, the `configureScrolling` uses the `desiredVisibleRow` which is always set to 1. This statement updates the desired visible row to the last visible index of whatever the selection is pointing to."
 
-	directoryTreePresenter verticalAlignment lastVisibleRowIndex ifNotNil: [ :index | index directoryTreePresenter verticalAlignment desiredVisibleRow: index ]
+	directoryTreePresenter verticalAlignment lastVisibleRowIndex ifNotNil: [ :index | directoryTreePresenter verticalAlignment desiredVisibleRow: index ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
+++ b/src/NewTools-FileBrowser/StDirectoryTreePresenter.class.st
@@ -54,33 +54,29 @@ StDirectoryTreePresenter >> expandPath: aFileLocator [
 
 	currentNode := directoryTreePresenter roots anyOne.
 	Smalltalk os isWindows ifTrue: [
-		currentNode := currentNode asFileReference parent.
-		aPathForSpec := OrderedCollection new ].
-	
+			currentNode := currentNode asFileReference parent.
+			aPathForSpec := OrderedCollection new ].
+
 	"This code is (a certainly wrong) way to ensure the treeNavigationPresenter widget points to the right fileSystem (that could be a MemoryStore) as it search for roots of the disk and doesn't allow to check in a MemoryStore "
 	"(currentNode fileReference fileSystem = aFileLocator fileSystem)
         ifFalse: [ directoryTreePresenter roots: { StRootDirectoryWrapper on: aFileLocator fileSystem root }.
                     currentNode fileReference: aFileLocator ]."
 
 	path do: [ :aPart |
-		| subdirs |
-		subdirs := currentNode directories sorted: [ :a :b |
-			           a basename caseInsensitiveLessOrEqual: b basename ].
-		currentNode := nil.
-		subdirs doWithIndex: [ :subdir :index |
-			(currentNode isNil and: [ subdir basename = aPart ]) ifTrue: [
-				currentNode := subdir.
-				aPathForSpec add: index ] ].
-		currentNode ifNil: [ ^ self ] ].
+			| subdirs |
+			subdirs := currentNode directories sorted: [ :a :b | a basename caseInsensitiveLessOrEqual: b basename ].
+			currentNode := nil.
+			subdirs doWithIndex: [ :subdir :index |
+					(currentNode isNil and: [ subdir basename = aPart ]) ifTrue: [
+							currentNode := subdir.
+							aPathForSpec add: index ] ].
+			currentNode ifNil: [ ^ self ] ].
 
-	directoryTreePresenter
-		selectPath: aPathForSpec
-		scrollToSelection: true.
+	directoryTreePresenter selectPath: aPathForSpec scrollToSelection: true.
 
 	"The Morphic `configureScrolling` is executed **AFTER** the desired scroll was configured from the `StDirectoryTreePresenter`. Furthermore, the `configureScrolling` uses the `desiredVisibleRow` which is always set to 1. This statement updates the desired visible row to the last visible index of whatever the selection is pointing to."
 
-	directoryTreePresenter verticalAlignment desiredVisibleRow:
-		directoryTreePresenter verticalAlignment lastVisibleRowIndex
+	directoryTreePresenter verticalAlignment lastVisibleRowIndex ifNotNil: [ :index | index directoryTreePresenter verticalAlignment desiredVisibleRow: index ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
In some cases the file browser will crash because it uses a weird way to select some elements in some trees without checking that the index to select exists.

This is just a guard added, I think we should refactor the code to not have to go throught the vertical aligment to have something cleaner