### PR TITLE
[ Method Browser ] Senders refresh fixes

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -428,34 +428,39 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodModified: anAnnouncement [
-	| item oldItem sel index text list edits |
-	
+
+	| item oldItem matchingItem index text edits list |
 	self isDisplayed ifFalse: [ ^ self ].
-	
 	refreshingBlock ifNil: [ ^ self ].
 	item := anAnnouncement newMethod.
 	oldItem := anAnnouncement oldMethod.
-	sel := self selectedMethod.
-	sel ifNil: [ ^ self ].
-	(sel methodClass = oldItem methodClass
-		and: [ sel selector = oldItem selector ])
-		ifFalse: [ ^ self ].
-	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement)
-		ifFalse: [ ^ self ].
-	
+
+	matchingItem := self methods
+		                detect: [ :m | m methodClass = oldItem methodClass and: [ m selector = oldItem selector ] ]
+		                ifNone: [ nil ].
+	matchingItem ifNil: [
+			(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifTrue: [
+					self methods: (self methods
+							 add: item asFullRingDefinition;
+							 yourself) ].
+			^ self ].
+
 	edits := textPresenter hasUnacceptedEdits.
-	edits ifTrue: [ 
-		text := textPresenter pendingText ].
+	edits ifTrue: [ text := textPresenter pendingText ].
 	index := methodList selectedIndex.
+
 	list := self methods
-		remove: sel ifAbsent: [  ];
-		add: item asFullRingDefinition;
-		"to ensure it's still a RGMethod"
-			yourself.
+		        remove: matchingItem ifAbsent: [ ];
+		        yourself.
+	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
+			self methods: list.
+			self selectIndex: (index min: self methods size).
+			^ self ].
+	list add: item asFullRingDefinition.
 	self methods: list.
 	self selectIndex: index.
+
 	edits ifFalse: [ ^ self ].
-	
 	textPresenter pendingText: text.
 	textPresenter hasEditingConflicts: true
 ]


### PR DESCRIPTION
Multiple fixes for senders when method are modified:
- When looking for senders of a method, if a user update one of them and the method ends up not being a sender  anymore, the list removes it
- For the same scenario but the user modify a method in an OTHER browser, the list refresh itself too
- When a method becomes a sender while the method browser is opened, the list refresh itself.

Fixes https://github.com/pharo-project/pharo/issues/19529