### PR TITLE
[P12] Fix Issue 16827: Method version history timestamp always shows a wired date

### DIFF
--- a/src/NewTools-MethodBrowsers/StMessageVersionListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMessageVersionListPresenter.class.st
@@ -65,5 +65,6 @@ StMessageVersionListPresenter >> messageListActions [
 
 { #category : 'private' }
 StMessageVersionListPresenter >> timeStampOf: anItem [
-	^ anItem timeStamp
+	"If the item does not have an stamp, let's mark it as unknown."
+	^ anItem stamp ifNil: [ 'Unknown' ]
 ]


### PR DESCRIPTION
Using the stamp instead of the timestamp. So we avoid trying to parse the string that may content author and different date format.

Fix issue https://github.com/pharo-project/pharo/issues/16827