### PR TITLE
Fix potential freezing browser

### DIFF
--- a/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
+++ b/src/NewTools-FileBrowser/StFileSystemPresenter.class.st
@@ -100,25 +100,22 @@ StFileSystemPresenter >> bookmarksTreeTable [
 ]
 
 { #category : 'initialization' }
-StFileSystemPresenter >> connectPresenters [ 
+StFileSystemPresenter >> connectPresenters [
 	"Here we check that the window is displayed. 
 	If it's not, that means this is a first opening so it should preserve the path selected by the user (through openOnLastDirectory preference, or defaultRoot: message send) and not to transmit the directory selection"
 
 	super connectPresenters.
-	
-	treeNavigationSystem
-		transmitDo: [ : selection | 
-			(self isDisplayed and: [ selection isNotNil ])
-				ifTrue: [ self updateWidgetWithFileReference: selection fileReference ] ].
-			
-	bookmarksTreeTable whenSelectionChangedDo: [ :selection | 
-		selection selectedItem ifNotNil: [ :selectedItem | 
-			selectedItem isComposite ifFalse: [ 
-				self fileNavigationSystem openFolder: selectedItem location ] ] ].
 
-	self whenDisplayDo: [ 
-		self centered.
-		treeNavigationSystem expandPath: fileNavigationSystem currentDirectory ].
+	treeNavigationSystem transmitDo: [ :selection |
+			(self isDisplayed and: [ selection isNotNil ]) ifTrue: [
+				self updateWidgetWithFileReference: selection fileReference ] ].
+
+	bookmarksTreeTable whenSelectionChangedDo: [ :selection |
+			selection selectedItem ifNotNil: [ :selectedItem |
+					selectedItem isComposite ifFalse: [
+						self fileNavigationSystem openFolder: selectedItem location ] ] ].
+
+	self whenDisplayDo: [ self centered ]
 ]
 
 { #category : 'layout' }


### PR DESCRIPTION
Due to the **possible complexity** of subdirectories when opening the ```File Browser```,  now it dont expand the tree when its opened.
<img width="1611" height="747" alt="Screen Shot 2025-09-12 at 14 14 35" src="https://github.com/user-attachments/assets/fbf4829d-3564-4d34-9dd4-065f1acc8785" />

Fixes https://github.com/pharo-project/pharo/issues/18450#issuecomment-3164391609

@ELePors is it okay for you that way ?
