### PR TITLE
Cut dependency of Monticello to UIManager

### DIFF
--- a/src/NewTools-Utils/MCMergeOrLoadWarning.extension.st
+++ b/src/NewTools-Utils/MCMergeOrLoadWarning.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'MCMergeOrLoadWarning' }
+
+{ #category : '*NewTools-Utils' }
+MCMergeOrLoadWarning >> defaultAction [
+
+	^ (StMCMergeOrLoadChoicePresenter newApplication: StPharoApplication current) requestReslutionWithDescription: self messageText
+]

--- a/src/NewTools-Utils/StMCMergeOrLoadChoicePresenter.class.st
+++ b/src/NewTools-Utils/StMCMergeOrLoadChoicePresenter.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : 'StMCMergeOrLoadChoicePresenter',
+	#superclass : 'StPresenter',
+	#instVars : [
+		'answer',
+		'label'
+	],
+	#category : 'NewTools-Utils',
+	#package : 'NewTools-Utils'
+}
+
+{ #category : 'layout' }
+StMCMergeOrLoadChoicePresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: label expand: false;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StMCMergeOrLoadChoicePresenter >> initializeDialogWindow: aDialogWindowPresenter [
+	"Used to initialize the model in the case of the use into a dialog window.
+	 Override this to set buttons other than the default (Ok, Cancel)."
+
+	aDialogWindowPresenter
+		addButton: 'Load' do: [ :presenter |
+				answer := true.
+				presenter close ];
+		addButton: 'Merge' do: [ :presenter |
+				answer := false.
+				presenter close ];
+		addDefaultButton: 'Cancel' do: [ :presenter |
+				answer := nil.
+				presenter close ]
+]
+
+{ #category : 'initialization' }
+StMCMergeOrLoadChoicePresenter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter title: 'Alert'
+]
+
+{ #category : 'accessing' }
+StMCMergeOrLoadChoicePresenter >> label: anObject [
+	label := anObject
+]
+
+{ #category : 'initialization' }
+StMCMergeOrLoadChoicePresenter >> requestReslutionWithDescription: aString [
+
+	| dialog |
+	self label: aString.
+	dialog := self asBlockedDialogWindow.
+
+	dialog open.
+
+	^ answer
+]


### PR DESCRIPTION
Monticello is using the UIManager to ask the user if they want to load/merge or cancel the loading of a package if it would impact dirty packages. This change propose to use Spec to ask this question and cut one more dependency over the UIManager.