### PR TITLE
Inspecting a string should display the ' ' (Fix #814)

### DIFF
--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -25,9 +25,15 @@ String >> inspectionFullString: aBuilder [
 
 { #category : '*NewTools-Inspector-Extensions' }
 String >> inspectionString: aBuilder [
+
 	<inspectorPresentationOrder: -10 title: 'Preview'>
-	
 	^ aBuilder newText
-		text: (self truncateWithElipsisTo: 1000);
-		yourself
+		  text: self previewString;
+		  yourself
+]
+
+{ #category : '*NewTools-Inspector-Extensions' }
+String >> previewString [
+
+	^ self truncateWithElipsisTo: 1000
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -28,6 +28,6 @@ String >> inspectionString: aBuilder [
 
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	^ aBuilder newText
-		  text: self printString ;
+		  text: (self truncateWithElipsisTo: 1000) printString;
 		  yourself
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -28,12 +28,6 @@ String >> inspectionString: aBuilder [
 
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	^ aBuilder newText
-		  text: self previewString;
+		  text: self printString ;
 		  yourself
-]
-
-{ #category : '*NewTools-Inspector-Extensions' }
-String >> previewString [
-
-	^ self truncateWithElipsisTo: 1000
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -28,6 +28,6 @@ String >> inspectionString: aBuilder [
 
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	^ aBuilder newText
-		  text: (self truncateWithElipsisTo: 1000) printString;
+		  text: (self printStringLimitedTo: 1000);
 		  yourself
 ]

--- a/src/NewTools-Inspector-Extensions/StringTest.extension.st
+++ b/src/NewTools-Inspector-Extensions/StringTest.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : 'StringTest' }
-
-{ #category : '*NewTools-Inspector-Extensions' }
-StringTest >> testStDisplayString [
-
-	self assert: #test stDisplayString equals: '#test'.
-	self assert: #'#test' stDisplayString equals: '#''#test'''
-]

--- a/src/NewTools-Inspector-Extensions/StringTest.extension.st
+++ b/src/NewTools-Inspector-Extensions/StringTest.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'StringTest' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+StringTest >> testStDisplayString [
+
+	self assert: #test stDisplayString equals: '#test'.
+	self assert: #'#test' stDisplayString equals: '#''#test'''
+]

--- a/src/NewTools-Inspector-Extensions/Symbol.extension.st
+++ b/src/NewTools-Inspector-Extensions/Symbol.extension.st
@@ -1,7 +1,13 @@
 Extension { #name : 'Symbol' }
 
 { #category : '*NewTools-Inspector-Extensions' }
+Symbol >> previewString [
+
+	^ self stDisplayString
+]
+
+{ #category : '*NewTools-Inspector-Extensions' }
 Symbol >> stDisplayString [
 
-	^ '#{1}' format: { super stDisplayString }
+	^ (self truncateWithElipsisTo: 1000) printString
 ]

--- a/src/NewTools-Inspector-Extensions/Symbol.extension.st
+++ b/src/NewTools-Inspector-Extensions/Symbol.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'Symbol' }
 
 { #category : '*NewTools-Inspector-Extensions' }
-Symbol >> previewString [
-
-	^ self stDisplayString
-]
-
-{ #category : '*NewTools-Inspector-Extensions' }
 Symbol >> stDisplayString [
 
 	^ (self truncateWithElipsisTo: 1000) printString

--- a/src/NewTools-Inspector-Extensions/Symbol.extension.st
+++ b/src/NewTools-Inspector-Extensions/Symbol.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'Symbol' }
 { #category : '*NewTools-Inspector-Extensions' }
 Symbol >> stDisplayString [
 
-	^ (self truncateWithElipsisTo: 1000) printString
+	^ self printStringLimitedTo: 1000
 ]

--- a/src/NewTools-Inspector-Extensions/SymbolTest.extension.st
+++ b/src/NewTools-Inspector-Extensions/SymbolTest.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'SymbolTest' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+SymbolTest >> testStDisplayString [
+
+	| largeString largeSymbol expectedPrintSymbol |
+	largeString := String loremIpsum: 1001.
+	largeSymbol := largeString asSymbol.
+	expectedPrintSymbol :=  '#''' , (largeString truncateTo: 994) , '[..]'.
+
+	self assert: #test stDisplayString equals: '#test'.
+	self assert: #'#test' stDisplayString equals: '#''#test'''.
+	self assert: largeSymbol stDisplayString equals: expectedPrintSymbol 
+]


### PR DESCRIPTION
Change methods ```Symbol>>#stDisplayString``` and ```String>>#inspectionString:```.
Add methods ```String>>#previewString``` and ```Symbol>>#previewString```.

It answer the #814 issue by printing the '' when printing a symbol with a string.