### PR TITLE
[Method Browser] Fix method browser announcement handlers and improve UX

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -454,11 +454,11 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 		        yourself.
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
 			self methods: list.
-			self selectIndex: (index min: self methods size).
+			self defer: [ self selectIndex: (index min: self methods size) ].
 			^ self ].
 	list add: item asFullRingDefinition.
 	self methods: list.
-	self selectIndex: index.
+	self defer: [ self selectIndex: index ].
 
 	edits ifFalse: [ ^ self ].
 	textPresenter pendingText: text.
@@ -467,23 +467,20 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodRemoved: anAnnouncement [
-	| item selection removeItem |
 
+	| item selection removeItem |
 	self isDisplayed ifFalse: [ ^ self ].
 	refreshingBlock ifNil: [ ^ self ].
-	self okToChange ifFalse: [ ^ self ].
-
-	"Item is a compiled methed, where the list is populated with RGMethod"
+	self okToChange ifFalse: [ ^ self ]. "Item is a compiled methed, where the list is populated with RGMethod"
 	item := anAnnouncement method.
-	(item methodClass isNotNil and: [ item methodClass isObsolete not ])
-		ifFalse: [ ^ self ].
+	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
 	selection := methodList selectedIndex.
 	removeItem := self selectedMethod.
 
 	self methods: (self methods
-		remove: item ifAbsent: [ nil ];
-		yourself).
-	self selectIndex: (selection min: self methods size)
+			 remove: item ifAbsent: [ nil ];
+			 yourself).
+	self defer: [ self selectIndex: (selection min: self methods size) ]
 ]
 
 { #category : 'text selection' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -406,23 +406,26 @@ StMethodBrowser >> handleClassRenamed: anAnnouncement [
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodAdded: anAnnouncement [
-	| item sel text boolean |
 
+	| item sel text boolean |
 	self isDisplayed ifFalse: [ ^ self ].
 	refreshingBlock ifNil: [ ^ self ].
-	
+
 	item := anAnnouncement method.
-	
+
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [ ^ self ].
-	((item methodClass isNotNil) and:[item methodClass isObsolete not]) ifFalse: [ ^ self ].
-	
+	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
 	boolean := textPresenter hasUnacceptedEdits.
 	boolean ifTrue: [ text := textPresenter pendingText ].
-	
+
 	sel := self selectedMethod.
-	self methods: (self methods add: item asFullRingDefinition; yourself).
+	self methods: (self methods
+			 add: item asFullRingDefinition;
+			 yourself).
+
+	self defer: [ self selectIndex: (self methods indexOf: sel) ].
 	self selectedMessage: sel.
-	
+
 	boolean ifTrue: [ textPresenter pendingText: text ]
 ]
 
@@ -468,19 +471,26 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodRemoved: anAnnouncement [
 
-	| item selection removeItem |
+	| item selection matchingItem selectedMethod |
 	self isDisplayed ifFalse: [ ^ self ].
 	refreshingBlock ifNil: [ ^ self ].
 	self okToChange ifFalse: [ ^ self ]. "Item is a compiled methed, where the list is populated with RGMethod"
 	item := anAnnouncement method.
 	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
 	selection := methodList selectedIndex.
-	removeItem := self selectedMethod.
+	matchingItem := self methods
+		                detect: [ :m | m methodClass = item methodClass and: [ m selector = item selector ] ]
+		                ifNone: [ ^ self ].
 
+	selection := methodList selectedIndex.
+	selectedMethod := self selectedMethod.
 	self methods: (self methods
-			 remove: item ifAbsent: [ nil ];
+			 remove: matchingItem ifAbsent: [ ];
 			 yourself).
-	self defer: [ self selectIndex: (selection min: self methods size) ]
+	self defer: [
+			selectedMethod = matchingItem
+				ifTrue: [ self selectIndex: (selection min: self methods size) ]
+				ifFalse: [ self selectIndex: (self methods indexOf: selectedMethod) ] ]
 ]
 
 { #category : 'text selection' }
@@ -604,10 +614,12 @@ StMethodBrowser >> methods [
 { #category : 'api' }
 StMethodBrowser >> methods: aCollection [
 
+	| currentFilter |
+	currentFilter := filterPresenter filterText.
 	filterPresenter unfilteredItems: aCollection asOrderedCollection.
-	filterPresenter resetFilter.
 	methodList methods: aCollection.
-	self toolbarPresenter updatePresenter
+	self toolbarPresenter updatePresenter.
+	currentFilter isEmpty ifFalse: [ filterPresenter applyFilter: currentFilter ]
 ]
 
 { #category : 'api - instance side' }
@@ -865,7 +877,7 @@ StMethodBrowser >> topologicSort: aBoolean [
 
 { #category : 'api' }
 StMethodBrowser >> updateTitle [
-	self withWindowDo: [ :window | window title: self title ]
+	self withWindowDo: [ :window | window title: self windowTitle ]
 ]
 
 { #category : 'layout' }
@@ -906,8 +918,12 @@ StMethodBrowser >> windowIsClosing [
 { #category : 'private' }
 StMethodBrowser >> windowTitle [
 
-	| msg |
-	msg := methodList ifNil: [ '' ] ifNotNil: [ ' [' , methodList numberOfElements printString , ']' ].
-	^ (title ifNil: [ 'Message Browser' ]), msg 
-	
+	| msg total |
+	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
+	total := filterPresenter unfilteredItems size.
+	msg := methodList ifNil: [ '' ] ifNotNil: [
+			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])
+				       ifTrue: [ ' [' , total printString , ']' ]
+				       ifFalse: [ ' [' , methodList numberOfElements printString , '/' , total printString , ']' ] ].
+	^ (title ifNil: [ 'Message Browser' ]) , msg
 ]


### PR DESCRIPTION
- Fix `handleMethodRemoved:` and `handleMethodModified:` to handle any method 
  in the list, not only the currently selected one,
- Fix `handleMethodModified:` for the selection when recompiling a method
- Fix selection offset after removal by restoring selection by identity 
  instead of by index
- Fix filter text being reset on announcement-triggered reload
- Add `[visible/total]` count in window title when filter is active for better UX


 
Fixes https://github.com/pharo-project/pharo/issues/19545