### PR TITLE
Several fixes for Pharo14

### DIFF
--- a/src/NewTools-Debugger-Extensions/Exception.extension.st
+++ b/src/NewTools-Debugger-Extensions/Exception.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'Exception' }
 
 { #category : '*NewTools-Debugger-Extensions' }
-Exception >> signalContext [
-
-	^ signalContext
-]
-
-{ #category : '*NewTools-Debugger-Extensions' }
 Exception >> stDebuggerInspectorNodesFor: aStDebuggerContext [
 
 	^ aStDebuggerContext exceptionNodesFor: self

--- a/src/NewTools-Debugger-Tests/StDebuggerObjectForTests.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerObjectForTests.class.st
@@ -36,6 +36,9 @@ StDebuggerObjectForTests >> methodWithArg1: i arg2: j [
 
 { #category : 'utilities' }
 StDebuggerObjectForTests >> methodWithArgsInBlock [
+
+	<compilerOptions: #(- optionCleanBlockClosure)>
+
 	^[ :a :b| a + b ] value: 4 value: 2
 ]
 

--- a/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StVersionBrowserPresenter.class.st
@@ -91,7 +91,7 @@ StVersionBrowserPresenter >> buildChangeList [
 
 	rgMethod sourcePointer ifNil: [ ^ #(  ) ].
 
-	^ (SourceFileArray default changeRecordsFor: rgMethod) collectWithIndex: [ :c :i |
+	^ (SourcesManager current changeRecordsFor: rgMethod) collectWithIndex: [ :c :i |
 			  | rg |
 			  rg := c asRingDefinition.
 			  rg annotationNamed: #versionIndex put: i ]


### PR DESCRIPTION
- Fix test depending on non clean blocks (remove compiler optimization breaking tests for now)
- Apply rename `SourceFileArray`->`SourcesManager`
- Move accessor extension method `signalContext` to the actual class