### PR TITLE
Cleanup log.

### DIFF
--- a/src/NewTools-Debugger-Fuel/FLDebuggerStackSerializer.class.st
+++ b/src/NewTools-Debugger-Fuel/FLDebuggerStackSerializer.class.st
@@ -54,13 +54,11 @@ FLDebuggerStackSerializer >> fileNameForContext: aContext [
 
 { #category : 'private' }
 FLDebuggerStackSerializer >> imageInformationString [
+
 	^ String streamContents: [ :stringStream |
-		stringStream	
-			nextPutAll: 'Image: ';
-			nextPutAll:  SystemVersion current version asString;
-			nextPutAll: ' [';
-			nextPutAll: Smalltalk lastUpdateString asString;
-			nextPutAll: ']' ]
+			  stringStream
+				  nextPutAll: 'Image: ';
+				  nextPutAll: SystemVersion current asString ]
 ]
 
 { #category : 'serializing' }


### PR DESCRIPTION
Avoid writing duplicate information, and remove dependency to strange "Smalltalk" method