### PR TITLE
Cavrois fix for UI process order

### DIFF
--- a/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
+++ b/src/NewTools-Window-Profiles/CavroisWindowManager.class.st
@@ -728,36 +728,28 @@ CavroisWindowManager >> initializeBlocks [
 			self cellSize ifNotNil: [ :size |
 					self resetCells.
 					self createPlaceHolderGrid: size ].
-			self applyWorldResize ].
+			UIManager default defer: [ self applyWorldResize ] ].
 
 	WorldMorph dragActionBlock: [ :aClient |
-			((aClient isKindOf: SystemWindow) or:
-				 (aClient isKindOf: SpWindowMorph)) ifTrue: [
+			((aClient isKindOf: SystemWindow) or: (aClient isKindOf: SpWindowMorph)) ifTrue: [
 					self cellSize ifNotNil: [
 							| dragProcess |
 							self cellDisplay.
 							dragProcess := [
 								               [ aClient owner notNil ] whileTrue: [
-										               self
-											               handleWindowDrag: aClient
-											               at: aClient position.
-										               (Delay forMilliseconds: 2) wait ] ] forkAt:
-								               Processor userBackgroundPriority.
+										               self handleWindowDrag: aClient at: aClient position.
+										               (Delay forMilliseconds: 2) wait ] ] forkAt: Processor userBackgroundPriority.
 							aClient setProperty: #cavroisDragProcess toValue: dragProcess ] ] ].
 
 	WorldMorph dropActionBlock: [ :anEvent |
 			| dragProcess |
-			dragProcess := anEvent contents
-				               valueOfProperty: #cavroisDragProcess
-				               ifAbsent: nil.
+			dragProcess := anEvent contents valueOfProperty: #cavroisDragProcess ifAbsent: nil.
 			dragProcess ifNotNil: [
 					dragProcess terminate.
 					anEvent contents removeProperty: #cavroisDragProcess ].
 			self cellSize ifNotNil: [
 					self removeVisualPlaceholders.
-					self
-						handleCellWindowDrop: anEvent contents
-						at: anEvent contents position ] ]
+					self handleCellWindowDrop: anEvent contents at: anEvent contents position ] ]
 ]
 
 { #category : 'internals' }


### PR DESCRIPTION
I did an investigation and the `applyWorldResize` was looking at existing windows without waiting the UI process execution, meaning it was looking for iceberg windows (if present in a profile) despite Iceberg not being initialized. It could also break other thing, having race conditions or any other thing, so I fixed it using the UIManager defer: .

Fixes[ #19149](https://github.com/issues/assigned?issue=pharo-project%7Cpharo%7C19149)