### PR TITLE
Fix syntax of "packages selected" for the finder

### DIFF
--- a/src/NewTools-Finder/StFinderEnvironmentBar.class.st
+++ b/src/NewTools-Finder/StFinderEnvironmentBar.class.st
@@ -88,5 +88,7 @@ StFinderEnvironmentBar >> searchInPackages: aCollection [
 { #category : 'updating - widgets' }
 StFinderEnvironmentBar >> updateStatus [
 
-	statusLabel label: self model selectedPackages size asString , ' Packages selected'
+	statusLabel label: self model selectedPackages size asString , ' Package' , (self model selectedPackages size = 1
+			 ifTrue: [ '' ]
+			 ifFalse: [ 's' ]) , ' selected' 
 ]


### PR DESCRIPTION
- It was written ```packages``` even when only one single package was selected
- Fixes https://github.com/pharo-project/pharo/issues/18475#issuecomment-3206166526