### PR TITLE
[ Method Browser ] Test result announcement refresh

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -513,6 +513,13 @@ StMethodBrowser >> initializePresenters [
 	self initializeDropList
 ]
 
+{ #category : 'initialization' }
+StMethodBrowser >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ]
+]
+
 { #category : 'private' }
 StMethodBrowser >> installIconStylerFor: anItem [
 	"icons styler are only supported for method definitions (not nil / not for comment definitions    

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -231,11 +231,18 @@ StMethodListPresenter >> executeTestFor: aMethod [
 ]
 
 { #category : 'initialization' }
+StMethodListPresenter >> handleTestResultChanged: anAnnouncement [
+
+	self defer: [ listPresenter updateItemsKeepingSelection: listPresenter items ]
+]
+
+{ #category : 'initialization' }
 StMethodListPresenter >> initialize [
 
 	super initialize.
 	topologySort := true.
 	allMessages := Set empty.
+	self registerToTestAnnouncements
 ]
 
 { #category : 'initialization' }
@@ -390,6 +397,14 @@ StMethodListPresenter >> protocolNameForItem: anItem [
 	^ anItem protocolName ifNil: [ '' ]
 ]
 
+{ #category : 'initialization' }
+StMethodListPresenter >> registerToTestAnnouncements [
+
+	TestCase historyAnnouncer unsubscribe: self.
+
+	TestCase historyAnnouncer weak when: TestSuiteEnded send: #handleTestResultChanged: to: self
+]
+
 { #category : 'private - scopes' }
 StMethodListPresenter >> scopes [
 	"Answer a <Collection> of the receiver's message list scopes"
@@ -457,27 +472,6 @@ StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [
 
 	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages)
 
-]
-
-{ #category : 'tests' }
-StMethodListPresenter >> testIconFor: aMethod [
-
-	| allCount successCount failureCount errorCount |
-	(aMethod selector isTestSelector and: [ aMethod isInstanceSide ]) ifFalse: [ ^ nil ].
-	allCount := 0.
-	successCount := 0.
-	failureCount := 0.
-	errorCount := 0.
-	allCount := allCount + 1.
-	successCount := successCount + (aMethod methodClass methodPassed: aMethod selector) asBit.
-	failureCount := failureCount + (aMethod methodClass methodFailed: aMethod selector) asBit.
-	errorCount := errorCount + (aMethod methodClass methodRaisedError: aMethod selector) asBit.
-
-	allCount = 0 ifTrue: [ ^ self iconNamed: #testNotRun ].
-	allCount = successCount ifTrue: [ ^ self iconNamed: #testGreen ].
-	errorCount = 0 & (failureCount > 0) ifTrue: [ ^ self iconNamed: #testYellow ].
-	errorCount > 0 ifTrue: [ ^ self iconNamed: #testRed ].
-	^ self iconNamed: #testNotRun
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -400,8 +400,6 @@ StMethodListPresenter >> protocolNameForItem: anItem [
 { #category : 'initialization' }
 StMethodListPresenter >> registerToTestAnnouncements [
 
-	TestCase historyAnnouncer unsubscribe: self.
-
 	TestCase historyAnnouncer weak when: TestSuiteEnded send: #handleTestResultChanged: to: self
 ]
 

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -27,7 +27,7 @@ StRunMethodTestCommand >> canBeExecuted [
 	| method |
 	method := context selectedMethod.
 	method ifNil: [ ^ false ].
-	^ method selector isTestSelector and: [ method isInstanceSide ]
+	^ method isTestMethod
 ]
 
 { #category : 'executing' }

--- a/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StTestIconCellPresenter.class.st
@@ -60,6 +60,7 @@ StTestIconCellPresenter >> testIconFor: aMethod [
 StTestIconCellPresenter >> updatePresenter [
 
 	| method |
+
 	method := self model.
 
 	method ifNil: [
@@ -67,7 +68,7 @@ StTestIconCellPresenter >> updatePresenter [
 			buttonPresenter enabled: false.
 			^ self ].
 
-	(method selector isTestSelector and: [ method isInstanceSide ])
+	method isTestMethod
 		ifTrue: [
 				buttonPresenter
 					icon: (self testIconFor: method);


### PR DESCRIPTION
Now the method browser listen to Test announcements, meaning if we browse some test method and any of them is run elsewhere, the icons in the method browser will refresh based on test result. 
Also cleaned some code !