### PR TITLE
Playground: Add delete page feature

### DIFF
--- a/src/NewTools-Playground/StPlaygroundPage.class.st
+++ b/src/NewTools-Playground/StPlaygroundPage.class.st
@@ -119,6 +119,14 @@ StPlaygroundPage >> defaultObjectInspectorClass [
 	^ StPlaygroundPagePresenter
 ]
 
+{ #category : 'submorphs - add/remove' }
+StPlaygroundPage >> delete [
+	"Delete the corresponding page"
+
+	self fileReference ensureDelete.
+	(self fileReference withExtension: 'ombu') ensureDelete
+]
+
 { #category : 'accessing' }
 StPlaygroundPage >> ensureContentsFlushed [
 

--- a/src/NewTools-Playground/StPlaygroundPageSummaryPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPageSummaryPresenter.class.st
@@ -10,7 +10,9 @@ Class {
 	#classTraits : 'SpTModel classTrait',
 	#instVars : [
 		'firstLineLabel',
-		'timeLabel'
+		'timeLabel',
+		'deleteIcon',
+		'deleteBlock'
 	],
 	#category : 'NewTools-Playground-View',
 	#package : 'NewTools-Playground',
@@ -27,13 +29,26 @@ StPlaygroundPageSummaryPresenter >> contents [
 StPlaygroundPageSummaryPresenter >> initializePresenters [
 
 	layout := SpBoxLayout newTopToBottom
-		borderWidth: 1;
-		spacing: 2;
-		add: (firstLineLabel := self newLabel) expand: false;
-		add: (timeLabel := self newLabel) expand: false;
-		yourself.
+		          borderWidth: 1;
+		          spacing: 2;
+		          add: (firstLineLabel := self newLabel) expand: false;
+		          add: (SpBoxLayout newLeftToRight
+				           spacing: 5;
+				           borderWidth: 1;
+				           add: (timeLabel := self newLabel);
+				           add: (deleteIcon := self newButton) width: 25;
+				           yourself)
+		          expand: false;
+		          yourself.
 
-	timeLabel addStyle: 'dim'
+	timeLabel addStyle: 'dim'.
+
+	deleteIcon
+		icon: (self iconNamed: #remove);
+		help: 'This action will remove the page from the playground and remove the persisted page.';
+		action: [
+				self model delete.
+				deleteBlock ifNotNil: [ deleteBlock value ] ]
 ]
 
 { #category : 'accessing' }
@@ -54,4 +69,10 @@ StPlaygroundPageSummaryPresenter >> updatePresenter [
 	self model ifNil: [ ^ self ].
 	firstLineLabel label: self pageTitle.
 	timeLabel label: self model modificationTime epiceaBrowsersAsString
+]
+
+{ #category : 'events' }
+StPlaygroundPageSummaryPresenter >> whenDeleteButtonPressed: aBlock [
+
+	deleteBlock := aBlock
 ]

--- a/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
+++ b/src/NewTools-Playground/StPlaygroundPagesPresenter.class.st
@@ -174,10 +174,15 @@ StPlaygroundPagesPresenter >> pagesActions [
 { #category : 'initialization' }
 StPlaygroundPagesPresenter >> pagesAsPresenters [
 
-	^ self pages collect: [ :each | 
-		self 
-			instantiate: StPlaygroundPageSummaryPresenter
-			on: each  ]
+	^ self pages collect: [ :each |
+			  (self instantiate: StPlaygroundPageSummaryPresenter on: each)
+				  whenDeleteButtonPressed: [
+						  | oldIndex |
+						"Refresh the list but keep the selected index to not jump in the list."
+						  oldIndex := pageList selectedIndex. 
+						  pageList presenters: self pagesAsPresenters.
+						  pageList selectIndex: oldIndex ];
+				  yourself ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
This change adds a remove page icon. When we share the play-cache between multiple images it's common to have pages we do not want to keep. Instead of going to the folder to remove the files I propose to have an icon to do it from the playground directly

<img width="994" height="776" alt="image" src="https://github.com/user-attachments/assets/832291f7-df3a-44c6-b98c-4c1df250cd0e" />

@estebanlm What do you think?