### PR TITLE
[ Method Browser ] Fix selection asynchrone execution

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -319,8 +319,8 @@ StMethodListPresenter >> methods: aCollection [
 	self cacheHierarchyForClasses: aCollection.
 	listPresenter items: cachedHierarchy keys asOrderedCollection.
 	allMessages := listPresenter items.
-	listPresenter listSize > 0 ifTrue: [ 
-		listPresenter selectIndex: 1 ]
+
+	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Selection was not working since the filtering introduction to the method browser.  
Use `defer:` to ensure selection is applied after the GTK widget has finished rendering its items.