### PR TITLE
Fix bugs for `StMethodBrowser` + Testing features

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -260,13 +260,10 @@ StMethodBrowser >> addHighlightedSegments [
 	| message highlightInterval highlights |
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
-	
+
 	highlights := highlight isString
 		              ifTrue: [ { highlight } ]
-		              ifFalse: [
-				              highlight isGlobalVariable
-					              ifTrue: [ { highlight name } ]
-					              ifFalse: [ highlight ] ].
+		              ifFalse: [ highlight ].
 
 	highlights asArray do: [ :each |
 			highlightInterval := (self isMethodDefinition: message)

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -258,13 +258,13 @@ StMethodBrowser >> accept: text notifying: notifyer [
 { #category : 'private' }
 StMethodBrowser >> addHighlightedSegments [
 
-	| message highlightInterval highlights |
+	| message highlightInterval highlights  |
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
 
-	highlights := highlight isString
-		              ifTrue: [ { highlight } ]
-		              ifFalse: [ highlight ].
+	highlights := (highlight isCollection and: [ highlight isString not ])
+		              ifTrue: [ highlight ]
+		              ifFalse: [ { highlight } ].
 
 	highlights asArray do: [ :each |
 			highlightInterval := (self isMethodDefinition: message)

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -148,8 +148,8 @@ StMethodBrowser class >> browseSendersOfAll: aCollectionOfSymbols [
 { #category : 'private' }
 StMethodBrowser class >> implementorsOf: aSymbol [
 	"Do not use aSymbol implementors because it is a disguised global"
-	
-	^ SystemNavigation new allImplementorsOf: aSymbol 
+
+	^ (SystemNavigation new allImplementorsOf: aSymbol) reject: [ :m | m isFromTrait ]
 ]
 
 { #category : 'instance creation' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -260,10 +260,13 @@ StMethodBrowser >> addHighlightedSegments [
 	| message highlightInterval highlights |
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
-
+	
 	highlights := highlight isString
 		              ifTrue: [ { highlight } ]
-		              ifFalse: [ highlight ].
+		              ifFalse: [
+				              highlight isGlobalVariable
+					              ifTrue: [ { highlight name } ]
+					              ifFalse: [ highlight ] ].
 
 	highlights asArray do: [ :each |
 			highlightInterval := (self isMethodDefinition: message)

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -117,6 +117,12 @@ StMethodBrowser class >> browseImplementorsOfAll: aCollectionOfSymbols [
 ]
 
 { #category : 'opening' }
+StMethodBrowser class >> browseMethodsWithSourceString: aString [
+
+	SystemNavigation default browseMethodsWithSourceString: aString matchCase: false
+]
+
+{ #category : 'opening' }
 StMethodBrowser class >> browseReferencesOf: aClassName [
 	"Special version that sets the correct refreshing block for senders"
 
@@ -255,8 +261,8 @@ StMethodBrowser >> addHighlightedSegments [
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
 
-	highlights := highlight isSymbol
-		              ifTrue: [ Array with: highlight ]
+	highlights := highlight isString
+		              ifTrue: [ { highlight } ]
 		              ifFalse: [ highlight ].
 
 	highlights asArray do: [ :each |
@@ -623,33 +629,32 @@ StMethodBrowser >> registerToAnnouncements [
 StMethodBrowser >> searchedString: searchedString in: aString [
 	"Return the interval that corresponds to the portion of aString "
 	"This method takes care of finding complete match to searchedString. "
-	| string interval firstIndex |
-	
+
+	| string interval firstIndex lowerString lowerSearch |
 	searchedString ifNil: [ ^ 0 to: 0 ].
-	aString isEmptyOrNil ifTrue: [ ^0 to: 0 ].
+	aString isEmptyOrNil ifTrue: [ ^ 0 to: 0 ].
 	string := aString asString.
+	lowerString := string asLowercase.
+	lowerSearch := searchedString asLowercase.
 	interval := 0 to: 0.
-	
-	(searchedString includes: $:)
-		ifTrue: [ | list |
-			list := searchedString substrings: ':'.
-			list size = 1
-				ifTrue: [" binary selector "
-					firstIndex := self findFirstOccurrenceOf: searchedString in: string.
-					firstIndex isZero
-						ifFalse: [ interval := firstIndex to: (firstIndex+searchedString size-1) ] ] 
-					
-				ifFalse: [
-					| lastIndex |
-					firstIndex := self findFirstOccurrenceOf: list first, ':' in: string. 
-					firstIndex >0 ifTrue: [ 
-								lastIndex := string findString: list last,':' startingAt: firstIndex+ (list first size -1).
-								interval := firstIndex to: (lastIndex + list last size) ] ] ]
+
+	(lowerSearch includes: $:)
+		ifTrue: [
+				| list |
+				list := lowerSearch substrings: ':'.
+				list size = 1
+					ifTrue: [
+							firstIndex := self findFirstOccurrenceOf: lowerSearch in: lowerString.
+							firstIndex isZero ifFalse: [ interval := firstIndex to: firstIndex + searchedString size - 1 ] ]
+					ifFalse: [
+							| lastIndex |
+							firstIndex := self findFirstOccurrenceOf: list first , ':' in: lowerString.
+							firstIndex > 0 ifTrue: [
+									lastIndex := lowerString findString: list last , ':' startingAt: firstIndex + (list first size - 1).
+									interval := firstIndex to: lastIndex + list last size ] ] ]
 		ifFalse: [
-			" unary selector "
-			firstIndex := self findFirstOccurrenceOf: searchedString in: string.
-			 firstIndex > 0
-						ifTrue: [ interval := firstIndex to: (firstIndex+searchedString size - 1) ] ].
+				firstIndex := self findFirstOccurrenceOf: lowerSearch in: lowerString.
+				firstIndex > 0 ifTrue: [ interval := firstIndex to: firstIndex + searchedString size - 1 ] ].
 	^ interval
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -72,6 +72,14 @@ StMethodBrowser class >> browse: compiledMethods asSendersOf: aSymbol [
 		  open
 ]
 
+{ #category : 'opening explicit' }
+StMethodBrowser class >> browse: compiledMethods asSendersOfAll: aCollectionOfSymbols [
+
+	^ self new
+		  methods: compiledMethods asSendersOfAll: aCollectionOfSymbols;
+		  open
+]
+
 { #category : 'opening - old' }
 StMethodBrowser class >> browse: aCollection title: aString [
 	"Basic version with limited UX feedback. Use only if you cannot use the other methods."
@@ -138,11 +146,9 @@ StMethodBrowser class >> browseSendersOf: aSymbol [
 
 { #category : 'opening' }
 StMethodBrowser class >> browseSendersOfAll: aCollectionOfSymbols [
-
-	| methods |
-	methods := aCollectionOfSymbols flatCollect: [ :sym | self sendersOf: sym ].
-
-	^ self browse: methods asArray
+    | methods |
+    methods := aCollectionOfSymbols flatCollect: [ :sym | self sendersOf: sym ].
+    ^ self browse: methods asArray asSendersOfAll: aCollectionOfSymbols 
 ]
 
 { #category : 'private' }
@@ -244,18 +250,23 @@ StMethodBrowser >> accept: text notifying: notifyer [
 
 { #category : 'private' }
 StMethodBrowser >> addHighlightedSegments [
-	| message highlightInterval |
 
+	| message highlightInterval highlights |
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
-	
-	highlightInterval := (self isMethodDefinition: message)
-		ifFalse: [ self intervalOf: highlight inCommentText: textPresenter text ] 
-		ifTrue: [ self intervalOf: highlight inCode: textPresenter text of: message ].
-		
-	textPresenter addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight 
-		interval: (highlightInterval first to: highlightInterval last + 1);
-		yourself)
+
+	highlights := highlight isSymbol
+		              ifTrue: [ Array with: highlight ]
+		              ifFalse: [ highlight ].
+
+	highlights asArray do: [ :each |
+			highlightInterval := (self isMethodDefinition: message)
+				                     ifFalse: [ self intervalOf: each inCommentText: textPresenter text ]
+				                     ifTrue: [ self intervalOf: each inCode: textPresenter text of: message ].
+
+			textPresenter addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
+					 interval: (highlightInterval first to: highlightInterval last + 1);
+					 yourself) ]
 ]
 
 { #category : 'to remove' }
@@ -558,6 +569,16 @@ StMethodBrowser >> methods: compiledMethods asSendersOf: aSymbol [
 		title: 'Senders of ' , aSymbol
 ]
 
+{ #category : 'api - instance side' }
+StMethodBrowser >> methods: compiledMethods asSendersOfAll: aCollectionOfSymbols [
+
+	self
+		setRefreshingBlockForSendersOfAll: aCollectionOfSymbols;
+		highlight: aCollectionOfSymbols;
+		methods: compiledMethods;
+		title: 'Senders of ' , (', ' join: aCollectionOfSymbols)
+]
+
 { #category : 'initialization' }
 StMethodBrowser >> newMethodToolbar [
 
@@ -688,6 +709,16 @@ StMethodBrowser >> setRefreshingBlockForSendersOf: aSelector [
 	specialIndex := Smalltalk specialSelectorIndexOrNil: aSelector.
 	self refreshingBlock: [:method | 
 		method hasSelector: aSelector specialSelectorIndex: specialIndex ]
+]
+
+{ #category : 'api' }
+StMethodBrowser >> setRefreshingBlockForSendersOfAll: aCollectionOfSymbols [
+
+	self refreshingBlock: [ :method |
+			aCollectionOfSymbols anySatisfy: [ :sym |
+					| specialIndex |
+					specialIndex := Smalltalk specialSelectorIndexOrNil: sym.
+					method hasSelector: sym specialSelectorIndex: specialIndex ] ]
 ]
 
 { #category : 'announcements' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -54,16 +54,18 @@ StMethodBrowserToolbarPresenter >> doFlipLayout [
 StMethodBrowserToolbarPresenter >> initializePresenters [
 
 	super initializePresenters.
-	
-	scopeList := self newDropList
-		addStyle: 'stMessageBrowserScopeList';
-		display: [ : item | item description ];
-		yourself.
-	
-	toolbarPresenter add: (self newToolbarButton
-		label: 'Flip';
-		action: [ self doFlipLayout ]).
 
+	scopeList := self newDropList
+		             addStyle: 'stMessageBrowserScopeList';
+		             display: [ :item |
+				             (item respondsTo: #description)
+					             ifTrue: [ item description ]
+					             ifFalse: [ item printString ] ];
+		             yourself.
+
+	toolbarPresenter add: (self newToolbarButton
+			 label: 'Flip';
+			 action: [ self doFlipLayout ])
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -207,20 +207,26 @@ StMethodListPresenter >> doRemoveMethod [
 ]
 
 { #category : 'execution' }
-StMethodListPresenter >> executeTestForSelectedMethod [
+StMethodListPresenter >> executeTestFor: aMethod [
 
-	| method selector testClasses suite result |
-	method := self selectedMethod.
-	method ifNil: [ ^ self ].
-	selector := method selector.
-	testClasses := method methodClass isAbstract
-		               ifTrue: [ method methodClass allSubclasses ]
-		               ifFalse: [ { method methodClass } ].
+	| selector testClasses suite result |
+	aMethod ifNil: [ ^ self ].
+
+	selector := aMethod selector.
+
+	testClasses := aMethod methodClass isAbstract
+		               ifTrue: [ aMethod methodClass allSubclasses ]
+		               ifFalse: [ { aMethod methodClass } ].
+
 	suite := TestSuite named: selector.
-	testClasses do: [ :concreteClass | suite addTest: (concreteClass selector: selector) ].
+
+	testClasses do: [ :each | suite addTest: (each selector: selector) ].
+
 	result := suite run.
 	result updateResultsInHistory.
+
 	self application inform: result printString.
+
 	listPresenter updateItemsKeepingSelection: listPresenter items
 ]
 
@@ -240,7 +246,7 @@ StMethodListPresenter >> initializePresenters [
 		sortingBlock: [ :a :b | self sortClassesInCachedHierarchy: a b: b ];
 		addColumn: (SpStringTableColumn title: 'Location' evaluated: [ :item | self locationOf: item ]);
 		addColumn: (StTestIconColumnView new
-				 executeBlock: [ :method | self executeTestForSelectedMethod ];
+				 executeBlock: [ :method | self executeTestFor: method ]; 
 				 cellPresenterClass: StTestIconCellPresenter;
 				 width: 20;
 				 yourself);

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -240,7 +240,7 @@ StMethodListPresenter >> initializePresenters [
 		sortingBlock: [ :a :b | self sortClassesInCachedHierarchy: a b: b ];
 		addColumn: (SpStringTableColumn title: 'Location' evaluated: [ :item | self locationOf: item ]);
 		addColumn: (StTestIconColumnView new
-				 executeBlock: [ self executeTestForSelectedMethod ];
+				 executeBlock: [ :method | self executeTestForSelectedMethod ];
 				 cellPresenterClass: StTestIconCellPresenter;
 				 width: 20;
 				 yourself);

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -221,7 +221,7 @@ StMethodListPresenter >> executeTestForSelectedMethod [
 	result := suite run.
 	result updateResultsInHistory.
 	self application inform: result printString.
-	listPresenter refresh
+	listPresenter updateItemsKeepingSelection: listPresenter items
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -261,26 +261,27 @@ StMethodListPresenter >> methodClassNameForItem: anItem [
 
 { #category : 'private' }
 StMethodListPresenter >> methodListActions [
-	
+
 	^ CmCommandGroup forSpec
-		beRoot;
-		register: ((CmCommandGroup forSpecNamed: 'View')
-			beDisplayedAsGroup;
-			register: (StMethodBrowseFullCommand forSpecContext: self);
-			register: (StInspectMethodCommand forSpecContext: self);
-			yourself);
-		register: ((CmCommandGroup forSpecNamed: 'Navigation')
-			beDisplayedAsGroup;
-			register: (StMessageSendersCommand forSpecContext: self);
-			register: (StImplementorsCommand forSpecContext: self);
-			register: (StClassReferencesCommand forSpecContext: self);
-			register: (StMethodVersionsCommand forSpecContext: self);
-			yourself);
-		register: ((CmCommandGroup forSpecNamed: 'CRITICAL')
-			beDisplayedAsGroup;
-			register: (StRemoveMethodCommand forSpecContext: self);
-			yourself);
-		yourself
+		  beRoot;
+		  register: ((CmCommandGroup forSpecNamed: 'View')
+				   beDisplayedAsGroup;
+				   register: (StMethodBrowseFullCommand forSpecContext: self);
+				   register: (StInspectMethodCommand forSpecContext: self);
+				   register: (StRunMethodTestCommand forSpecContext: self);
+				   yourself);
+		  register: ((CmCommandGroup forSpecNamed: 'Navigation')
+				   beDisplayedAsGroup;
+				   register: (StMessageSendersCommand forSpecContext: self);
+				   register: (StImplementorsCommand forSpecContext: self);
+				   register: (StClassReferencesCommand forSpecContext: self);
+				   register: (StMethodVersionsCommand forSpecContext: self);
+				   yourself);
+		  register: ((CmCommandGroup forSpecNamed: 'CRITICAL')
+				   beDisplayedAsGroup;
+				   register: (StRemoveMethodCommand forSpecContext: self);
+				   yourself);
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -206,6 +206,24 @@ StMethodListPresenter >> doRemoveMethod [
 			inClass: aMethod methodClass ]
 ]
 
+{ #category : 'execution' }
+StMethodListPresenter >> executeTestForSelectedMethod [
+
+	| method selector testClasses suite result |
+	method := self selectedMethod.
+	method ifNil: [ ^ self ].
+	selector := method selector.
+	testClasses := method methodClass isAbstract
+		               ifTrue: [ method methodClass allSubclasses ]
+		               ifFalse: [ { method methodClass } ].
+	suite := TestSuite named: selector.
+	testClasses do: [ :concreteClass | suite addTest: (concreteClass selector: selector) ].
+	result := suite run.
+	result updateResultsInHistory.
+	self application inform: result printString.
+	listPresenter refresh
+]
+
 { #category : 'initialization' }
 StMethodListPresenter >> initialize [
 
@@ -217,18 +235,17 @@ StMethodListPresenter >> initialize [
 { #category : 'initialization' }
 StMethodListPresenter >> initializePresenters [
 
-	listPresenter := self newTable.
+	listPresenter := self newEasyColumnView.
 	listPresenter
 		sortingBlock: [ :a :b | self sortClassesInCachedHierarchy: a b: b ];
-		addColumn: (SpStringTableColumn 
-			title: 'Location' 
-			evaluated: [ :item | self locationOf: item ]);
-		addColumn: (SpStringTableColumn 
-			title: 'Selector' 
-			evaluated: [ :item | self selectorOf: item ]);
-		addColumn: (SpStringTableColumn 
-			title: 'Package' 
-			evaluated: [ :item | self packageNameOf: item ]);
+		addColumn: (SpStringTableColumn title: 'Location' evaluated: [ :item | self locationOf: item ]);
+		addColumn: (StTestIconColumnView new
+				 executeBlock: [ self executeTestForSelectedMethod ];
+				 cellPresenterClass: StTestIconCellPresenter;
+				 width: 20;
+				 yourself);
+		addColumn: (SpStringTableColumn title: 'Selector' evaluated: [ :item | self selectorOf: item ]);
+		addColumn: (SpStringTableColumn title: 'Package' evaluated: [ :item | self packageNameOf: item ]);
 		beResizable.
 
 	listPresenter outputActivationPort transmitDo: [ :aMethod | self doBrowseMethod ].
@@ -434,6 +451,27 @@ StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [
 
 	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages)
 
+]
+
+{ #category : 'tests' }
+StMethodListPresenter >> testIconFor: aMethod [
+
+	| allCount successCount failureCount errorCount |
+	(aMethod selector isTestSelector and: [ aMethod isInstanceSide ]) ifFalse: [ ^ nil ].
+	allCount := 0.
+	successCount := 0.
+	failureCount := 0.
+	errorCount := 0.
+	allCount := allCount + 1.
+	successCount := successCount + (aMethod methodClass methodPassed: aMethod selector) asBit.
+	failureCount := failureCount + (aMethod methodClass methodFailed: aMethod selector) asBit.
+	errorCount := errorCount + (aMethod methodClass methodRaisedError: aMethod selector) asBit.
+
+	allCount = 0 ifTrue: [ ^ self iconNamed: #testNotRun ].
+	allCount = successCount ifTrue: [ ^ self iconNamed: #testGreen ].
+	errorCount = 0 & (failureCount > 0) ifTrue: [ ^ self iconNamed: #testYellow ].
+	errorCount > 0 ifTrue: [ ^ self iconNamed: #testRed ].
+	^ self iconNamed: #testNotRun
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -20,3 +20,28 @@ StRunMethodTestCommand class >> defaultShortcut [
 
 	^ $t actionModifier
 ]
+
+{ #category : 'testing' }
+StRunMethodTestCommand >> canBeExecuted [
+
+	| method |
+	method := context selectedMethod.
+	method ifNil: [ ^ false ].
+	^ method selector isTestSelector and: [ method isInstanceSide ]
+]
+
+{ #category : 'executing' }
+StRunMethodTestCommand >> execute [
+
+	| method selector testClasses suite result |
+	method := self context selectedMethod.
+	selector := method selector.
+	testClasses := method methodClass isAbstract
+		               ifTrue: [ method methodClass allSubclasses ]
+		               ifFalse: [ { method methodClass } ].
+	suite := TestSuite named: selector.
+	testClasses do: [ :concreteClass | suite addTest: (concreteClass selector: selector) ].
+	result := suite run.
+	result updateResultsInHistory.
+	self context application inform: result printString
+]

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -33,5 +33,5 @@ StRunMethodTestCommand >> canBeExecuted [
 { #category : 'executing' }
 StRunMethodTestCommand >> execute [
 
-	self context executeTestForSelectedMethod
+	self context executeTestFor: self context selectedMethod
 ]

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -33,15 +33,5 @@ StRunMethodTestCommand >> canBeExecuted [
 { #category : 'executing' }
 StRunMethodTestCommand >> execute [
 
-	| method selector testClasses suite result |
-	method := self context selectedMethod.
-	selector := method selector.
-	testClasses := method methodClass isAbstract
-		               ifTrue: [ method methodClass allSubclasses ]
-		               ifFalse: [ { method methodClass } ].
-	suite := TestSuite named: selector.
-	testClasses do: [ :concreteClass | suite addTest: (concreteClass selector: selector) ].
-	result := suite run.
-	result updateResultsInHistory.
-	self context application inform: result printString
+	self context executeTestForSelectedMethod
 ]

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -1,0 +1,22 @@
+"
+Run the test case selected from a message browser list
+"
+Class {
+	#name : 'StRunMethodTestCommand',
+	#superclass : 'StCommand',
+	#category : 'NewTools-MethodBrowsers-Commands',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StRunMethodTestCommand class >> defaultName [
+
+	^ 'Run test'
+]
+
+{ #category : 'accessing' }
+StRunMethodTestCommand class >> defaultShortcut [
+
+	^ $t actionModifier
+]

--- a/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
@@ -13,6 +13,12 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'initialization' }
+StTestIconCellPresenter >> connectPresenters [
+
+	buttonPresenter action: [ (executeBlock notNil and: [ self model notNil ]) ifTrue: [ executeBlock value: self model ] ]
+]
+
 { #category : 'layout' }
 StTestIconCellPresenter >> defaultLayout [
 
@@ -55,13 +61,20 @@ StTestIconCellPresenter >> updatePresenter [
 
 	| method |
 	method := self model.
+
 	method ifNil: [
 			buttonPresenter icon: nil.
+			buttonPresenter enabled: false.
 			^ self ].
+
 	(method selector isTestSelector and: [ method isInstanceSide ])
 		ifTrue: [
-				buttonPresenter 
+				buttonPresenter
 					icon: (self testIconFor: method);
-					action: [ executeBlock value: method ] ]
-		ifFalse: [ buttonPresenter icon: nil ]
+					enabled: true;
+					help: 'Run test' ]
+		ifFalse: [
+				buttonPresenter
+					icon: nil;
+					enabled: false ]
 ]

--- a/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
@@ -1,0 +1,66 @@
+"
+I represent a presenter that contains an icon
+"
+Class {
+	#name : 'StTestIconCellPresenter',
+	#superclass : 'SpEasyColumnCellPresenter',
+	#instVars : [
+		'iconPresenter',
+		'executeBlock'
+	],
+	#category : 'NewTools-MethodBrowsers-Base',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Base'
+}
+
+{ #category : 'initialization' }
+StTestIconCellPresenter >> connectPresenters [
+
+	self eventHandler whenMouseDownDo: [ :anEvent | executeBlock ifNotNil: [ executeBlock value ] ]
+]
+
+{ #category : 'layout' }
+StTestIconCellPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: iconPresenter;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StTestIconCellPresenter >> initializePresenters [
+
+	iconPresenter := self newImage
+]
+
+{ #category : 'block' }
+StTestIconCellPresenter >> onExecute: aBlock [
+
+	executeBlock := aBlock
+]
+
+{ #category : 'tests' }
+StTestIconCellPresenter >> testIconFor: aMethod [
+
+	| allCount successCount failureCount errorCount |
+	allCount := 1.
+	successCount := (aMethod methodClass methodPassed: aMethod selector) asBit.
+	failureCount := (aMethod methodClass methodFailed: aMethod selector) asBit.
+	errorCount := (aMethod methodClass methodRaisedError: aMethod selector) asBit.
+	allCount = 0 ifTrue: [ ^ self iconNamed: #testNotRun ].
+	allCount = successCount ifTrue: [ ^ self iconNamed: #testGreen ].
+	errorCount = 0 & (failureCount > 0) ifTrue: [ ^ self iconNamed: #testYellow ].
+	errorCount > 0 ifTrue: [ ^ self iconNamed: #testRed ].
+	^ self iconNamed: #testNotRun
+]
+
+{ #category : 'initialization' }
+StTestIconCellPresenter >> updatePresenter [
+
+	| method |
+	
+	method := self model.
+	(method selector isTestSelector and: [ method isInstanceSide ])
+		ifTrue: [ iconPresenter image: (self testIconFor: method) ]
+		ifFalse: [ iconPresenter image: nil ]
+]

--- a/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
@@ -16,7 +16,8 @@ Class {
 { #category : 'initialization' }
 StTestIconCellPresenter >> connectPresenters [
 
-	self eventHandler whenMouseDownDo: [ :anEvent | executeBlock ifNotNil: [ executeBlock value ] ]
+	self eventHandler whenMouseDownDo: [ :anEvent |
+		(executeBlock notNil and: [ self model notNil ]) ifTrue: [ executeBlock value: self model ] ]
 ]
 
 { #category : 'layout' }
@@ -58,9 +59,12 @@ StTestIconCellPresenter >> testIconFor: aMethod [
 StTestIconCellPresenter >> updatePresenter [
 
 	| method |
-	
 	method := self model.
+	method ifNil: [
+			iconPresenter image: nil.
+			^ self ].
+
 	(method selector isTestSelector and: [ method isInstanceSide ])
 		ifTrue: [ iconPresenter image: (self testIconFor: method) ]
-		ifFalse: [ iconPresenter image: nil ]
+		ifFalse: [  ]
 ]

--- a/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : 'StTestIconCellPresenter',
 	#superclass : 'SpEasyColumnCellPresenter',
 	#instVars : [
-		'iconPresenter',
+		'buttonPresenter',
 		'executeBlock'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
@@ -13,25 +13,20 @@ Class {
 	#tag : 'Base'
 }
 
-{ #category : 'initialization' }
-StTestIconCellPresenter >> connectPresenters [
-
-	self eventHandler whenMouseDownDo: [ :anEvent |
-		(executeBlock notNil and: [ self model notNil ]) ifTrue: [ executeBlock value: self model ] ]
-]
-
 { #category : 'layout' }
 StTestIconCellPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  add: iconPresenter;
+		  add: buttonPresenter;
 		  yourself
 ]
 
 { #category : 'initialization' }
 StTestIconCellPresenter >> initializePresenters [
 
-	iconPresenter := self newImage
+	buttonPresenter := self newButton
+		                   addStyle: 'flat';
+		                   yourself
 ]
 
 { #category : 'block' }
@@ -61,10 +56,12 @@ StTestIconCellPresenter >> updatePresenter [
 	| method |
 	method := self model.
 	method ifNil: [
-			iconPresenter image: nil.
+			buttonPresenter icon: nil.
 			^ self ].
-
 	(method selector isTestSelector and: [ method isInstanceSide ])
-		ifTrue: [ iconPresenter image: (self testIconFor: method) ]
-		ifFalse: [  ]
+		ifTrue: [
+				buttonPresenter 
+					icon: (self testIconFor: method);
+					action: [ executeBlock value: method ] ]
+		ifFalse: [ buttonPresenter icon: nil ]
 ]

--- a/src/NewTools-MethodBrowsers/StTestIconColumnView.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconColumnView.class.st
@@ -1,0 +1,28 @@
+"
+A subclass of easy column, used for test icon view
+"
+Class {
+	#name : 'StTestIconColumnView',
+	#superclass : 'SpEasyColumnViewColumn',
+	#instVars : [
+		'executeBlock'
+	],
+	#category : 'NewTools-MethodBrowsers-Base',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Base'
+}
+
+{ #category : 'accessing' }
+StTestIconColumnView >> executeBlock: aBlock [
+
+	executeBlock := aBlock
+]
+
+{ #category : 'initialization' }
+StTestIconColumnView >> initialize [
+
+	super initialize.
+	self bind: [ :aPresenter :anObject |
+			aPresenter model: anObject.
+			aPresenter onExecute: executeBlock ]
+]


### PR DESCRIPTION
First of all, when showing implementors of a method in a trait, all classes that uses the trait were displayed too (fixed). 
Then when clicking on a trait before there was a `DNU: description`. 
Therefore I fixed it to answer printString if it don't understand description.

I added the **execute test** feature as a new command, actionable in the context menu.
As well I implemented a new column in method list, allowing the user to run any test method directly in the browser.


And also I implemented multiple highlighting for collections of senders, meaning each command called for senders now highlight well each selector in the method browsed.

Lastly, I added support for `Method source with it` removing class comments from the resulting methods.
Also updated the highlight to do a case-insensitive search, as `Method source with it` feature does the same !

Fixes #1359, Fixes https://github.com/pharo-project/pharo/issues/19479, Fixes https://github.com/pharo-project/pharo/issues/19475, Fixes https://github.com/pharo-project/pharo/issues/19470