### PR TITLE
Speed up the Spotter

### DIFF
--- a/src/NewTools-Spotter-Processors/StAbstractStringFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StAbstractStringFilter.class.st
@@ -58,17 +58,13 @@ StAbstractStringFilter >> doReset [
 { #category : 'accessing' }
 StAbstractStringFilter >> filteringText: aString [
 
-	inner := originalUnwrapped select: [ :e | self criterium: e].
+	inner := originalUnwrapped select: [ :e | self criterium: e ].
 
-	(aString asLowercase beginsWith: filteringText asLowercase) 
-		ifFalse: [ 
-			self reset ].
+	(aString beginsWith: filteringText caseSensitive: false) ifFalse: [ self reset ].
 
 	filteringText := aString.
-	results := results select: [ :e | self criterium: e].
-	returnedIndex := 0.
-
-
+	results := results select: [ :e | self criterium: e ].
+	returnedIndex := 0
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Spotter-Processors/StBeginsWithFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StBeginsWithFilter.class.st
@@ -18,7 +18,5 @@ StBeginsWithFilter >> beginsWithFilter: aString [
 { #category : 'protected' }
 StBeginsWithFilter >> criterium: aValue [
 
-	^ aValue asString asLowercase beginsWith: filteringText asLowercase
-
-
+	^ aValue asString beginsWith: filteringText caseSensitive: false
 ]

--- a/src/NewTools-Spotter-Processors/StSourceFactory.class.st
+++ b/src/NewTools-Spotter-Processors/StSourceFactory.class.st
@@ -16,7 +16,7 @@ Class {
 { #category : 'accessing' }
 StSourceFactory class >> current [
 
-	^ Current ifNil: [ self defaultSourceFactory ]
+	^ Current ifNil: [ Current := self defaultSourceFactory ]
 ]
 
 { #category : 'detecting implementations' }

--- a/src/NewTools-Spotter-Processors/StSubStringFilter.class.st
+++ b/src/NewTools-Spotter-Processors/StSubStringFilter.class.st
@@ -12,9 +12,7 @@ Class {
 { #category : 'protected' }
 StSubStringFilter >> criterium: aValue [
 
-	^ aValue asString asLowercase includesSubstring: filteringText asLowercase
-
-
+	^ aValue asString includesSubstring: filteringText caseSensitive: false
 ]
 
 { #category : 'filtering' }

--- a/src/NewTools-Spotter/StEntry.class.st
+++ b/src/NewTools-Spotter/StEntry.class.st
@@ -125,13 +125,6 @@ StEntry >> iconOn: anIconProvider [
 	^ anIconProvider iconNamed: self iconName
 ]
 
-{ #category : 'initialization' }
-StEntry >> initialize [
-
-	self class initializeSlots: self.
-	super initialize
-]
-
 { #category : 'accessing' }
 StEntry >> label [
 

--- a/src/NewTools-Spotter/StSpotter.class.st
+++ b/src/NewTools-Spotter/StSpotter.class.st
@@ -774,13 +774,13 @@ StSpotter >> searchText [
 
 { #category : 'private - actions' }
 StSpotter >> searchingString [
+
 	| searchString searchChunks |
-	
-	searchString := searchText text trimmed.
+	searchString := searchText text trimBoth.
 	searchChunks := searchString substrings.
 	^ (searchChunks anySatisfy: [ :each | each first = $# ])
-		ifTrue: [ ' ' join: (searchChunks reject: [ :each | each first = $# ]) ]
-		ifFalse: [ searchString ]
+		  ifTrue: [ ' ' join: (searchChunks reject: [ :each | each first = $# ]) ]
+		  ifFalse: [ searchString ]
 ]
 
 { #category : 'accessing - model' }


### PR DESCRIPTION
I have other ideas to speed up the spotter but here is a first batch.

- Remove StEntry>>#initialize because it does not do anything but it slow down the creation of objects that are instantiated all the time by the Spotter (at least once for each methods, class and package of the system)
- Use #beginsWith:caseSensitive: and #includesSubstring:caseSensitive instead of using #asLowercase everywhere. This is much faster

With those two improvements the tests of spotter went from 17sec to 11sec to run on my machine which is a nice improvement