### PR TITLE
Bring back `Select package as right dependency` feature

### DIFF
--- a/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
@@ -281,7 +281,14 @@ StDependencyTreePresenter >> initializePresenters [
 						action
 							name: 'Browse dependencies from class';
 							actionEnabled: [ self areClassToDependencyNodes: self selectedItemsFromTree ];
-							action: [ self openTreeFor: self selectedNames ] ] ]
+							action: [ self openTreeFor: self selectedNames ] ];
+				addActionWith: [ :action |
+						action
+							name: 'Select this package as the right dependency';
+							actionEnabled: [ self areMethodNodes: self selectedItemsFromTree ];
+							action: [
+									(TheManifestBuilder of: self selectedItemsFromTree first packageUnderAnalysis packageManifest)
+										addManuallyResolvedDependency: self selectedItemsFromTree first content package name ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-DependencyAnalyser-UI/StMethodImplementationNode.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StMethodImplementationNode.class.st
@@ -9,22 +9,15 @@ Class {
 	#tag : 'Nodes'
 }
 
-{ #category : 'building-menu' }
-StMethodImplementationNode >> addMenuActionsOn: anActionGroup [
-	| method |
-	
-	method := self content.
-	anActionGroup addActionWith: [ :action | action
-		name: 'Select this package as the right dependency';
-		action: [
-			(TheManifestBuilder of: self packageUnderAnalysis packageManifest)
-				addManuallyResolvedDependency: method package name.
-				"TODO: run the analysis again" ] ]
-]
-
 { #category : 'accessing' }
 StMethodImplementationNode >> icon [
 	^ self iconNamed: #package
+]
+
+{ #category : 'testing' }
+StMethodImplementationNode >> isMethodImplementationNode [
+
+	^ true
 ]
 
 { #category : 'displaying' }

--- a/src/NewTools-DependencyAnalyser-UI/StNode.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StNode.class.st
@@ -92,6 +92,12 @@ StNode >> isCycleNode [
 ]
 
 { #category : 'testing' }
+StNode >> isMethodImplementationNode [
+
+	^ false
+]
+
+{ #category : 'testing' }
 StNode >> isPackageNode [
  	^ false
 ]

--- a/src/NewTools-DependencyAnalyser-UI/StPackageTreePresenter.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StPackageTreePresenter.class.st
@@ -30,6 +30,12 @@ StPackageTreePresenter >> areClassToDependencyNodes: aCollectionOfItem [
 ]
 
 { #category : 'testing' }
+StPackageTreePresenter >> areMethodNodes: aCollectionOfItem [
+
+	^ aCollectionOfItem allSatisfy: [ :node |  node isMethodImplementationNode ]
+]
+
+{ #category : 'testing' }
 StPackageTreePresenter >> arePackageNodes: aCollectionOfItem [
 
 	^ aCollectionOfItem allSatisfy: [ :node |  node isPackageNode ]


### PR DESCRIPTION
Since actions are implemented a new way I had to delete old action method, implement new ones...

Fixes https://github.com/pharo-project/pharo/issues/18829
@jecisc everything works