### PR TITLE
Trim the name on protocol creation

### DIFF
--- a/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StProtocolNameChooserPresenterTest.class.st
@@ -46,6 +46,19 @@ StProtocolNameChooserPresenterTest >> testCreatingProtocolThatExists [
 ]
 
 { #category : 'tests' }
+StProtocolNameChooserPresenterTest >> testNewProtocolIsTrimmedByBothSides [
+
+
+	| protocolName |
+	protocolName := ' nameWithSpaces '.
+	presenter concernedClass: self class.
+
+	presenter protocolName: protocolName.
+	presenter doAcceptFromTextInput.
+	self assert: presenter selectedProtocolName equals: 'nameWithSpaces'
+]
+
+{ #category : 'tests' }
 StProtocolNameChooserPresenterTest >> testSmoke [
 
 	| window |

--- a/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
+++ b/src/NewTools-Core/StProtocolNameChooserPresenter.class.st
@@ -101,9 +101,12 @@ StProtocolNameChooserPresenter >> doAcceptFromList [
 
 { #category : 'private - actions' }
 StProtocolNameChooserPresenter >> doAcceptFromTextInput [
-	
-	selectedProtocolName := protocolNameField text.
-	self withWindowDo: [ :w | w beOk; close ]
+
+	selectedProtocolName := protocolNameField text trimBoth.
+	self withWindowDo: [ :w |
+			w
+				beOk;
+				close ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -650,7 +650,7 @@ CavroisWindowManager >> currentProfile: aProfile [
 	currentProfile := aProfile
 ]
 
-{ #category : 'accessing' }
+{ #category : 'kara te' }
 CavroisWindowManager >> defaultLocation [
 
 	^ defaultLocation

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -650,7 +650,7 @@ CavroisWindowManager >> currentProfile: aProfile [
 	currentProfile := aProfile
 ]
 
-{ #category : 'kara-te' }
+{ #category : 'accessing' }
 CavroisWindowManager >> defaultLocation [
 
 	^ defaultLocation

--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -650,7 +650,7 @@ CavroisWindowManager >> currentProfile: aProfile [
 	currentProfile := aProfile
 ]
 
-{ #category : 'kara te' }
+{ #category : 'kara-te' }
 CavroisWindowManager >> defaultLocation [
 
 	^ defaultLocation


### PR DESCRIPTION
To avoid getting a warning from the rule that looks for spaces in protocol name, I made it impossible by construction trimming the new protocol name. I also added a new test for this behaviour
Thanks to those changes, the rule can be safely removed. ( in Pharo repository, other PR).
Fixes [#19178](https://github.com/pharo-project/pharo/issues/19178)