### PR TITLE
Adding-test-for-inspecting-outer-variable-in-clean-block

### DIFF
--- a/src/NewTools-Debugger-Tests/StClassUsingCleanBlockForTest.class.st
+++ b/src/NewTools-Debugger-Tests/StClassUsingCleanBlockForTest.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'StClassUsingCleanBlockForTest',
+	#superclass : 'Object',
+	#instVars : [
+		'myVar'
+	],
+	#category : 'NewTools-Debugger-Tests-Utils',
+	#package : 'NewTools-Debugger-Tests',
+	#tag : 'Utils'
+}
+
+{ #category : 'initialization' }
+StClassUsingCleanBlockForTest >> boom [
+
+	| r |
+
+	r := myVar yourself.
+
+	^ self in: [ :e | 
+		1 + 1 ].
+	
+]
+
+{ #category : 'initialization' }
+StClassUsingCleanBlockForTest >> initialize [ 
+	
+	super initialize.
+	myVar := Object new.
+]

--- a/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerTest.class.st
@@ -874,6 +874,39 @@ StDebuggerTest >> testPrintReceiverClassInContext [
 	self assert: stream contents equals: 'Set'.
 ]
 
+{ #category : 'tests - context inspector' }
+StDebuggerTest >> testPrintingOutsideVariableInCleanBlockShouldGiveAnError [
+
+	| mySession searchedMethod ctx myProcess codePresenter varStart varSize errorDetected |
+	
+	searchedMethod := ((StClassUsingCleanBlockForTest >> #boom) literalAt: 2) method.
+	errorDetected := false.
+
+	ctx := [ StClassUsingCleanBlockForTest new boom ] asContext.
+	[ ctx method = searchedMethod ] whileFalse: [ctx := ctx step ].
+
+	myProcess := Process forContext: ctx priority: 40.
+	
+	mySession := DebugSession named: 'MySession' on: myProcess startedAt: ctx.
+	mySession exception: (OupsNullException fromSignallerContext: ctx).
+	
+	debugger := self debuggerOn: mySession.
+	codePresenter := debugger code.
+	
+	varStart := codePresenter text indexOfSubCollection: 'myVar'.
+	varSize := 'myVar' size.
+	codePresenter selectionInterval: (varStart to: varStart + varSize).
+	
+	codePresenter interactionModel beNonInteractive.
+	codePresenter announcer when: SpCodeEvaluationFailedAnnouncement do: [ errorDetected:= true ] for: nil.
+	
+	"We simulate the inspect of a variable that is outside the block. Check the method StClassUsingCleanBlockForTest >> #boom "
+	(SpCodeInspectItCommand forSpecContext: codePresenter) execute.
+	
+	self assert: errorDetected
+
+]
+
 { #category : 'tests - receiver inspector' }
 StDebuggerTest >> testReceiverChangedAfterStepIn [ 
 

--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'StDebuggerContextInteractionModel',
 	#superclass : 'SpContextInteractionModel',
 	#instVars : [
-		'bindings'
+		'bindings',
+		'interactive'
 	],
 	#category : 'NewTools-Debugger-Model',
 	#package : 'NewTools-Debugger',
@@ -22,6 +23,12 @@ StDebuggerContextInteractionModel >> addBinding: aBinding [
 	self bindings add: aBinding 
 ]
 
+{ #category : 'accessing' }
+StDebuggerContextInteractionModel >> beNonInteractive [
+
+	interactive := false
+]
+
 { #category : 'binding' }
 StDebuggerContextInteractionModel >> bindingOf: aString [
 
@@ -37,6 +44,18 @@ StDebuggerContextInteractionModel >> bindingOf: aString [
 StDebuggerContextInteractionModel >> bindings [
 
 	^ bindings ifNil: [ bindings := Dictionary new ] 
+]
+
+{ #category : 'accessing' }
+StDebuggerContextInteractionModel >> compiler [
+	"Provide a compiler set up on the current context/class/receiver"
+
+	^ self doItReceiver class compiler
+		context: self doItContext;
+		receiver: self doItReceiver;
+		isScripting: self isScripting;
+		requestor: self;
+		yourself
 ]
 
 { #category : 'testing' }
@@ -57,6 +76,19 @@ StDebuggerContextInteractionModel >> hasBindingOf: aString [
 
 	^ (self hasBindingInContextOf: aString) or: [ 
 		  self hasBindingInInteractionModelOf: aString ]
+]
+
+{ #category : 'accessing' }
+StDebuggerContextInteractionModel >> initialize [
+
+	super initialize.
+	interactive := true
+]
+
+{ #category : 'accessing' }
+StDebuggerContextInteractionModel >> interactive [
+
+	^ interactive
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
If we inpect or evaluate any expression using a variable in the outer context of a clean block it crashes the VM.

The fix in Pharo is PR #19487
This test will crash until that PR is integrated