### PR TITLE
Update a metacello view

### DIFF
--- a/src/NewTools-Spotter-Extensions/MetacelloVersion.extension.st
+++ b/src/NewTools-Spotter-Extensions/MetacelloVersion.extension.st
@@ -17,7 +17,7 @@ MetacelloVersion >> spotterForPackagesFor: aStep [
 	aStep listProcessor
 		title: 'Packages';
 		allCandidates: [ self packages ];
-		itemName: [ :item | item file ];
+		itemName: [ :item | item name ];
 		filter: StFilterSubstring;
 		wantsToDisplayOnEmptyQuery: true
 ]


### PR DESCRIPTION
I am removing #file that just return the name so I'm updating the spotter. But in reallity I don't know if this is used? Or is it dead code?