### PR TITLE
Clicking on "Close" is closing the window

### DIFF
--- a/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
+++ b/src/NewTools-WindowManager/SpClosedWindowListPresenter.class.st
@@ -136,7 +136,7 @@ SpClosedWindowListPresenter class >> windowMenuOn: aBuilder [
 	(aBuilder item: #Close)
 		order: 1.0;
 		action: [
-			aBuilder model hide.
+			aBuilder model close.
 			announcement := WindowClosed new
 				                window: aBuilder model;
 				                yourself.


### PR DESCRIPTION
When opening the "Window menu" of windows and clicking on "Close", windows were hidden.

So we fixed this to match the expected behavior (i.e. closing the window).