### PR TITLE
Fix #1376 by using cached icons

### DIFF
--- a/src/NewTools-FileBrowser/StFileBrowserIconColumn.class.st
+++ b/src/NewTools-FileBrowser/StFileBrowserIconColumn.class.st
@@ -18,7 +18,9 @@ StFileBrowserIconColumn class >> addConstraintTo: aTableColumn [
 StFileBrowserIconColumn class >> evaluateOn: aFileReference [
 	"I'm provide action for fileReference"
 
-	^ aFileReference isDirectory ifTrue: [ self iconNamed: #configNew ] ifFalse: [ self iconNamed: #page ]
+	^ StFileBrowserIconCache iconNamed: (aFileReference isDirectory
+			   ifTrue: [ #folderIcon ]
+			   ifFalse: [ #fileIcon ])
 ]
 
 { #category : 'sorting' }


### PR DESCRIPTION
Fix #1376 to properly display the correct (cached) folder/file icons in the list pane too:

<img width="455" height="204" alt="Screenshot from 2026-04-08 23-45-17" src="https://github.com/user-attachments/assets/738724c4-b9a9-463b-8216-b96f16d2cbb3" />
