### PR TITLE
Change menu for ShortcutBrowser from Tools to System

### DIFF
--- a/src/NewTools-ShortcutsBrowser/StShortcutsBrowserPresenter.class.st
+++ b/src/NewTools-ShortcutsBrowser/StShortcutsBrowserPresenter.class.st
@@ -39,7 +39,7 @@ StShortcutsBrowserPresenter class >> menuCommandOn: aBuilder [
 	(aBuilder item: 'Shortcuts Browser')
 		action: [ self open ];
 		order: 34;
-		parent: #Tools;
+		parent: #SystemTools;
 		icon: self icon;
 		help: self descriptionText
 ]


### PR DESCRIPTION
Fixes #1310 
- This tool was not in the system menu, now its simpler to browse it