### PR TITLE
Fix String display in Inspector

### DIFF
--- a/src/NewTools-Inspector-Extensions/ByteString.extension.st
+++ b/src/NewTools-Inspector-Extensions/ByteString.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ByteString' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+ByteString >> stDisplayString [
+
+	^ self printStringLimitedTo: 1000
+]

--- a/src/NewTools-Inspector-Extensions/StringTest.extension.st
+++ b/src/NewTools-Inspector-Extensions/StringTest.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'StringTest' }
+
+{ #category : '*NewTools-Inspector-Extensions' }
+StringTest >> testStDisplayString [
+
+	| largeString expectedPrintSymbol |
+	largeString := String loremIpsum: 1001.
+	expectedPrintSymbol :=  '''' , (largeString truncateTo: 995) , '[..]'.
+
+	self assert: 'test' stDisplayString equals: '''test'''.
+	self assert: largeString stDisplayString equals: expectedPrintSymbol
+]

--- a/src/NewTools-Inspector-Extensions/StringTest.extension.st
+++ b/src/NewTools-Inspector-Extensions/StringTest.extension.st
@@ -3,10 +3,10 @@ Extension { #name : 'StringTest' }
 { #category : '*NewTools-Inspector-Extensions' }
 StringTest >> testStDisplayString [
 
-	| largeString expectedPrintSymbol |
+	| largeString expectedPrintString |
 	largeString := String loremIpsum: 1001.
-	expectedPrintSymbol :=  '''' , (largeString truncateTo: 995) , '[..]'.
+	expectedPrintString :=  '''' , (largeString truncateTo: 995) , '[..]'.
 
 	self assert: 'test' stDisplayString equals: '''test'''.
-	self assert: largeString stDisplayString equals: expectedPrintSymbol
+	self assert: largeString stDisplayString equals: expectedPrintString
 ]


### PR DESCRIPTION
This pull request fix the display of String objects in the Inspector by adding quotes.

Here is an example of an Array inspection: 

<img width="1486" height="525" alt="Example_DisplayString_Inspector" src="https://github.com/user-attachments/assets/dd6d7a2c-d099-4f72-94c2-9784f3be05e9" />
