### PR TITLE
Remove NewTools-ObjectCentricBreakpoints

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -102,8 +102,6 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-ProjectLoader' with: [ spec requires: #( 'NewTools-Core') ] ;
 			package: 'NewTools-ProjectLoader-Microdown';
 	
-			"Object-centric breakpoints"
-			package: 'NewTools-ObjectCentricBreakpoints'  with: [ spec requires: #( 'NewTools-Inspector') ] ;
 	
 			"Sindarin"
 			package: 'NewTools-Sindarin-Commands';
@@ -194,7 +192,6 @@ BaselineOfNewTools >> baseline: spec [
 					 	'NewTools-Debugger'
 
 						'NewTools-Debugger-Morphic'
-				    	'NewTools-ObjectCentricBreakpoints'
 				    	'NewTools-Sindarin-Tools' 
 
 					 	'NewTools-Sindarin-Commands'

--- a/src/NewTools-ObjectCentricBreakpoints/package.st
+++ b/src/NewTools-ObjectCentricBreakpoints/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'NewTools-ObjectCentricBreakpoints' }

--- a/src/NewTools-Playground/StPlaygroundPage.class.st
+++ b/src/NewTools-Playground/StPlaygroundPage.class.st
@@ -89,11 +89,11 @@ StPlaygroundPage >> contents [
 { #category : 'accessing' }
 StPlaygroundPage >> contents: aString [
 
-	aString asString trimmed ifEmpty: [ ^ self ].
+	aString asString trimBoth ifEmpty: [ ^ self ].
 	mutex critical: [
-		self basicContents: aString.
-		contentReceived := true.
-		self spawnFlushProcess ]
+			self basicContents: aString.
+			contentReceived := true.
+			self spawnFlushProcess ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This package is empty but still declared in the baseline causing a test failure in the CI.

I also fixed a deprecation