### PR TITLE
Select method's content when ShouldBeImplemented instruction 

### DIFF
--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -1149,9 +1149,7 @@ StDebugger >> selectTopContext [
 { #category : 'highlighting' }
 StDebugger >> selectedCodeRangeForContext: aContext [
 
-	^ self debuggerClientModel exception
-		  selectedCodeRangeForContext: aContext
-		  forDebugger: self
+	^ self debuggerClientModel exception selectedCodeRangeForContext: aContext forDebugger: self
 ]
 
 { #category : 'accessing - model' }
@@ -1477,20 +1475,19 @@ StDebugger >> updateCodeFromContext: aContext [
 	aContext ifNil: [ ^ self clearCode ].
 
 	self recordUnsavedCodeChanges.
-	aContext sourceCode = self code text ifFalse: [
-		self updateSourceCodeFor: aContext ].
+	aContext sourceCode = self code text ifFalse: [ self updateSourceCodeFor: aContext ].
 	selectionInterval := self selectedCodeRangeForContext: aContext.
 	formerCodeInteractionModel := self code interactionModel.
-	self code beForContext: aContext.
-	"add bindings of the old interaction model in the new one"
+	self code beForContext: aContext. "add bindings of the old interaction model in the new one"
 	formerCodeInteractionModel ifNotNil: [
-		formerCodeInteractionModel bindings associations do: [ :assoc |
-			self code interactionModel addBinding: assoc ] ].
-	self code selectionInterval:
-		(selectionInterval last to: selectionInterval last - 1).
-	self
-		updateCodeTextSegmentDecoratorsIn: aContext
-		forInterval: selectionInterval
+		formerCodeInteractionModel bindings associations do: [ :assoc | self code interactionModel addBinding: assoc ] ].
+	self code selectionInterval: (selectionInterval last to: selectionInterval last - 1).
+	self updateCodeTextSegmentDecoratorsIn: aContext forInterval: selectionInterval.
+	self debuggerClientModel isInterruptedContextShouldBeImplemented ifTrue: [
+			| bodyAst |
+			bodyAst := aContext method ast body.
+			self code selectionInterval: (bodyAst start to: bodyAst stop).
+			self code takeKeyboardFocus ]
 ]
 
 { #category : 'updating - presenters' }

--- a/src/NewTools-Debugger/StDebuggerClientModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerClientModel.class.st
@@ -263,6 +263,11 @@ StDebuggerClientModel >> isInterruptedContextPostMortem [
 ]
 
 { #category : 'debug - predicates' }
+StDebuggerClientModel >> isInterruptedContextShouldBeImplemented [
+	^ self contextPredicate isInterruptedContextShouldBeImplemented
+]
+
+{ #category : 'debug - predicates' }
 StDebuggerClientModel >> isInterruptedContextSubclassResponsibilityException [
 	^ self contextPredicate isContextSubclassResponsibilityException
 ]

--- a/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextPredicate.class.st
@@ -82,6 +82,11 @@ StDebuggerContextPredicate >> isGeneratingCode [
 ]
 
 { #category : 'predicates' }
+StDebuggerContextPredicate >> isInterruptedContextShouldBeImplemented [
+	^ false
+]
+
+{ #category : 'predicates' }
 StDebuggerContextPredicate >> isSteppable [
 
 	^ self isContextPostMortem not and: [ self isContextDead not ]

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -72,6 +72,11 @@ StDebuggerErrorContextPredicate >> isGeneratingCode [
 ]
 
 { #category : 'predicates' }
+StDebuggerErrorContextPredicate >> isInterruptedContextShouldBeImplemented [
+	^ exception class == ShouldBeImplemented 
+]
+
+{ #category : 'predicates' }
 StDebuggerErrorContextPredicate >> isSteppable [
 
 	super isSteppable ifFalse: [ ^ false ].


### PR DESCRIPTION
When there is a `self ShouldBeImplemented` instruction in a method and the associated exception is raised by the Debugger, content of this method is directly selected.

This feature allows developpers to modify directly the method (they don't have to do the selection manually).

https://github.com/user-attachments/assets/5162a96a-cff6-4048-a8dd-f037629b4095