### PR TITLE
Fix/18914

### DIFF
--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -29,5 +29,6 @@ String >> inspectionString: aBuilder [
 	<inspectorPresentationOrder: -10 title: 'Preview'>
 	^ aBuilder newCode 
 		  text: (self printStringLimitedTo: 1000);
+		  beNotEditable;
 		  yourself
 ]

--- a/src/NewTools-Inspector-Extensions/String.extension.st
+++ b/src/NewTools-Inspector-Extensions/String.extension.st
@@ -27,7 +27,7 @@ String >> inspectionFullString: aBuilder [
 String >> inspectionString: aBuilder [
 
 	<inspectorPresentationOrder: -10 title: 'Preview'>
-	^ aBuilder newText
+	^ aBuilder newCode 
 		  text: (self printStringLimitedTo: 1000);
 		  yourself
 ]


### PR DESCRIPTION
This pull request answer https://github.com/pharo-project/pharo/issues/18914.

To allow commands like "senders of it", a CodePresenter is required. However, "preview" tab on the Inspector (for Strings and Symbols) was a TextPresenter allowing just "copy", "paste", ...

So the presenter was changed to have this feature.