### PR TITLE
Fixing  18505: Pulse is not working

### DIFF
--- a/src/NewTools-Pulse-Tests/StPulseHistoryCollectionTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseHistoryCollectionTest.class.st
@@ -78,6 +78,16 @@ StPulseHistoryCollectionTest >> testEntries [
 ]
 
 { #category : 'running' }
+StPulseHistoryCollectionTest >> testEntryUnderstandContentString [ 
+	
+	| entry1 |
+
+	entry1 := StClassEntry new content: 'entry1'.
+	self assert: entry1 contentString equals: 'entry1'
+	
+]
+
+{ #category : 'running' }
 StPulseHistoryCollectionTest >> testMaxEntries [
 	
 	| entry1 entry2 |

--- a/src/NewTools-Pulse-Tests/StPulseTest.class.st
+++ b/src/NewTools-Pulse-Tests/StPulseTest.class.st
@@ -35,6 +35,16 @@ StPulseTest >> testDefaultKeyboardFocus [
 ]
 
 { #category : 'running' }
+StPulseTest >> testHistoryIsWellInitialized [
+
+	StPulse reset.
+	self 
+		shouldnt: [ StPulse historize: (StClassEntry on: self class)  ]
+		raise: Error 
+	
+]
+
+{ #category : 'running' }
 StPulseTest >> testSearchingAllTypeOfCandidates [
 
 	| window candidates |	

--- a/src/NewTools-Pulse/StPulse.class.st
+++ b/src/NewTools-Pulse/StPulse.class.st
@@ -125,7 +125,7 @@ StPulse class >> hidePreview [
 { #category : 'accessing' }
 StPulse class >> historize: aStEntry [
 
-	History add: aStEntry
+	self history add: aStEntry
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Spotter/StEntry.class.st
+++ b/src/NewTools-Spotter/StEntry.class.st
@@ -77,6 +77,12 @@ StEntry >> content: anObject [
 	content := anObject
 ]
 
+{ #category : 'accessing' }
+StEntry >> contentString [
+
+	^ content asString
+]
+
 { #category : 'spotter-extensions' }
 StEntry >> displayString [
 


### PR DESCRIPTION
- adding tests
- adding contentString to StEntry (how could it work without it?)
- make history related method follow lazy initialization (else of course you get bugs).

Fixing https://github.com/pharo-project/pharo/issues/18505