### PR TITLE
Cleanup: remove  an override of #==

### DIFF
--- a/src/NewTools-Scopes-Editor/ScopeNode.class.st
+++ b/src/NewTools-Scopes-Editor/ScopeNode.class.st
@@ -41,12 +41,6 @@ ScopeNode >> = anotherNode [
 		and: [ self label = anotherNode label ]
 ]
 
-{ #category : 'comparing' }
-ScopeNode >> == anotherNode [
-
-	^ self = anotherNode
-]
-
 { #category : 'accessing' }
 ScopeNode >> basicEqualsTo: aNode [
 


### PR DESCRIPTION
remove  an override of #==. As the special bytecode inlines the primitive, this can not be called