### PR TITLE
Improve Finder search options

### DIFF
--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -58,7 +58,7 @@ StBrowserSearchPresenter >> connectPresenters [
 
 	searchField whenTextChangedDo: [ self updateList ].
 	
-	searchOptions substringBox click.
+	searchOptions substringRadioButton click.
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-Finder-Tests/StFinderTest.class.st
+++ b/src/NewTools-Finder-Tests/StFinderTest.class.st
@@ -41,21 +41,21 @@ StFinderTest >> openInstance [
 { #category : 'initialization' }
 StFinderTest >> setExactAndCaseInsensitive [
 
-	presenter searchOptions exactCheckBox click.
+	presenter searchOptions exactRadioButton click.
 	presenter searchOptions caseCheckBox state: false.
 ]
 
 { #category : 'initialization' }
 StFinderTest >> setExactAndCaseSensitive [
 
-	presenter searchOptions exactCheckBox click.
+	presenter searchOptions exactRadioButton click.
 	presenter searchOptions caseCheckBox click.
 ]
 
 { #category : 'tests' }
 StFinderTest >> setRegex [
 		
-	presenter searchOptions regexpCheckBox click.
+	presenter searchOptions regexRadioButton click.
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-Finder/StFinderExampleSearch.class.st
+++ b/src/NewTools-Finder/StFinderExampleSearch.class.st
@@ -132,6 +132,6 @@ StFinderExampleSearch >> updateDefaultPreview: aSpCodePresenter [
 { #category : 'accessing' }
 StFinderExampleSearch >> validSearchOptions [
 	"Answer a <Collection> of valid search options for the receiver"
-	
-	^ #(#deactivateAll)
+
+	^ #( #disable )
 ]

--- a/src/NewTools-Finder/StFinderPresenter.class.st
+++ b/src/NewTools-Finder/StFinderPresenter.class.st
@@ -299,7 +299,7 @@ StFinderPresenter >> connectPresenters [
 			open ].
 
 	self connectSearchOptions.
-	searchOptions substringBox click.
+	searchOptions substringRadioButton click.
 
 	resultTree 
 		whenSelectedItemChangedDo: [ :newResult |
@@ -336,41 +336,14 @@ StFinderPresenter >> connectSearchBar [
 StFinderPresenter >> connectSearchOptions [
 
 	searchOptions
-		whenSubstringActivatedDo: [ 
-			self model useSubstring: true.
-			searchOptions 
-				disableExact;
-				disableRegex ];
-		whenSubstringDeactivatedDo: [ 
-			self model useSubstring: false.
-			searchOptions
-				enableExact;
-				enableRegex ];
-
-		whenRegexActivatedDo: [ 
-			self model useRegex: true.
-			searchOptions 
-				disableSubstring;
-				disableExact. ];
-		whenRegexDeactivatedDo: [ 
-			self model useRegex: false.
-			searchOptions 
-				enableSubstring;
-				enableExact ];
-		
+		whenSubstringActivatedDo: [ self model useSubstring: true ];
+		whenSubstringDeactivatedDo: [ self model useSubstring: false ];
+		whenRegexActivatedDo: [ self model useRegex: true ];
+		whenRegexDeactivatedDo: [ self model useRegex: false ];
+		whenExactActivatedDo: [ self model useExact: true ];
+		whenExactDeactivatedDo: [ self model useExact: false ];
 		whenCaseActivatedDo: [ self model useCase: true ];
-		whenCaseDeactivatedDo: [ self model useCase: false ];
-		
-		whenExactActivatedDo: [
-			self model useExact: true.
-			searchOptions 
-				disableSubstring;
-				disableRegex ];
-		whenExactDeactivatedDo: [ 
-			self model useExact: false.
-			searchOptions 
-				enableSubstring;
-				enableRegex ].
+		whenCaseDeactivatedDo: [ self model useCase: false ]
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-Finder/StFinderSearch.class.st
+++ b/src/NewTools-Finder/StFinderSearch.class.st
@@ -111,6 +111,6 @@ StFinderSearch >> updateDefaultPreview: aSpCodePresenter [
 { #category : 'accessing' }
 StFinderSearch >> validSearchOptions [
 	"Answer a <Collection> of valid search options for the receiver"
-	
-	^ #(#activateAll)
+
+	^ #( #enable )
 ]

--- a/src/NewTools-Finder/StFinderSearchBar.class.st
+++ b/src/NewTools-Finder/StFinderSearchBar.class.st
@@ -171,11 +171,10 @@ StFinderSearchBar >> updateSearchModes [
 ]
 
 { #category : 'updating - widgets' }
-StFinderSearchBar >> updateSearchOptions: aStFinderSelectorSearch [ 
+StFinderSearchBar >> updateSearchOptions: aStFinderSelectorSearch [
 	"Private - Search mode changed, update the valid search options for the selected aStFinderSelectorSearch"
 
 	owner updateSearchOptions: aStFinderSelectorSearch validSearchOptions
-
 ]
 
 { #category : 'events' }

--- a/src/NewTools-Finder/StFinderSearchOptions.class.st
+++ b/src/NewTools-Finder/StFinderSearchOptions.class.st
@@ -27,25 +27,15 @@ Class {
 	#name : 'StFinderSearchOptions',
 	#superclass : 'SpPresenter',
 	#instVars : [
-		'regexpCheckBox',
-		'exactCheckBox',
+		'exactRadioButton',
 		'caseCheckBox',
-		'substringBox'
+		'substringRadioButton',
+		'regexRadioButton'
 	],
 	#category : 'NewTools-Finder-Widgets',
 	#package : 'NewTools-Finder',
 	#tag : 'Widgets'
 }
-
-{ #category : 'initialization' }
-StFinderSearchOptions >> activateAll [
-	"Activate all the receiver's search options"
-
-	regexpCheckBox enabled: true.
-	exactCheckBox enabled: true.
-	caseCheckBox enabled: true.
-	substringBox enabled: true
-]
 
 { #category : 'accessing' }
 StFinderSearchOptions >> caseCheckBox [
@@ -53,104 +43,82 @@ StFinderSearchOptions >> caseCheckBox [
 	^ caseCheckBox
 ]
 
-{ #category : 'initialization' }
-StFinderSearchOptions >> deactivateAll [
-	"Deactivate all the receiver's search options"
-
-	regexpCheckBox enabled: false.
-	exactCheckBox enabled: false.
-	caseCheckBox enabled: false.
-	substringBox enabled: false
-]
-
 { #category : 'layout' }
 StFinderSearchOptions >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
-		spacing: 2;
-		add: substringBox width: 95;
-		add: regexpCheckBox width: 70;
-		add: exactCheckBox width: 70;
-		add: caseCheckBox width: 70;
-		yourself
+		  spacing: 2;
+		  add: substringRadioButton width: 95;
+		  add: regexRadioButton width: 70;
+		  add: exactRadioButton width: 70;
+		  add: caseCheckBox width: 70;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StFinderSearchOptions >> disable [
+	"Deactivate all the receiver's search options"
+
+	regexRadioButton enabled: false.
+	exactRadioButton enabled: false.
+	caseCheckBox enabled: false.
+	substringRadioButton enabled: false
+]
+
+{ #category : 'initialization' }
+StFinderSearchOptions >> enable [
+	"Activate all the receiver's search options"
+
+	regexRadioButton enabled: true.
+	exactRadioButton enabled: true.
+	caseCheckBox enabled: true.
+	substringRadioButton enabled: true
 ]
 
 { #category : 'accessing' }
-StFinderSearchOptions >> disableExact [
+StFinderSearchOptions >> exactRadioButton [
 
-	exactCheckBox enabled: false.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> disableRegex [
-
-	regexpCheckBox enabled: false.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> disableSubstring [
-
-	substringBox enabled: false.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> enableExact [
-
-	exactCheckBox enabled: true.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> enableRegex [
-
-	regexpCheckBox enabled: true.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> enableSubstring [
-
-	substringBox enabled: true.
-]
-
-{ #category : 'accessing' }
-StFinderSearchOptions >> exactCheckBox [
-
-	^ exactCheckBox
+	^ exactRadioButton
 ]
 
 { #category : 'initialization' }
 StFinderSearchOptions >> initializePresenters [
 
-	regexpCheckBox := self newCheckBox 
-		label: 'Regexp';
-		help: 'Use regular expression';
-		yourself.
-		
-	exactCheckBox := self newCheckBox 
-		label: 'Exact';
-		help: 'Use exact match';
-		yourself.
-		
-	caseCheckBox := self newCheckBox 
-		label: 'Case';
-		help: 'Use match case';
-		yourself.
-		
-	substringBox := self newCheckBox
-		label: 'Substring';
-		help: 'Use substring search';
-		yourself.
+	regexRadioButton := self newRadioButton
+		                    label: 'Regex';
+		                    help: 'Use regular expression';
+		                    yourself.
+
+	exactRadioButton := self newRadioButton
+		                    label: 'Exact';
+		                    help: 'Use exact match';
+		                    yourself.
+
+	substringRadioButton := self newRadioButton
+		                        label: 'Substring';
+		                        help: 'Use substring search';
+		                        yourself.
+
+	substringRadioButton associatedRadioButtons: {
+			regexRadioButton.
+			exactRadioButton }.
+
+	caseCheckBox := self newCheckBox
+		                label: 'Case';
+		                help: 'Use match case';
+		                yourself
 ]
 
 { #category : 'accessing' }
-StFinderSearchOptions >> regexpCheckBox [
+StFinderSearchOptions >> regexRadioButton [
 
-	^ regexpCheckBox
+	^ regexRadioButton
 ]
 
 { #category : 'accessing' }
-StFinderSearchOptions >> substringBox [
+StFinderSearchOptions >> substringRadioButton [
 
-	^ substringBox
+	^ substringRadioButton
 ]
 
 { #category : 'events' }
@@ -170,36 +138,35 @@ StFinderSearchOptions >> whenCaseDeactivatedDo: aBlock [
 { #category : 'events' }
 StFinderSearchOptions >> whenExactActivatedDo: aBlock [
 
-	exactCheckBox whenActivatedDo: aBlock.
-
+	exactRadioButton whenActivatedDo: aBlock
 ]
 
 { #category : 'events' }
 StFinderSearchOptions >> whenExactDeactivatedDo: aBlock [
 
-	exactCheckBox whenDeactivatedDo: aBlock.
+	exactRadioButton whenDeactivatedDo: aBlock
 ]
 
 { #category : 'events' }
 StFinderSearchOptions >> whenRegexActivatedDo: aBlock [
 
-	regexpCheckBox whenActivatedDo: aBlock
+	regexRadioButton whenActivatedDo: aBlock
 ]
 
 { #category : 'events' }
 StFinderSearchOptions >> whenRegexDeactivatedDo: aBlock [
 
-	regexpCheckBox whenDeactivatedDo: aBlock
+	regexRadioButton whenDeactivatedDo: aBlock
 ]
 
 { #category : 'events' }
 StFinderSearchOptions >> whenSubstringActivatedDo: aBlock [
 
-	substringBox whenActivatedDo: aBlock
+	substringRadioButton whenActivatedDo: aBlock
 ]
 
 { #category : 'events' }
 StFinderSearchOptions >> whenSubstringDeactivatedDo: aBlock [
 
-	substringBox whenDeactivatedDo: aBlock
+	substringRadioButton whenDeactivatedDo: aBlock
 ]


### PR DESCRIPTION
Currently 3 options are checkboxes but they are mutually exclusive. I'm replacing those by a radio button and simplify the code. 

There are ugly code still in the finder relying on perform of selector tables. But that cleaning will be for later...

This should fix broken Pharo tests