### PR TITLE
Fix #acceptText:in: was sent to nil

### DIFF
--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -290,8 +290,7 @@ StFinderPresenter >> connectPresenters [
 
 	self connectSearchBar.
 	previewSourcePresenter whenSubmitDo: [ :text |
-		resultTree selectedItem 
-			acceptText: text in: previewSourcePresenter ].
+		resultTree selectedItem ifNotNil: [ resultTree selectedItem acceptText: text in: previewSourcePresenter ] ].
 
 	configButton action: [
 		SettingBrowser new


### PR DESCRIPTION
fix [pharo-project/pharo/#18668 ](https://github.com/pharo-project/pharo/issues/18668)

- #acceptText:in: was sent to nil because there is no item selected