### PR TITLE
Fix method browser refreshing block for class refs

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -578,6 +578,12 @@ StMethodBrowser >> packageNameForItem: anItem [
 ]
 
 { #category : 'api' }
+StMethodBrowser >> refreshingBlock [
+
+	^ refreshingBlock
+]
+
+{ #category : 'api' }
 StMethodBrowser >> refreshingBlock: aBlock [
 	refreshingBlock := aBlock
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -664,9 +664,8 @@ StMethodBrowser >> selectedMethod [
 
 { #category : 'api' }
 StMethodBrowser >> setRefreshingBlockForClassReferencesOf: aString [
-	
-	self refreshingBlock: [ :method | 
-		method accessesRef: (self class environment at: aString asSymbol) ]
+
+	self refreshingBlock: [ :method | method hasLiteral: aString ]
 ]
 
 { #category : 'api' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -29,7 +29,7 @@ StMethodBrowserTest >> testBrowseClassNameAsLiteral [
 	[
 		window := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
 
-		self assert: window presenter methods size equals: 3 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: window presenter methods size equals: 4 ] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -115,3 +115,14 @@ StMethodBrowserTest >> testOpenWithoutMessageShouldNotDNU [
 	self shouldnt: [ br open ] raise: MessageNotUnderstood.
 		] ensure: [ br window close ]
 ]
+
+{ #category : 'tests' }
+StMethodBrowserTest >> testRefreshingBlockWithLiteralString [
+
+	| window browser methodToAdd |
+	[
+		window := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
+		browser := window presenter.
+		methodToAdd := (self class >> #dataMethodForTest) copy.
+		self assert: (browser refreshingBlock value: methodToAdd) ] ensure: [ window ifNotNil: [ window delete ] ]
+]


### PR DESCRIPTION
`hasLiteral:` looks for `GlobalVariable` and the method was given a symbol as argument. 
Fixes https://github.com/pharo-project/pharo/issues/19477