### PR TITLE
fix: show the finder search options again #19105

### DIFF
--- a/src/NewTools-Finder/StFinderSearchOptions.class.st
+++ b/src/NewTools-Finder/StFinderSearchOptions.class.st
@@ -48,10 +48,10 @@ StFinderSearchOptions >> defaultLayout [
 
 	^ SpBoxLayout newLeftToRight
 		  spacing: 2;
-		  add: substringRadioButton width: 95;
-		  add: regexRadioButton width: 70;
-		  add: exactRadioButton width: 70;
-		  add: caseCheckBox width: 70;
+		  add: substringRadioButton;
+		  add: regexRadioButton;
+		  add: exactRadioButton;
+		  add: caseCheckBox;
 		  yourself
 ]
 


### PR DESCRIPTION
Issue https://github.com/pharo-project/pharo/issues/19105

The menu is back:

<img width="797" height="111" alt="Screenshot 2026-01-15 alle 20 02 19" src="https://github.com/user-attachments/assets/f5d760be-93ae-4375-b563-bf94641a40ea" />
