### PR TITLE
filtering protocols when creating a new method in debugger

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerMNUExtensionTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerMNUExtensionTest.class.st
@@ -58,6 +58,43 @@ StDebuggerMNUExtensionTest >> tearDown [
 ]
 
 { #category : 'tests' }
+StDebuggerMNUExtensionTest >> testExtensionDisplaysFilteredProtocolsDNU [
+
+	self hideExtensionInDebugger.
+	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
+	debugger
+		application: debugger class currentApplication;
+		initialize.
+
+	self assert: debugger debuggerActionModel isInterruptedContextDoesNotUnderstand.
+	self assert: debugger canExecuteCreateMissingMethodCommand.
+
+	self displayExtensionInDebugger.
+
+self assertCollection:  ( (debugger extensionTools first instVarNamed: #selectedProtocol) items collect: #name)  hasSameElements:  StTestDebuggerProvider protocolNames.
+self denyCollection: ( (debugger extensionTools first instVarNamed: #selectedProtocol) items collect: #name) includesAny: Object protocolNames.
+]
+
+{ #category : 'tests' }
+StDebuggerMNUExtensionTest >> testExtensionDisplaysObjectProtocolsDNU [
+
+	| extensionFilteredProtocols |
+	self hideExtensionInDebugger.
+	debugger := StTestDebuggerProvider new debuggerWithObjectClassDNUContext.
+	debugger
+		application: debugger class currentApplication;
+		initialize.
+
+	self assert: debugger debuggerActionModel isInterruptedContextDoesNotUnderstand.
+	self assert: debugger canExecuteCreateMissingMethodCommand.
+
+	self displayExtensionInDebugger.
+extensionFilteredProtocols:=( (debugger extensionTools first instVarNamed: #selectedProtocol) items ).
+self assertCollection:  (extensionFilteredProtocols collect: #name)  includesAll:  Object class protocolNames.
+self denyCollection: (extensionFilteredProtocols reject: #isExtensionProtocol thenCollect: #name) includesAny: ((Object allSuperclasses collect:#protocols) flattened reject:#isExtensionProtocol thenCollect:#name).
+]
+
+{ #category : 'tests' }
 StDebuggerMNUExtensionTest >> testExtensionDisplaysWhenDNU [
 
 	self hideExtensionInDebugger.

--- a/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
+++ b/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
@@ -151,6 +151,15 @@ StTestDebuggerProvider >> debuggerWithMissingSubclassResponsibilityContextWithSt
 ]
 
 { #category : 'helpers' }
+StTestDebuggerProvider >> debuggerWithObjectClassDNUContext [
+	[ self methodProducingDNUonObject ]
+		on: Error
+		do: [ :err | 
+			self sessionFor: err signalerContext exception: err.					
+			^ self newDebugger ]
+]
+
+{ #category : 'helpers' }
 StTestDebuggerProvider >> debuggerWithObjectHalting [
 	[ StDebuggerObjectForTests new haltingMethod ]
 		on: Halt
@@ -193,6 +202,12 @@ StTestDebuggerProvider >> intermediateRecursiveMethodCall [
 StTestDebuggerProvider >> methodProducingDNU [
 
 	^ self foobar
+]
+
+{ #category : 'helpers' }
+StTestDebuggerProvider >> methodProducingDNUonObject [
+
+	^ Object foobar
 ]
 
 { #category : 'helpers' }

--- a/src/NewTools-Debugger/StDebuggerMethodImplementorPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerMethodImplementorPresenter.class.st
@@ -54,17 +54,20 @@ StDebuggerMethodImplementorPresenter >> addProtocolsFrom: aClassOrTrait [
 	aClassOrTrait ifNil: [ ^ self ].
 
 	allProtocolsWithDuplicates := Dictionary new.
+	
 	(aClassOrTrait isTrait
 		 ifTrue: [ aClassOrTrait protocols ]
 		 ifFalse: [
-				 (aClassOrTrait withAllSuperclasses copyWithoutAll: {
+			((aClassOrTrait withAllSuperclasses copyWithoutAll: ({
 						  Object.
 						  ProtoObject.
 						  Class.
 						  Behavior.
 						  ClassDescription.
 						  Object class.
-						  ProtoObject class }) flatCollect: #protocols ]) do: [ :protocol |
+						  ProtoObject class } copyWithout: aClassOrTrait)) flatCollect: #protocols) asSet .
+						
+					 ]) do: [ :protocol |
 		allProtocolsWithDuplicates at: protocol name put: protocol ].
 	self addProtocols: allProtocolsWithDuplicates values
 ]

--- a/src/NewTools-Debugger/StDebuggerMethodImplementorPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerMethodImplementorPresenter.class.st
@@ -57,9 +57,14 @@ StDebuggerMethodImplementorPresenter >> addProtocolsFrom: aClassOrTrait [
 	(aClassOrTrait isTrait
 		 ifTrue: [ aClassOrTrait protocols ]
 		 ifFalse: [
-			 (aClassOrTrait withAllSuperclasses copyWithoutAll: {
-					  Object.
-					  ProtoObject }) flatCollect: #protocols ]) do: [ :protocol |
+				 (aClassOrTrait withAllSuperclasses copyWithoutAll: {
+						  Object.
+						  ProtoObject.
+						  Class.
+						  Behavior.
+						  ClassDescription.
+						  Object class.
+						  ProtoObject class }) flatCollect: #protocols ]) do: [ :protocol |
 		allProtocolsWithDuplicates at: protocol name put: protocol ].
 	self addProtocols: allProtocolsWithDuplicates values
 ]


### PR DESCRIPTION
Restrained added protocol names when creating a new class-side method in the debugger.

fix #1207
@Julesboul @DurieuxPol 