### PR TITLE
Revert part of the changes done in #1259.

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1555,7 +1555,8 @@ StDebugger >> updateInspectorFromContext: aContext [
 		isAssertionFailure:
 		self debuggerActionModel isInterruptedContextAnAssertEqualsFailure.
 	inspector updateWith: (self newDebuggerContextFor: aContext).
-	self updateStep
+	self flag: #DBG_INSPECTOR_UPDATE_BUG.
+	inspector getRawInspectorPresenterOrNil ifNotNil: [ :p | p update ]
 ]
 
 { #category : 'updating' }


### PR DESCRIPTION
Updating the UI does a full refresh, expecting to update only when the entire state of the debugger is new. Thus, calling updateStep loses the scroll, and sometimes forces a scrolling to the beginning.

Fixes https://github.com/pharo-project/pharo/issues/18953