### PR TITLE
add package 'NewTools-Sindarin-Scripts' to baseline group 'Debugger'

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -107,7 +107,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Sindarin-Commands';
 			package: 'NewTools-Sindarin-Commands-Tests' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
 			package: 'NewTools-Sindarin-Tools' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
-			package: 'NewTools-Sindarin-Scripts' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
+			package: 'NewTools-Sindarin-Scripts' with: [ spec requires: #( 'NewTools-Sindarin-Tools') ];
 	
 			"package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];""Debugger Selector"
 			package: 'NewTools-DebuggerSelector' with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -198,6 +198,7 @@ BaselineOfNewTools >> baseline: spec [
 
 						'NewTools-Debugger-Morphic'
 				    	'NewTools-Sindarin-Tools' 
+						'NewTools-Sindarin-Scripts'
 
 					 	'NewTools-Sindarin-Commands'
 				    	'NewTools-Sindarin-Commands-Tests'

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -107,7 +107,6 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Sindarin-Commands';
 			package: 'NewTools-Sindarin-Commands-Tests' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
 			package: 'NewTools-Sindarin-Tools' with: [ spec requires: #( 'NewTools-Sindarin-Commands' 'Sindarin' ) ];
-			package: 'NewTools-Sindarin-Scripts' with: [ spec requires: #( 'NewTools-Sindarin-Tools') ];
 	
 			"package: 'NewTools-Sindarin-ProcessInspector' with: [ spec requires: #('NewTools-Sindarin-Commands' 'Sindarin') ];""Debugger Selector"
 			package: 'NewTools-DebuggerSelector' with: [ spec requires: #( 'NewTools-SpTextPresenterDecorators' ) ];
@@ -197,8 +196,7 @@ BaselineOfNewTools >> baseline: spec [
 					 	'NewTools-Debugger'
 
 						'NewTools-Debugger-Morphic'
-				    	'NewTools-Sindarin-Tools' 
-						'NewTools-Sindarin-Scripts'
+				    	'NewTools-Sindarin-Tools'
 
 					 	'NewTools-Sindarin-Commands'
 				    	'NewTools-Sindarin-Commands-Tests'

--- a/src/NewTools-Sindarin-Scripts/package.st
+++ b/src/NewTools-Sindarin-Scripts/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'NewTools-Sindarin-Scripts' }

--- a/src/NewTools-Sindarin-Tools/SindarinDefaultScriptRepository.class.st
+++ b/src/NewTools-Sindarin-Tools/SindarinDefaultScriptRepository.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SindarinDefaultScriptRepository',
-	#superclass : 'StSindarinDebuggerScriptRepository',
-	#category : 'NewTools-Sindarin-Scripts',
-	#package : 'NewTools-Sindarin-Scripts'
+	#superclass : 'StSindarinDebuggerScriptRepositoryAbstract',
+	#category : 'NewTools-Sindarin-Tools-Scripts',
+	#package : 'NewTools-Sindarin-Tools',
+	#tag : 'Scripts'
 }
 
 { #category : 'accessing' }

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerCommandPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerCommandPresenter.class.st
@@ -94,6 +94,7 @@ StSindarinDebuggerCommandPresenter >> generateCommand [
 
 	class := (SindarinCommand << className)
 		         package: package;
+					tag: 'Scripts';
 		         build;
 		         install.
 
@@ -101,7 +102,7 @@ StSindarinDebuggerCommandPresenter >> generateCommand [
 		compile: ('execute
 	|sindarin|
 	sindarin := self context sindarinDebugger.
-	self context debuggerActionModel preventUpdatesDuring: [
+	self context debuggerClientModel preventUpdatesDuring: [
 		{1}
 	]' format: { code })
 		classified: 'executing'.

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryAbstract.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryAbstract.class.st
@@ -10,7 +10,7 @@ Subclasses are expected to implement the class side `repositoryName` method, whi
 
 "
 Class {
-	#name : 'StSindarinDebuggerScriptRepository',
+	#name : 'StSindarinDebuggerScriptRepositoryAbstract',
 	#superclass : 'Object',
 	#classInstVars : [
 		'scripts'
@@ -21,35 +21,35 @@ Class {
 }
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> clearScripts [
+StSindarinDebuggerScriptRepositoryAbstract class >> clearScripts [
 	<script>
 	scripts := Dictionary new.
 ]
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> loadScript: aString [
+StSindarinDebuggerScriptRepositoryAbstract class >> loadScript: aString [
 	^ self scripts at: aString ifAbsent: nil.
 	
 ]
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> repositoryName [
+StSindarinDebuggerScriptRepositoryAbstract class >> repositoryName [
 	"Return the name of the repository."
 	self subclassResponsibility
 ]
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> saveScript: aStringKey code: aStringValue [
+StSindarinDebuggerScriptRepositoryAbstract class >> saveScript: aStringKey code: aStringValue [
 	
 	self scripts add: aStringKey -> aStringValue.
 ]
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> scripts [
+StSindarinDebuggerScriptRepositoryAbstract class >> scripts [
 	^ scripts ifNil: [ scripts := Dictionary new]
 ]
 
 { #category : 'accessing' }
-StSindarinDebuggerScriptRepository class >> scriptsNames [
+StSindarinDebuggerScriptRepositoryAbstract class >> scriptsNames [
    ^ self scripts keys
 ]

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryChooserPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryChooserPresenter.class.st
@@ -15,7 +15,7 @@ StSindarinDebuggerScriptRepositoryChooserPresenter >> display [
 { #category : 'initialization' }
 StSindarinDebuggerScriptRepositoryChooserPresenter >> findRepositories [
 
-	self items: StSindarinDebuggerScriptRepository subclasses
+	self items: StSindarinDebuggerScriptRepositoryAbstract subclasses
 ]
 
 { #category : 'actions' }

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryTest.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptRepositoryTest.class.st
@@ -10,7 +10,7 @@ Class {
 StSindarinDebuggerScriptRepositoryTest >> setUp [
 	super setUp.
 	
-	StSindarinDebuggerScriptRepository clearScripts.
+	StSindarinDebuggerScriptRepositoryAbstract clearScripts.
 ]
 
 { #category : 'tests' }
@@ -23,14 +23,14 @@ StSindarinDebuggerScriptRepositoryTest >> testAddMultipleScriptsStoresEachCorrec
 	name2 := '02'.
 	code2 := '"code02'.
 	
-	StSindarinDebuggerScriptRepository saveScript: name1 code: code1.
-	StSindarinDebuggerScriptRepository saveScript: name2 code: code2.
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: name1 code: code1.
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: name2 code: code2.
 	
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: name1 ).
-	self assert: (StSindarinDebuggerScriptRepository loadScript: name1 ) identicalTo: code1 .
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: name1 ).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract loadScript: name1 ) identicalTo: code1 .
 	
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: name2 ).
-	self assert: (StSindarinDebuggerScriptRepository loadScript: name2 ) identicalTo: code2 .
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: name2 ).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract loadScript: name2 ) identicalTo: code2 .
 
 ]
 
@@ -43,10 +43,10 @@ StSindarinDebuggerScriptRepositoryTest >> testAddScriptStoresCodeCorrectly [
 	scriptName := 'Script01'.
 	script := '"code de script"'.
 	
-	StSindarinDebuggerScriptRepository saveScript: scriptName code: script .
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: scriptName code: script .
 	
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName).
-	self assert: (StSindarinDebuggerScriptRepository loadScript: scriptName ) identicalTo: script .
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract loadScript: scriptName ) identicalTo: script .
 ]
 
 { #category : 'tests' }
@@ -59,16 +59,16 @@ StSindarinDebuggerScriptRepositoryTest >> testClearScriptsEmptiesDictionary [
 	scriptName2 := '02'.
 	script := '"code"'.
 	
-	StSindarinDebuggerScriptRepository saveScript: scriptName1 code: script.
-	StSindarinDebuggerScriptRepository saveScript: scriptName2 code: script.
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: scriptName1 code: script.
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: scriptName2 code: script.
 	
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName1).
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName2).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName1).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName2).
 	
-	StSindarinDebuggerScriptRepository clearScripts.
+	StSindarinDebuggerScriptRepositoryAbstract clearScripts.
 	
-	self deny: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName1).
-	self deny: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName2).
+	self deny: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName1).
+	self deny: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName2).
 ]
 
 { #category : 'tests' }
@@ -79,8 +79,8 @@ StSindarinDebuggerScriptRepositoryTest >> testLookupNonexistentScriptReturnsNil 
 	
 	notExistingScriptName := 'Script404'.
 	
-	self deny: (StSindarinDebuggerScriptRepository scriptsNames includes: notExistingScriptName).
-	self assert: ((StSindarinDebuggerScriptRepository loadScript: notExistingScriptName) isNil).
+	self deny: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: notExistingScriptName).
+	self assert: ((StSindarinDebuggerScriptRepositoryAbstract loadScript: notExistingScriptName) isNil).
 ]
 
 { #category : 'tests' }
@@ -92,13 +92,13 @@ StSindarinDebuggerScriptRepositoryTest >> testOverwriteScriptReplacesCode [
 	oldScript := '"ancien code de script"'.
 	newScript := '"nouveau code de script"'.
 	
-	StSindarinDebuggerScriptRepository saveScript: scriptName code: oldScript .
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName).
-	self assert: (StSindarinDebuggerScriptRepository loadScript: scriptName ) identicalTo: oldScript .
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: scriptName code: oldScript .
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract loadScript: scriptName ) identicalTo: oldScript .
 	
-	StSindarinDebuggerScriptRepository saveScript: scriptName code: newScript .
-	self assert: (StSindarinDebuggerScriptRepository scriptsNames includes: scriptName).
-	self assert: (StSindarinDebuggerScriptRepository loadScript: scriptName ) identicalTo: newScript .
+	StSindarinDebuggerScriptRepositoryAbstract saveScript: scriptName code: newScript .
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract scriptsNames includes: scriptName).
+	self assert: (StSindarinDebuggerScriptRepositoryAbstract loadScript: scriptName ) identicalTo: newScript .
 
 ]
 
@@ -106,5 +106,5 @@ StSindarinDebuggerScriptRepositoryTest >> testOverwriteScriptReplacesCode [
 StSindarinDebuggerScriptRepositoryTest >> testScriptsDictionaryIsInitialized [
 	"We assume that the setup clears the scripts dictionary"
 	
-	self deny: (StSindarinDebuggerScriptRepository scripts isNil).
+	self deny: (StSindarinDebuggerScriptRepositoryAbstract scripts isNil).
 ]

--- a/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
+++ b/src/NewTools-Sindarin-Tools/StSindarinDebuggerScriptingPresenter.class.st
@@ -79,7 +79,8 @@ StSindarinDebuggerScriptingPresenter >> defaultLayout [
 
 { #category : 'accessing' }
 StSindarinDebuggerScriptingPresenter >> defaultScriptRepository [
-	^ StSindarinDebuggerScriptRepository
+
+	^ SindarinDefaultScriptRepository
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
This pr fix the debugger 'Scripts' extension that was failing when trying to open 