### PR TITLE
Dependency Analyser: enables the action if items are valid

### DIFF
--- a/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
@@ -253,28 +253,35 @@ StDependencyTreePresenter >> initializePresenters [
 	super initializePresenters.
 	packageLabel := self newLabel label: 'Analysis of packages'.
 	textPackageField := self newTextInput
-		placeholder: 'Enter a package name';
-		entryCompletion: self packagesEntryCompletion.
+		                    placeholder: 'Enter a package name';
+		                    entryCompletion: self packagesEntryCompletion.
 	self initializeButtons.
-	
-	tree actionsWith: [ :group | group 
-		addActionWith: [ :action | action 
-			name: 'Browse scoped dependencies';
-			actionEnabled: [ self selectedPackageNames isNotEmpty ];
-			action: [
-				 (StPackageDependenciesPresenter onPackagesNamed: self selectedPackageNames) 
-					application: self application;
-					open ] ];
-		addActionWith: [ :action | action 
-			name: 'Find cycles among packages';
-			action: [
-				(StCycleDetectionPresenter onPackagesNamed: self selectedPackageNames)
-					application: self application;
-					open ] ];
-		addActionWith: [ :action | action 
-			name: 'Browse dependencies from class';
-			actionEnabled: [ self areClassToDependencyNodes: self selectedItemsFromTree ];
-			action: [  self openTreeFor: self selectedNames ] ] ]
+
+	tree actionsWith: [ :group |
+			group
+				addActionWith: [ :action |
+						action
+							name: 'Browse scoped dependencies';
+							actionEnabled: [
+									(self areSubclassToPackageDependencyNodes: self selectedItemsFromTree)
+										ifTrue: [ self selectedPackageNames isNotEmpty ]
+										ifFalse: [ false ] ];
+							action: [
+									(StPackageDependenciesPresenter onPackagesNamed: self selectedPackageNames)
+										application: self application;
+										open ] ];
+				addActionWith: [ :action |
+						action
+							name: 'Find cycles among packages';
+							action: [
+									(StCycleDetectionPresenter onPackagesNamed: self selectedPackageNames)
+										application: self application;
+										open ] ];
+				addActionWith: [ :action |
+						action
+							name: 'Browse dependencies from class';
+							actionEnabled: [ self areClassToDependencyNodes: self selectedItemsFromTree ];
+							action: [ self openTreeFor: self selectedNames ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-DependencyAnalyser-UI/StPackageTreePresenter.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StPackageTreePresenter.class.st
@@ -35,6 +35,12 @@ StPackageTreePresenter >> arePackageNodes: aCollectionOfItem [
 	^ aCollectionOfItem allSatisfy: [ :node |  node isPackageNode ]
 ]
 
+{ #category : 'testing' }
+StPackageTreePresenter >> areSubclassToPackageDependencyNodes: aCollectionOfItem [
+
+	^ aCollectionOfItem allSatisfy: [ :node | node content class inheritsFrom: StPackageDependency ]
+]
+
 { #category : 'initialization' }
 StPackageTreePresenter >> browseReference [
 	self selectedItemFromTree isReferenceNode ifTrue: [


### PR DESCRIPTION
- Only takes items that understand ```packageName```  before calling the method since it was raising DNU, because calling ```self selectedPackageNames``` to enable the menu action was causing an error
 - I tried to do it the cleanest way I know, using the actual logic ( see ```self areClassToDependencyNodes: self selectedItemsFromTree``` in the same method)
 - Fixes [#18527](https://github.com/pharo-project/pharo/issues/18527#issuecomment-3376739372)