### PR TITLE
Add name to recovered changes window (Epicea)

### DIFF
--- a/src/NewTools-Epicea/EpLogBrowserPresenter.class.st
+++ b/src/NewTools-Epicea/EpLogBrowserPresenter.class.st
@@ -1,5 +1,7 @@
 "
-I am a Spec browser for an EpLog.
+I am a Spec browser for an EpLog. 
+
+I am used to recovered code not saved after an image crash. 
 
 For example, open with:
 
@@ -576,6 +578,14 @@ EpLogBrowserPresenter >> initializeSearchPresenters [
 		                   placeholder: 'Filter...';
 		                   whenTextChangedDo: [ :text | self searchList: text ];
 		                   yourself
+]
+
+{ #category : 'initialization' }
+EpLogBrowserPresenter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+
+	aWindowPresenter title: 'Epicea - Recovered changes'
 ]
 
 { #category : 'menu - operations' }


### PR DESCRIPTION
Add a windowName and a little description to `EpLogBrowserPresenter` (recovered changes window) in Epicea. 
Working with @FlavienVolant 

closes https://github.com/pharo-project/pharo/issues/19424