### PR TITLE
Using DebugInfo

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerContextTest.class.st
@@ -67,16 +67,16 @@ StDebuggerContextTest >> setUp [
 StDebuggerContextTest >> testArgumentsNodes [
 	|nodes| 
 	debuggerContext context: self contextWithArgs.
-	nodes := debuggerContext temporaryVariablesNodes select: [ :tempNode | tempNode tempVariable isArgumentVariable ].	
+	nodes := debuggerContext temporaryVariablesNodes select: [ :tempNode | tempNode isArgumentVariable ].	
 	self assert: nodes size equals: 2.
 	self assert: nodes first key equals: 'i'.
 	self assert: nodes first variableTag equals: 'arg'.
 	self assert: nodes first rawValue equals: 4.
-	self assert: nodes first class equals: StInspectorTempNode.
+	self assert: nodes first class equals: StInspectorNewTempNode.
 	self assert: nodes second key equals: 'j'.
 	self assert: nodes second variableTag equals: 'arg'.
 	self assert: nodes second rawValue equals: 2.
-	self assert: nodes second class equals: StInspectorTempNode.
+	self assert: nodes second class equals: StInspectorNewTempNode.
 	self deny: (nodes anySatisfy: [:n| n key = 'self'])
 ]
 
@@ -84,7 +84,7 @@ StDebuggerContextTest >> testArgumentsNodes [
 StDebuggerContextTest >> testArgumentsNodesInBlock [
 	|nodes|
 	debuggerContext context: self contextWithArgsInBlock.
-	nodes := debuggerContext temporaryVariablesNodes select: [ :tempNode | tempNode tempVariable isArgumentVariable ].	
+	nodes := debuggerContext temporaryVariablesNodes select: [ :tempNode | tempNode isArgumentVariable ].	
 	self assert: nodes size equals: 2.
 	self assert: nodes first key equals: 'a'.
 	self assert: nodes first variableTag equals: 'arg'.
@@ -254,11 +254,11 @@ StDebuggerContextTest >> testTemporaryVariablesNodes [
 	self assert: nodes first key equals: 'a'.
 	self assert: nodes first variableTag equals: 'temp. var'.	
 	self assert: nodes first rawValue equals: 0.
-	self assert: nodes first tempVariable isTempVariable.
+	self assert: nodes first isTempVariable.
 	self assert: nodes second key equals: 'b'.
 	self assert: nodes second variableTag equals: 'temp. var'.	
 	self assert: nodes second rawValue equals: nil.
-	self assert: nodes first tempVariable isTempVariable.
+	self assert: nodes first isTempVariable.
 	self deny: (nodes anySatisfy: [:n| n key = 'self'])
 ]
 

--- a/src/NewTools-Debugger-Tests/StDebuggerInspectorTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerInspectorTest.class.st
@@ -141,11 +141,11 @@ StDebuggerInspectorTest >> testUpdateLayoutForContextsWithAssertionFailure [
 	self
 		assert: assertionFailure actualObject
 		equals:
-		((session interruptedContext tempNamed: #aStringOrBlock) at: 2).
+		((session interruptedContext tempNamed: #aStringOrBlock) at: 1).
 	self
 		assert: assertionFailure expectedObject
 		equals:
-		((session interruptedContext tempNamed: #aStringOrBlock) at: 1)
+		((session interruptedContext tempNamed: #aStringOrBlock) at: 2)
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -330,7 +330,7 @@ StDebuggerTest >> testContextChangedAfterStepOverAndReturn [
 { #category : 'tests - context inspector' }
 StDebuggerTest >> testContextTempVarList [
 	| contextItems inspectorTable |
-	
+
 	dbg := self debuggerOn: session.
 	inspectorTable := dbg inspector getRawInspectorPresenterOrNil attributeTable.
 	
@@ -342,10 +342,10 @@ StDebuggerTest >> testContextTempVarList [
 	self assert: (contextItems at: 1) class equals: StInspectorSelfNode.	
 	
 	"Next nodes are temps"
-	self assert: (contextItems at: 2) tempVariable isTempVariable.
-	self assert: (contextItems at: 3) tempVariable isTempVariable.
-	self assert: (contextItems at: 4) tempVariable isTempVariable.
-	self assert: (contextItems at: 5) tempVariable isTempVariable.
+	self assert: (contextItems at: 2) isTempVariable.
+	self assert: (contextItems at: 3) isTempVariable.
+	self assert: (contextItems at: 4) isTempVariable.
+	self assert: (contextItems at: 5) isTempVariable.
 	
 	"receiver"	
 	self assert: (contextItems at: 6) rawValue identicalTo: session shortStack first receiver session.
@@ -413,8 +413,8 @@ StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlined
 			assert: (newContextItems at: i)
 			identicalTo: (contextItems at: i) ].
 
-	self assert: (newContextItems at: 9) tempVariable isTempVariable.
-	self assert: (newContextItems at: 9) tempVariable name equals: 'j'.
+	self assert: (newContextItems at: 9) isTempVariable.
+	self assert: (newContextItems at: 9) tempName equals: 'j'.
 
 	"We leave inlined block"
 	2 timesRepeat: [ dbg stepOver ].
@@ -620,7 +620,6 @@ StDebuggerTest >> testDiscardCodeChangesFor [
 { #category : 'tests - code pane' }
 StDebuggerTest >> testDynamicVariableEvaluation [
 	|activeProcess debuggedProcess|
-	self skipOnPharoCITestingEnvironment.
 	debugger := StTestDebuggerProvider new
 		            debuggerWithDynamicVariableSuspendedContext.
 	debugger initializeCode.
@@ -1307,11 +1306,11 @@ StDebuggerTest >> testUpdateLayoutForContextsIfAssertionFailure [
 	self
 		assert: assertionFailure actualObject
 		equals:
-		((session interruptedContext tempNamed: #aStringOrBlock) at: 2).
+		((session interruptedContext tempNamed: #aStringOrBlock) at: 1).
 	self
 		assert: assertionFailure expectedObject
 		equals:
-		((session interruptedContext tempNamed: #aStringOrBlock) at: 1)
+		((session interruptedContext tempNamed: #aStringOrBlock) at: 2)
 ]
 
 { #category : 'tests - code pane' }

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -458,11 +458,10 @@ StDebuggerTest >> testContextTempVarListUpdatesTempsWhenEnteringOrLeavingInlined
 			identicalTo: (contextItems at: i) ].
 
 	self assert:
-		(newContextItems at: contextItems size + 1) tempVariable
-			isTempVariable.
+		(newContextItems at: contextItems size + 1) isTempVariable.
 	self
 		assert:
-		(newContextItems at: contextItems size + 1) tempVariable name
+		(newContextItems at: contextItems size + 1) tempName
 		equals: 'list'.
 
 	"We leave inlined block"

--- a/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
+++ b/src/NewTools-Debugger-Tests/StTestDebuggerProvider.class.st
@@ -41,22 +41,25 @@ StTestDebuggerProvider >> debuggerWithDNUContext [
 
 { #category : 'helpers' }
 StTestDebuggerProvider >> debuggerWithDynamicVariableSuspendedContext [
-	|process|
+
+	| process progressSemaphore |
+	progressSemaphore := Semaphore new.
 	process := [
-	           TestDynamicVariable value: 42 during: [
-		           self assert:
-			           (thisProcess psValueAt: TestDynamicVariable soleInstance index) = 42.
-					  100 milliSeconds wait.
-		           thisProcess suspend ] ] fork.
-	session := DebugSession
-		           named: 'test session providerSessionFor:'
-		           on: process
-		           startedAt: process suspendedContext.
-	session exception:
-		(OupsNullException fromSignallerContext: process suspendedContext).
-"	self assert:
-		(process psValueAt: TestDynamicVariable soleInstance index) = 42."
+		           TestDynamicVariable value: 42 during: [
+				           self assert: (thisProcess psValueAt: TestDynamicVariable soleInstance index) = 42.
+				           "Let's tell our owner that we are inside the block!"
+							  progressSemaphore signal.
+							  "And now we suspend ourselves"
+				           thisProcess suspend ] ] fork.
 	
+	"We wait until the process reaches the block.
+	Then we can continue"
+	progressSemaphore wait.
+
+	session := DebugSession named: 'test session providerSessionFor:' on: process startedAt: process suspendedContext.
+	session exception: (OupsNullException fromSignallerContext: process suspendedContext).
+	self assert: (process psValueAt: TestDynamicVariable soleInstance index) = 42.
+
 	^ self newDebugger
 ]
 

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -87,7 +87,7 @@ Class {
 		'programmaticallyClosed',
 		'stackAndCodeContainer',
 		'toolbarPresenter',
-		'previousASTScope'
+		'namesVisibleInPreviousScope'
 	],
 	#classVars : [
 		'EnableStackColoring'
@@ -847,6 +847,7 @@ StDebugger >> initializeInspector [
 	inspector := self
 		instantiate: self debuggerInspectorClass
 		on: (self debuggerInspectorModelClass on: self newDebuggerContext).
+	namesVisibleInPreviousScope := self newDebuggerContext context temporaryVariableNames.
 	inspector label: 'Receiver'
 ]
 
@@ -1602,25 +1603,26 @@ StDebugger >> updateStackFromSession: aSession [
 { #category : 'updating' }
 StDebugger >> updateStep [
 
-	| previousContext currentASTScope currentContext |
+	| previousContext currentlyVisibleNames currentContext |
 	previousContext := self currentContext.
 	self updateStackFromSession: self session.
 	self updateWindowTitle.
 	self updateExtensionsFromSession: self session.
 	self updateToolbar.
-
+1haltOnce.
 	currentContext := self currentContext.
-	currentASTScope := currentContext temporaryVariables.
+	currentlyVisibleNames := currentContext temporaryVariableNames.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
+
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
 			previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes.""Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."
 					p
 						updateNodesFromScope:
-						(previousASTScope ifNil: [ currentASTScope ])
-						to: currentASTScope ].
+						(namesVisibleInPreviousScope ifNil: [ currentlyVisibleNames ])
+						to: currentlyVisibleNames ].
 			p update ].
 
-	previousASTScope := currentASTScope
+	namesVisibleInPreviousScope := currentlyVisibleNames
 ]
 
 { #category : 'toolbar' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1611,7 +1611,7 @@ StDebugger >> updateStep [
 
 	currentContext := self currentContext.
 	currentASTScope := currentContext compiledCode debugInfo
-		variablesAt: currentContext executedPC.
+		                   variablesAt: currentContext executedPC.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
 			previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes.""Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -847,7 +847,6 @@ StDebugger >> initializeInspector [
 	inspector := self
 		instantiate: self debuggerInspectorClass
 		on: (self debuggerInspectorModelClass on: self newDebuggerContext).
-	namesVisibleInPreviousScope := self newDebuggerContext context temporaryVariableNames.
 	inspector label: 'Receiver'
 ]
 
@@ -1556,8 +1555,7 @@ StDebugger >> updateInspectorFromContext: aContext [
 		isAssertionFailure:
 		self debuggerActionModel isInterruptedContextAnAssertEqualsFailure.
 	inspector updateWith: (self newDebuggerContextFor: aContext).
-	self flag: #DBG_INSPECTOR_UPDATE_BUG.
-	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
+	self updateStep
 ]
 
 { #category : 'updating' }

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1609,7 +1609,7 @@ StDebugger >> updateStep [
 	self updateWindowTitle.
 	self updateExtensionsFromSession: self session.
 	self updateToolbar.
-1haltOnce.
+
 	currentContext := self currentContext.
 	currentlyVisibleNames := currentContext temporaryVariableNames.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1610,8 +1610,7 @@ StDebugger >> updateStep [
 	self updateToolbar.
 
 	currentContext := self currentContext.
-	currentASTScope := currentContext compiledCode debugInfo
-		                   variablesAt: currentContext executedPC.
+	currentASTScope := currentContext temporaryVariables.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
 			previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes.""Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1138,10 +1138,10 @@ StDebugger >> saveGeneratedCodeAndProceed [
 { #category : 'actions' }
 StDebugger >> selectNextExecutedExpression [
 
-	| sourceNodeExecuted |
-	sourceNodeExecuted := self currentContext sourceNodeExecuted.
-	self code selectionInterval:
-		(sourceNodeExecuted start to: sourceNodeExecuted stop)
+	| interval previouslyExecutedPC |
+	previouslyExecutedPC := self currentContext executedPC.
+	interval := self currentContext method debugInfo rangeForPC: previouslyExecutedPC.
+	self code selectionInterval: (interval first to: interval last)
 ]
 
 { #category : 'stack' }
@@ -1610,8 +1610,8 @@ StDebugger >> updateStep [
 	self updateToolbar.
 
 	currentContext := self currentContext.
-	currentASTScope := (currentContext compiledCode sourceNodeForPC:
-		                    currentContext pc) scope.
+	currentASTScope := currentContext compiledCode debugInfo
+		variablesAt: currentContext executedPC.
 	self flag: #DBG_INSPECTOR_UPDATE_BUG.
 	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p |
 			previousContext == currentContext ifTrue: [ "otherwise, if contexts have changed, updating the stack has already updated all nodes.""Here it is necessary to update temporary nodes if we are still in the same context but in a different scope. This is possible when leaving or entering an optimized block scope."

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -161,7 +161,7 @@ StDebuggerContext >> stackTopNode [
 { #category : 'nodes' }
 StDebuggerContext >> temporaryVariablesNodes [
 
-	^ self context astScope allTemps collect: [ :temp | 
+	^ self context temporaryVariables collect: [ :temp | 
 		  (StInspectorTempNode hostObject: self context) tempVariable: temp ]
 ]
 

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -60,9 +60,9 @@ StDebuggerContext >> buildInspectorNodes [
 	nodes := OrderedCollection new.
 	tempsAndArgs := self temporaryVariablesNodes.
 	argsNodes := tempsAndArgs select: [ :tempNode | 
-		             tempNode tempVariable isArgumentVariable ].
+		             tempNode isArgumentVariable ].
 	tempsNodes := tempsAndArgs select: [ :tempNode | 
-		              tempNode tempVariable isTempVariable ].
+		              tempNode isTempVariable ].
 	nodes add: self selfNode.
 	nodes addAll: argsNodes.
 	nodes addAll: tempsNodes.
@@ -162,7 +162,7 @@ StDebuggerContext >> stackTopNode [
 StDebuggerContext >> temporaryVariablesNodes [
 
 	^ self context temporaryVariables collect: [ :temp | 
-		  (StInspectorTempNode hostObject: self context) tempVariable: temp ]
+		  (StInspectorNewTempNode hostObject: self context) tempDescriptor: temp ]
 ]
 
 { #category : 'nodes' }

--- a/src/NewTools-Debugger/StDebuggerContext.class.st
+++ b/src/NewTools-Debugger/StDebuggerContext.class.st
@@ -161,8 +161,8 @@ StDebuggerContext >> stackTopNode [
 { #category : 'nodes' }
 StDebuggerContext >> temporaryVariablesNodes [
 
-	^ self context temporaryVariables collect: [ :temp | 
-		  (StInspectorNewTempNode hostObject: self context) tempDescriptor: temp ]
+	^ self context temporaryVariableNames collect: [ :arg1 |
+		  (StInspectorNewTempNode hostObject: self context) tempName: arg1 ]
 ]
 
 { #category : 'nodes' }

--- a/src/NewTools-Debugger/StRawInspectionPresenter.extension.st
+++ b/src/NewTools-Debugger/StRawInspectionPresenter.extension.st
@@ -44,11 +44,9 @@ StRawInspectionPresenter >> selectedPageName [
 ]
 
 { #category : '*NewTools-Debugger' }
-StRawInspectionPresenter >> updateNodesFromScope: oldASTScope to: newASTScope [
+StRawInspectionPresenter >> updateNodesFromScope: oldTemps to: newTemps [
 
-	| nodes newTemps oldTemps tempsToRemove tempsToAdd |
-	oldTemps := oldASTScope allTemps.
-	newTemps := newASTScope allTemps.
+	| nodes tempsToRemove tempsToAdd |
 	tempsToRemove := oldTemps difference: newTemps.
 	tempsToAdd := newTemps difference: oldTemps.
 	nodes := self attributeTable roots.

--- a/src/NewTools-Debugger/StRawInspectionPresenter.extension.st
+++ b/src/NewTools-Debugger/StRawInspectionPresenter.extension.st
@@ -50,15 +50,14 @@ StRawInspectionPresenter >> updateNodesFromScope: oldTemps to: newTemps [
 	tempsToRemove := oldTemps difference: newTemps.
 	tempsToAdd := newTemps difference: oldTemps.
 	nodes := self attributeTable roots.
-
 	nodes removeAllSuchThat: [ :node |
-		node class = StInspectorTempNode and: [
-			tempsToRemove includes: node tempVariable ] ].
+		node class = StInspectorNewTempNode and: [
+			tempsToRemove includes: node tempName ] ].
 	tempsToAdd do: [ :temp |
 		nodes add:
-			((StInspectorTempNode hostObject:
+			((StInspectorNewTempNode hostObject:
 					  self model inspectedObject context)
-				 tempVariable: temp;
+				 tempName: temp;
 				 yourself) ].
 
 	self attributeTable roots: nodes

--- a/src/NewTools-Inspector/StInspectorNewTempNode.class.st
+++ b/src/NewTools-Inspector/StInspectorNewTempNode.class.st
@@ -1,0 +1,102 @@
+"
+I am a variable node for representing a temporary variable stored in a Context object that has a name attached. 
+This includes  local variables and method parameters.
+"
+Class {
+	#name : 'StInspectorNewTempNode',
+	#superclass : 'StInspectorNode',
+	#instVars : [
+		'debugInfo',
+		'tempDescriptor'
+	],
+	#category : 'NewTools-Inspector-Model',
+	#package : 'NewTools-Inspector',
+	#tag : 'Model'
+}
+
+{ #category : 'comparing' }
+StInspectorNewTempNode >> = anObject [
+
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ tempDescriptor = anObject name and: [ 
+		  hostObject = anObject hostObject ]
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> children [
+	^ #()
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> debugInfo [
+
+	^ debugInfo
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> debugInfo: anObject [
+
+	debugInfo := anObject
+]
+
+{ #category : 'comparing' }
+StInspectorNewTempNode >> hash [
+
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ tempDescriptor hash bitXor: (hostObject hash)
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> hostObject: aContext [
+
+	super hostObject: aContext.
+	debugInfo := aContext method debugInfo.
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> isArgumentVariable [
+
+	^ tempDescriptor second
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> isTempVariable [
+
+	^ self isArgumentVariable not
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> key [
+	^ tempDescriptor first
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> rawValue [
+	"Answer the object value of this object variable (slot, indexed attribute, computed value)."
+
+	| scope |
+	scope := (debugInfo debugScopeAt: (self hostObject executedPC max: self hostObject method initialPC)).
+	^ scope readVariableNamed: tempDescriptor first at: self hostObject
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> tempDescriptor [
+
+	^ tempDescriptor
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> tempDescriptor: anObject [
+
+	tempDescriptor := anObject
+]
+
+{ #category : 'accessing' }
+StInspectorNewTempNode >> variableTag [
+
+	^ 'temp. var'
+]

--- a/src/NewTools-Inspector/StInspectorNewTempNode.class.st
+++ b/src/NewTools-Inspector/StInspectorNewTempNode.class.st
@@ -7,7 +7,7 @@ Class {
 	#superclass : 'StInspectorNode',
 	#instVars : [
 		'debugInfo',
-		'tempDescriptor'
+		'tempName'
 	],
 	#category : 'NewTools-Inspector-Model',
 	#package : 'NewTools-Inspector',
@@ -17,12 +17,10 @@ Class {
 { #category : 'comparing' }
 StInspectorNewTempNode >> = anObject [
 
-	"Answer whether the receiver and anObject represent the same object."
-
 	self == anObject ifTrue: [ ^ true ].
+	nil.
 	self class = anObject class ifFalse: [ ^ false ].
-	^ tempDescriptor = anObject name and: [ 
-		  hostObject = anObject hostObject ]
+	^ tempName = anObject tempName and: [ hostObject = anObject hostObject ]
 ]
 
 { #category : 'accessing' }
@@ -42,12 +40,19 @@ StInspectorNewTempNode >> debugInfo: anObject [
 	debugInfo := anObject
 ]
 
+{ #category : 'accessing' }
+StInspectorNewTempNode >> debugScope [
+
+	^ debugInfo debugScopeAt:
+		  (self hostObject executedPC max: self hostObject method initialPC)
+]
+
 { #category : 'comparing' }
 StInspectorNewTempNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
 
-	^ tempDescriptor hash bitXor: (hostObject hash)
+	^ tempName hash bitXor: (hostObject hash)
 ]
 
 { #category : 'accessing' }
@@ -60,7 +65,7 @@ StInspectorNewTempNode >> hostObject: aContext [
 { #category : 'accessing' }
 StInspectorNewTempNode >> isArgumentVariable [
 
-	^ tempDescriptor second
+	^ self debugScope isArgumentNamed: tempName
 ]
 
 { #category : 'accessing' }
@@ -71,28 +76,28 @@ StInspectorNewTempNode >> isTempVariable [
 
 { #category : 'accessing' }
 StInspectorNewTempNode >> key [
-	^ tempDescriptor first
+
+	^ tempName
 ]
 
 { #category : 'accessing' }
 StInspectorNewTempNode >> rawValue [
-	"Answer the object value of this object variable (slot, indexed attribute, computed value)."
 
-	| scope |
-	scope := (debugInfo debugScopeAt: (self hostObject executedPC max: self hostObject method initialPC)).
-	^ scope readVariableNamed: tempDescriptor first at: self hostObject
+	^ self debugScope
+		  readVariableNamed: tempName
+		  fromContext: self hostObject
 ]
 
 { #category : 'accessing' }
-StInspectorNewTempNode >> tempDescriptor [
+StInspectorNewTempNode >> tempName [
 
-	^ tempDescriptor
+	^ tempName
 ]
 
 { #category : 'accessing' }
-StInspectorNewTempNode >> tempDescriptor: anObject [
+StInspectorNewTempNode >> tempName: anObject [
 
-	tempDescriptor := anObject
+	tempName := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Inspector/StInspectorNewTempNode.class.st
+++ b/src/NewTools-Inspector/StInspectorNewTempNode.class.st
@@ -103,5 +103,5 @@ StInspectorNewTempNode >> tempName: anObject [
 { #category : 'accessing' }
 StInspectorNewTempNode >> variableTag [
 
-	^ 'temp. var'
+	^ self isArgumentVariable ifTrue: [ 'arg' ] ifFalse: [ 'temp. var' ]
 ]


### PR DESCRIPTION
This PR makes use of the new debug info interface.
This API, which is to be used in tools such as debugger, inspector, is responsible of reading variables from a context, and to obtain bytecode to source code mappings:
  - is the current PC a send?
  - is the current PC a store?
  ...

Particular care is taken for optimized/inlined contexts, and avoiding creeping implementation details to users!!

Depends on: https://github.com/pharo-project/pharo/pull/18644