### PR TITLE
`StMethodBrowser` API improvement

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -128,6 +128,15 @@ StMethodBrowser class >> browseSendersOf: aSymbol [
 	^ self browse: (self sendersOf: aSymbol) asSendersOf: aSymbol
 ]
 
+{ #category : 'opening' }
+StMethodBrowser class >> browseSendersOfAll: aCollectionOfSymbols [
+
+	| methods |
+	methods := aCollectionOfSymbols flatCollect: [ :sym | self sendersOf: sym ].
+
+	^ self browse: methods asArray
+]
+
 { #category : 'private' }
 StMethodBrowser class >> implementorsOf: aSymbol [
 	"Do not use aSymbol implementors because it is a disguised global"

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -101,6 +101,14 @@ StMethodBrowser class >> browseImplementorsOf: aSymbol [
 ]
 
 { #category : 'opening' }
+StMethodBrowser class >> browseImplementorsOfAll: aCollectionOfSymbols [
+
+	| methods |
+	methods := aCollectionOfSymbols flatCollect: [ :sym | self implementorsOf: sym ].
+	^ self browse: methods asArray
+]
+
+{ #category : 'opening' }
 StMethodBrowser class >> browseReferencesOf: aClassName [
 	"Special version that sets the correct refreshing block for senders"
 


### PR DESCRIPTION
I added messages to be able to handle a collection of symbols,as we plan to replace the old browsers by this one.
Changes linked to Calypso will be done in an other PR in pharo repository.
@Ducasse :)