### PR TITLE
Fix IR inspector 

### DIFF
--- a/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
+++ b/src/NewTools-Inspector-Extensions/OCIRMethod.extension.st
@@ -2,10 +2,10 @@ Extension { #name : 'OCIRMethod' }
 
 { #category : '*NewTools-Inspector-Extensions' }
 OCIRMethod >> inpectionIr: aBuilder [
-	<inspectorPresentationOrder: 40 title: 'Symbolic'>
 
+	<inspectorPresentationOrder: 40 title: 'Symbolic'>
 	^ aBuilder newCode
-		withoutSyntaxHighlight;
-		text: (self ir longPrintString trimmed);
-		yourself
+		  withoutSyntaxHighlight;
+		  text: self ir longPrintString trimBoth;
+		  yourself
 ]


### PR DESCRIPTION
just a deprecation rewrite (as the tools discovers the method via pragmas, you see the rewrite only after opening a new browser)