### PR TITLE
Make debugger tests more robust

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerClientModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerClientModelTest.class.st
@@ -611,7 +611,7 @@ StDebuggerClientModelTest >> testFileOutMethod [
 { #category : 'tests - stack filtering' }
 StDebuggerClientModelTest >> testFilterDNUStack [
 
-	|stack filteredStack dummyActionModel|
+	|stack filteredStack dummyActionModel dnuContext dnuStack |
 	dummyActionModel := StTestDebuggerProvider new debuggerWithDNUContext debuggerClientModel.
 	self changeSession: dummyActionModel session.
 	dummyActionModel clear.
@@ -620,18 +620,22 @@ StDebuggerClientModelTest >> testFilterDNUStack [
 	"First, the stack contains a top context (i.e. from which a signal was sent), then the interrupted context"
 	stack add: debugActionModel topContext.
 	
-	"Second, the stack contexts is a MNU that has a method with the <debuggerCompleteToSender> pragma"
-	stack add: debugActionModel interruptedContext.	
+	"Second, the stack contexts are all contexts existing from a DNU send, that  should be marked with the <debuggerCompleteToSender> pragma, up to the signal of the MNU exception.
+	
+	The code below builds this *substack* in a robust way that is independent of the number of contexts"
+	dnuContext := debugActionModel interruptedContext findContextSuchThat: [ :c | c method selector = #doesNotUnderstand: ].
+	dnuStack := debugActionModel interruptedContext copyTo: dnuContext sender.
+	dnuStack stack do: [ :e | stack add: e ].
 	
 	"Then we have an imaginary call stack"
 	stack add: (self emptyContextForMethod: (self class>>#method1:)).
 	stack add: (self emptyContextForMethod: (self class>>#method2:)).
 	
 	filteredStack := debugActionModel filterStack: stack copy.
-	
+
 	self assert: filteredStack size equals: 2.
-	self assert: filteredStack first identicalTo: stack third.
-	self assert: filteredStack second identicalTo: stack fourth
+	self assert: filteredStack first identicalTo: (stack last: 2) first.
+	self assert: filteredStack second identicalTo: stack last
 	
 ]
 
@@ -660,14 +664,18 @@ StDebuggerClientModelTest >> testFilterMissingSubclassResponsibilityStack [
 { #category : 'tests - stack filtering' }
 StDebuggerClientModelTest >> testFilterStack [
 
-	|stack filteredStack dummyActionModel|
+	|stack filteredStack dummyActionModel dnuContext dnuStack |
 	dummyActionModel := StTestDebuggerProvider new debuggerWithDNUContext debuggerClientModel.
 	self changeSession: dummyActionModel session.
 	dummyActionModel clear.
 	stack := OrderedCollection new.
 	
-	"First, add to the stack a MNU context that has a method with the <debuggerCompleteToSender> pragma"
-	stack add: debugActionModel interruptedContext.	
+	"Second, the stack contexts are all contexts existing from a DNU send, that  should be marked with the <debuggerCompleteToSender> pragma, up to the signal of the MNU exception.
+	
+	The code below builds this *substack* in a robust way that is independent of the number of contexts"
+	dnuContext := debugActionModel interruptedContext findContextSuchThat: [ :c | c method selector = #doesNotUnderstand: ].
+	dnuStack := debugActionModel interruptedContext copyTo: dnuContext sender.
+	dnuStack stack do: [ :e | stack add: e ].
 	
 	"Then we have an imaginary call stack"
 	stack add: (self emptyContextForMethod: (self class>>#method1:)).
@@ -681,8 +689,8 @@ StDebuggerClientModelTest >> testFilterStack [
 	StDebuggerClientModel shouldFilterStack: true.
 	filteredStack := debugActionModel filterStack: stack copy.
 	self assert: filteredStack size equals: 2.
-	self assert: filteredStack first identicalTo: stack second.
-	self assert: filteredStack second identicalTo: stack third
+	self assert: filteredStack first identicalTo: (stack last: 2) first.
+	self assert: filteredStack second identicalTo: stack last
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
The stack contexts are all contexts existing from a DNU send, that  should be marked with the <debuggerCompleteToSender> pragma, up to the signal of the MNU exception. The change builds this *substack* in a robust way that is independent of the number of contexts