### PR TITLE
Make debugger tests more resilient

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -134,7 +134,6 @@ StDebuggerTest >> tearDown [
 		classified: 'util'.
 
 	StDebuggerClientModel shouldFilterStack: shouldFilterStack.
-	StTestDebuggerProvider removeSelector: #foobar.
 	oldMethodToSourceDictionary	associationsDo: [ :assoc |
 		assoc key methodClass
 			compile: assoc value
@@ -504,7 +503,7 @@ StDebuggerTest >> testCopyStackToClipboard [
 { #category : 'tests' }
 StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
 
-	| dnuMessage method pcRangeForContext segments highlightSegment adapter |
+	| dnuMessage method pcRangeForContext segments highlightSegment adapter exception |
 	StDebuggerClientModel shouldFilterStack: false.
 	debugger := StTestDebuggerProvider new debuggerWithDNUContext.
 	debugger
@@ -516,16 +515,17 @@ StDebuggerTest >> testCreateMissingMethodWithUnfilteredStackUpdatesCodePane [
 	debugger code adapter buildWidget.
 	self assert:
 		debugger debuggerClientModel isInterruptedContextDoesNotUnderstand.
+	
+	exception := debugger debuggerClientModel contextPredicate exception.
 	self
-		assert: debugger interruptedContext receiver class
+		assert: exception receiver class
 		identicalTo: StTestDebuggerProvider.
-	dnuMessage := debugger debuggerClientModel contextPredicate exception
-		              message.
+	dnuMessage := exception message.
 
 	self assert: dnuMessage selector identicalTo: #foobar.
 
 	"stack is unfiltered. So the text shown should be the code from the DNU"
-	self assert: (debugger code text beginsWith: 'doesNotUnderstand:').
+	self assert: debugger code text equals: exception signalerContext method sourceCode.
 
 	"we create the missing method #foobar"
 	debugger implementMissingMethod.

--- a/src/NewTools-Debugger/StDebugger.class.st
+++ b/src/NewTools-Debugger/StDebugger.class.st
@@ -791,9 +791,7 @@ StDebugger >> forceSessionUpdate [
 StDebugger >> implementMissingMethod [
 
 	self debuggerClientModel implementMissingMethod.
-	self selectTopContext.
-	self flag: 'why do we need to give code the keyboard focus?'
-	"code takeKeyboardFocus"
+	self selectTopContext
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
+++ b/src/NewTools-Debugger/StDebuggerErrorContextPredicate.class.st
@@ -46,12 +46,10 @@ StDebuggerErrorContextPredicate >> exceptionWhiteList [
 { #category : 'predicates' }
 StDebuggerErrorContextPredicate >> isContextDoesNotUnderstand [
 
-	^ exception class = MessageNotUnderstood and: [ 
-		  | message |
-		  message := exception message.
-		  
-			  (exception receiver respondsTo: message selector) not and: [ 
-				  exception signalerContext method methodClass == Object ] ]
+	^ exception class = MessageNotUnderstood and: [
+			  | message |
+			  message := exception message.
+			  (exception receiver respondsTo: message selector) not ]
 ]
 
 { #category : 'predicates' }

--- a/src/NewTools-Debugger/StDebuggerMethodImplementor.class.st
+++ b/src/NewTools-Debugger/StDebuggerMethodImplementor.class.st
@@ -42,7 +42,7 @@ StDebuggerMethodImplementor >> implementMissingMethod [
 	context := self targetContext.
 	method := session
 		          implement: (self exception messageToImplementInContext: context)
-		          inClass: (targetClassOrTrait ifNil: [context receiver class])
+		          inClass: (targetClassOrTrait ifNil: [self exception receiver class])
 		          forContext: context.
 	protocol ifNotNil: [ method protocol: protocol ].
 	^ method


### PR DESCRIPTION
Do not depend on strings, or DNU defined in Object, nor on the exact number of contexts in the stack.

This is a slight simplification required for https://github.com/pharo-project/pharo/pull/19352