### PR TITLE
New scope tests based on introduced matching package scope

### DIFF
--- a/src/NewTools-Scopes-Tests/ScopesManagerTest.class.st
+++ b/src/NewTools-Scopes-Tests/ScopesManagerTest.class.st
@@ -135,6 +135,36 @@ ScopesManagerTest >> testEditClassScopeRemovingClassAndBreakingFullPackage [
 ]
 
 { #category : 'tests' }
+ScopesManagerTest >> testMatchingPackageScopeEquality [
+
+	| scope1 scope2 scope3 pkgA pkgB |
+	pkgA := RBPackage named: 'Kernel-Core'.
+	pkgB := RBPackage named: 'Collections-Core'. 
+	scope1 := ClyMatchingPackageScope ofAll: { pkgA } in: nil withName: 'Kernel-'.
+	scope2 := ClyMatchingPackageScope ofAll: { pkgA } in: nil withName: 'Kernel-'.
+
+	self assert: scope1 = scope2.
+	scope3 := ClyMatchingPackageScope ofAll: { pkgA } in: nil withName: 'Kernel-Core-'.
+	self deny: scope1 = scope3. 
+	scope3 := ClyMatchingPackageScope ofAll: { pkgB } in: nil withName: 'Collections-'.
+	self deny: scope1 = scope3
+]
+
+{ #category : 'tests' }
+ScopesManagerTest >> testMatchingPackageScopeHash [
+
+	| scope1 scope2 scope3 pkgA pkgB |
+	pkgA := RBPackage named: 'Kernel-Core'.
+	pkgB := RBPackage named: 'Collections-Core'.
+
+	scope1 := ClyMatchingPackageScope ofAll: { pkgA } in: nil withName: 'Kernel-'.
+	scope2 := ClyMatchingPackageScope ofAll: { pkgA } in: nil withName: 'Kernel-'.
+	scope3 := ClyMatchingPackageScope ofAll: { pkgB } in: nil withName: 'Collections-'.
+	self assert: scope1 hash equals: scope2 hash.
+	self deny: scope1 hash equals: scope3 hash
+]
+
+{ #category : 'tests' }
 ScopesManagerTest >> testNewScopeFromAPackageWithExtendedClasses [
 	| packages scope |
 	packages := { ScClassC package } asSet.
@@ -199,4 +229,25 @@ ScopesManagerTest >> testNewScopeFromASinglePackageAndSomeOfItsClasses [
 	self assert: scope packages asSet equals: packages.
 	self assert: scope definedClasses equals: ScClassA1 package definedClasses.
 	self assert: scope orphanClasses asSet equals: Set new
+]
+
+{ #category : 'tests' }
+ScopesManagerTest >> testSplitOnMatchingScopesFiltersByPrefix [
+
+	| packages scope splitScopes collected |
+	packages := OrderedCollection new.
+	packages add: (RBPackage named: 'Kernel-ExtraUtils').
+	packages add: (RBPackage named: 'Kernel-Tests').
+	packages add: (RBPackage named: 'Collections-Strings').
+
+	scope := ClyMatchingPackageScope ofAll: packages in: nil withName: ''.
+	splitScopes := scope splitOnMatchingScopes.
+
+	collected := OrderedCollection new.
+	splitScopes do: [ :s | s packagesDo: [ :p | collected add: p name ] ].
+	
+	self assert: splitScopes size equals: 2.
+	self assert: (collected includes: 'Kernel-ExtraUtils').
+	self assert: (collected includes: 'Kernel-Tests').
+	self assert: (collected includes: 'Collections-Strings')
 ]

--- a/src/NewTools-Scopes-Tests/ScopesManagerTest.class.st
+++ b/src/NewTools-Scopes-Tests/ScopesManagerTest.class.st
@@ -238,7 +238,7 @@ ScopesManagerTest >> testSplitOnMatchingScopesFiltersByPrefix [
 	packages := OrderedCollection new.
 	packages add: (RBPackage named: 'Kernel-ExtraUtils').
 	packages add: (RBPackage named: 'Kernel-Tests').
-	packages add: (RBPackage named: 'Collections-Strings').
+	packages add: (RBPackage named: 'Collections-Strings'). 
 
 	scope := ClyMatchingPackageScope ofAll: packages in: nil withName: ''.
 	splitScopes := scope splitOnMatchingScopes.


### PR DESCRIPTION
These tests validate 3 behaviours: filtering based on prefix, `=`, and `hash` which are reimplemented on this new package. (The PR for this new scope is https://github.com/pharo-project/pharo/pull/19394)