### PR TITLE
add an accessor for application in morphs 

### DIFF
--- a/src/NewTools-Morphic/Morph.extension.st
+++ b/src/NewTools-Morphic/Morph.extension.st
@@ -1,6 +1,22 @@
 Extension { #name : 'Morph' }
 
 { #category : '*NewTools-Morphic' }
+Morph >> application [
+
+	^ self 
+		valueOfProperty: #application 
+		ifAbsent: [ StPharoApplication current ]
+]
+
+{ #category : '*NewTools-Morphic' }
+Morph >> application: anApplication [
+
+	^ self 
+		setProperty: #application 
+		toValue: anApplication
+]
+
+{ #category : '*NewTools-Morphic' }
 Morph >> inspectionLayout: aBuilder [
 	<inspectorPresentationOrder: 800 title: 'Layout'>
 	


### PR DESCRIPTION
for the case we use them in the context of a NewTool (like, when using calypso that is mixed with spec tools things).