### PR TITLE
Fix bug when choosing a protocol name

### DIFF
--- a/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
@@ -18,16 +18,6 @@ StProtocolNameChooserPresenterTest >> setUp [
 	presenter := StProtocolNameChooserPresenter new
 ]
 
-{ #category : 'running' }
-StProtocolNameChooserPresenterTest >> testAddButtonIsDiabledWhenTextFieldIsEmpty [
-
-	self assertEmpty: presenter protocolName.
-	self deny: presenter newProtocolButton isEnabled.
-
-	presenter protocolName: 'ANewProtocol'.
-	self assert: presenter newProtocolButton isEnabled
-]
-
 { #category : 'tests' }
 StProtocolNameChooserPresenterTest >> testCreatingProtocolThatDoesntExists [
 "When creating a protocol that doesn't exist beforehand, it should create it correctly with the same name as written."

--- a/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
@@ -44,16 +44,15 @@ StProtocolNameChooserPresenterTest >> testCreatingProtocolThatDoesntExists [
 
 { #category : 'tests' }
 StProtocolNameChooserPresenterTest >> testCreatingProtocolThatExists [
-"When creating a protocol that does exist beforehand, it should create the name of the suggested protocol instead of the name written."
-	| protocolName |
+	"When creating a new protocol, it should create the name written."
 
-	protocolName := 'acc' .
+	| protocolName |
+	protocolName := 'acc'.
 	presenter concernedClass: self class.
-	
+
 	presenter protocolName: protocolName.
 	presenter doAcceptFromTextInput.
-	self assert: presenter selectedProtocolName equals: 'accessing' 
-
+	self assert: presenter selectedProtocolName equals: 'acc'
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -106,8 +106,7 @@ StProtocolNameChooserPresenter >> doAcceptFromList [
 { #category : 'private - actions' }
 StProtocolNameChooserPresenter >> doAcceptFromTextInput [
 	
-	selectedProtocolName := suggestionList selectedItem 
-		ifNil: [  protocolNameField text. ].
+	selectedProtocolName := protocolNameField text.
 	self withWindowDo: [ :w | w beOk; close ]
 ]
 
@@ -252,6 +251,5 @@ StProtocolNameChooserPresenter >> updatePresenter [
 	newProtocolButton enabled: self protocolName isNotEmpty.
 
 	suggestionList
-		items: self protocolsToSuggest;
-		selectFirst
+		items: self protocolsToSuggest
 ]

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -18,7 +18,6 @@ Class {
 		'suggestionList',
 		'protocolNameField',
 		'concernedClass',
-		'newProtocolButton',
 		'selectedProtocolName'
 	],
 	#category : 'NewTools-Core-Calypso',
@@ -76,9 +75,7 @@ StProtocolNameChooserPresenter >> connectPresenters [
 	protocolNameField whenTextChangedDo: [ self updatePresenter ].
 	protocolNameField whenSubmitDo: [ :aString | self doAcceptFromTextInput  ].
 	
-	suggestionList whenActivatedDo: [ self doAcceptFromList ].
-	
-	newProtocolButton action: [ self doAcceptFromTextInput ]
+	suggestionList whenActivatedDo: [ self doAcceptFromList ]
 ]
 
 { #category : 'layout' }
@@ -90,7 +87,6 @@ StProtocolNameChooserPresenter >> defaultLayout [
 		add: (SpBoxLayout newLeftToRight
 				spacing: 3;
 				add: protocolNameField expand: true;
-				add: newProtocolButton expand: false;
 				yourself)
 			expand: false;
 		yourself
@@ -127,12 +123,6 @@ StProtocolNameChooserPresenter >> initializePresenters [
 	protocolNameField := self newTextInput.
 	protocolNameField placeholder: 'Protocol name (e.g. accessing)'.
 
-	newProtocolButton := self newButton.
-	newProtocolButton
-		addStyle: 'small';
-		icon: (self iconNamed: #add);
-		help: 'Create a new protocol with the content of the input field if this protocol is not in the list'.
-
 	self initializeProtocolNameField
 ]
 
@@ -163,12 +153,6 @@ StProtocolNameChooserPresenter >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter title: 'New protocol name'.
 	aWindowPresenter whenOpenedDo: [ protocolNameField takeKeyboardFocus ]
-]
-
-{ #category : 'private - accessing' }
-StProtocolNameChooserPresenter >> newProtocolButton [
-
-	^ newProtocolButton
 ]
 
 { #category : 'private - accessing' }
@@ -247,8 +231,6 @@ StProtocolNameChooserPresenter >> selectedProtocolName [
 
 { #category : 'initialization' }
 StProtocolNameChooserPresenter >> updatePresenter [
-
-	newProtocolButton enabled: self protocolName isNotEmpty.
 
 	suggestionList
 		items: self protocolsToSuggest


### PR DESCRIPTION
This pull request is fixing a bug on `StProtocolNameChooserPresenter`.

Indeed, the first protocol in the suggestion list was always selected and put as the choosen protocol (even if you've wrote something in the text editor).

So now the text editor is chosen by default (you can still select a name in the filtering list).

By the way, it will be very usefull to also add this fix in P13.