### PR TITLE
Add inspector tab ‘FormSet’ showing a FormSet as an ImageMorph

### DIFF
--- a/src/NewTools-Inspector-Extensions/FormSet.extension.st
+++ b/src/NewTools-Inspector-Extensions/FormSet.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'FormSet' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+FormSet >> inspectionFormSet: aBuilder [
+	<inspectorPresentationOrder: 0 title: 'FormSet'>
+	
+	^ aBuilder newMorph 
+		morph: self asMorph;
+		yourself
+]


### PR DESCRIPTION
This pull request adds an inspector tab ‘FormSet’ showing a FormSet as an ImageMorph.