### PR TITLE
debugger: using new easy list view for stack view

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -527,7 +527,7 @@ StDebugger >> codeLayout [
 
 	^ SpBoxLayout newTopToBottom
 		  add: self toolbarPresenter expand: false;
-		  add: #code;
+		  add: code;
 		  yourself
 ]
 
@@ -642,7 +642,7 @@ StDebugger >> defaultLayout [
 	^ SpPanedLayout newTopToBottom
 		positionOfSlider: 65 percent;
 		add: stackAndCodeContainer;
-		add: #inspector;
+		add: inspector;
 		yourself
 ]
 
@@ -890,22 +890,18 @@ StDebugger >> initializeShortcuts: aWindowPresenter [
 { #category : 'stack' }
 StDebugger >> initializeStack [
 
-	stackTable := self newList.
-	stackTable
-		activateOnDoubleClick;
-		whenActivatedDo: [ :selection | self doBrowseClass ].
-	stackTable display:[:selection| StContextPrinter printContext: selection].
-	stackTable displayColor:[ :context | self stackColorForContext: context ].
-	stackTable displayIcon: [ :context| self stackIconForContext: context ].	
-	stackTable transmitDo: [ :context |
-		stackTable selection isEmpty ifFalse: [
-			self updateInspectorFromContext: context.
-			self updateCodeFromContext: context.
-			self updateExtensionsFromSession: self session.
-			self expandStackIfLastItemIsSelected.
-			self updateWindowTitle ] ].
 	stackHeader := self instantiate: StHeaderBar.
-	stackHeader label: 'Stack'
+	stackHeader label: 'Stack'.
+
+	stackTable := self newEasyListView
+		activateOnDoubleClick;
+		rowPresenterClass: StDebuggerStackRowPresenter;
+		whenActivatedDo: [ :selection | self doBrowseClass ].		
+		
+	stackTable outputActivationPort 
+		transmitDo: [ :aContext | self doBrowseClass ].
+		
+	stackTable transmitDo: [ :aContext | self selectedContext: aContext ]
 ]
 
 { #category : 'initialization' }
@@ -1164,6 +1160,18 @@ StDebugger >> selectedContext [
 	^ self stackTable selection selectedItem
 ]
 
+{ #category : 'stack' }
+StDebugger >> selectedContext: aContext [
+
+	stackTable selection isEmpty ifTrue: [ ^ self ].
+	
+	self updateInspectorFromContext: aContext.
+	self updateCodeFromContext: aContext.
+	self updateExtensionsFromSession: self session.
+	self expandStackIfLastItemIsSelected.
+	self updateWindowTitle
+]
+
 { #category : 'accessing - model' }
 StDebugger >> session [
 	^ self debuggerClientModel session
@@ -1267,12 +1275,10 @@ StDebugger >> stackIconForContext: context [
 
 { #category : 'layout' }
 StDebugger >> stackLayout [
+
 	^ SpBoxLayout newTopToBottom
-		add: #stackHeader
-			expand: false
-			fill: false
-			padding: 5;
-		add: #stackTable;
+		add: stackHeader expand: false;
+		add: stackTable;
 		yourself
 ]
 

--- a/src/NewTools-Debugger/StDebuggerStackRowPresenter.class.st
+++ b/src/NewTools-Debugger/StDebuggerStackRowPresenter.class.st
@@ -1,0 +1,74 @@
+"
+A row for debugger stacks
+"
+Class {
+	#name : 'StDebuggerStackRowPresenter',
+	#superclass : 'SpEasyAbstractRowPresenter',
+	#instVars : [
+		'labelPresenter'
+	],
+	#category : 'NewTools-Debugger-View',
+	#package : 'NewTools-Debugger',
+	#tag : 'View'
+}
+
+{ #category : 'initialization' }
+StDebuggerStackRowPresenter >> colorStyleForContext [
+		
+	self isInSelectedContextClass ifTrue: [ ^ 'stDebuggerStackContextInSelectedClass' ].
+	self isInSelectedContextPackage ifTrue: [ ^ 'stDebuggerStackContextInSelectedPackage' ].
+
+	^ nil
+]
+
+{ #category : 'layout' }
+StDebuggerStackRowPresenter >> defaultLayout [ 
+
+	^ SpBoxLayout newLeftToRight 
+		"in fact, we are not using icons for the moment"
+		"spacing: 3;
+		add: iconPresenter expand: false;"
+		add: labelPresenter;
+		yourself
+]
+
+{ #category : 'initialization' }
+StDebuggerStackRowPresenter >> initializePresenters [ 
+
+	"iconPresenter := self newImage."
+	labelPresenter := self newLabel
+]
+
+{ #category : 'testing' }
+StDebuggerStackRowPresenter >> isInSelectedContextClass [
+	"Return true if the given context is in the same class than the currently 
+	 selected context of the stack."
+	| selectedContext |
+	
+	selectedContext := self listView selectedItem.
+	^ selectedContext isNotNil 
+		and: [ selectedContext methodClass = self model methodClass ]
+]
+
+{ #category : 'testing' }
+StDebuggerStackRowPresenter >> isInSelectedContextPackage [
+	"Return true if the given context is in the same package than 
+	 the currently selected context of the stack."
+	| selectedContext |
+	
+	selectedContext := listView selectedItem.
+	^ selectedContext isNotNil 
+		and: [ selectedContext method package = self model method package ]
+]
+
+{ #category : 'initialization' }
+StDebuggerStackRowPresenter >> updatePresenter [ 
+
+	self model ifNil: [ ^ self ].
+	
+	"iconPresenter image: self iconForContext."
+	labelPresenter label: (StContextPrinter printContext: self model).
+	labelPresenter removeAllStyles.
+	self colorStyleForContext
+		ifNotNil: [ :aStyle | labelPresenter addStyle: aStyle ]
+]

--- a/src/NewTools-Debugger/StDebuggerStyleContributor.class.st
+++ b/src/NewTools-Debugger/StDebuggerStyleContributor.class.st
@@ -1,0 +1,24 @@
+"
+A contributor to add styles referred to the debugger.
+"
+Class {
+	#name : 'StDebuggerStyleContributor',
+	#superclass : 'StPharoStyleContributor',
+	#category : 'NewTools-Debugger-View',
+	#package : 'NewTools-Debugger',
+	#tag : 'View'
+}
+
+{ #category : 'styles' }
+StDebuggerStyleContributor >> styleSheetContribution [
+
+	^ SpStyle newApplication
+		addClass: 'stDebuggerStackContextInSelectedClass' with: [ :class |
+			class addPropertyDrawWith: [ :draw |
+				draw color: Smalltalk ui theme highlightTextColor ] ];
+		addClass: 'stDebuggerStackContextInSelectedPackage' with: [ :class |
+			class addPropertyDrawWith: [ :draw |
+				draw color: (Smalltalk ui theme highlightTextColor 
+					mixed: 0.5 
+					with: Smalltalk ui theme textColor) ] ]
+]


### PR DESCRIPTION
- gives me more control (and fixes a long time bug on the stack list when not many rows were shown)
- adding a style contributor to handle styles in a better way than hardcoding in the wrong place.
- using direct presenters in layouts (instead of selectors) as the old way is no longer necesary and is confusing.

fixes https://github.com/pharo-spec/NewTools/issues/1296
