### PR TITLE
[Method Browser] Improve responsiveness to system announcements/new tests

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -419,15 +419,17 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
 	item := anAnnouncement method.
 
+
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [ ^ self ].
 	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
 	boolean := textPresenter hasUnacceptedEdits.
 	boolean ifTrue: [ text := textPresenter pendingText ].
 
 	sel := self selectedMethod.
-	self methods: (self methods
-			 add: item asFullRingDefinition;
-			 yourself).
+	(self methods includes: item) ifFalse: [
+			self methods: (self methods
+					 add: item asFullRingDefinition;
+					 yourself) ].
 
 	self defer: [ self selectIndex: (self methods indexOf: sel) ].
 	self selectedMessage: sel.

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -362,6 +362,12 @@ StMethodBrowser >> defaultLayout [
 	^ self perform: self class usingLayout
 ]
 
+{ #category : 'accessing' }
+StMethodBrowser >> filterPresenter [
+
+	^ filterPresenter
+]
+
 { #category : 'text selection' }
 StMethodBrowser >> findFirstOccurrenceOf: searchedString in: textToSearchIn [
 	"Return the first index of aString in textToSearchIn "

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -100,6 +100,46 @@ StMethodBrowserTest >> testExplicitBrowseSenders [
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodAddedAddsMatchingSender [
+
+	| window browser initialSize newMethod |
+	[
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+		initialSize := browser methods size.
+
+		self class compile: 'tmpSenderMethodForTest ^ self printOn: String new' classified: 'tests-protocol'.
+		newMethod := self class >> #tmpSenderMethodForTest.
+
+		browser handleMethodAdded: (MethodAdded method: newMethod).
+
+		self assert: browser methods size equals: initialSize + 1.
+		self assert: (browser methods includes: newMethod asFullRingDefinition) ] ensure: [
+			self class removeSelector: #tmpSenderMethodForTest.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodModifiedRemovesSenderWhenNoLongerMatching [
+
+	| window browser method |
+	[
+		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
+		method := self class >> #methodForTest.
+
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+		self assert: (browser methods includes: method).
+		self class compile: 'methodForTest ^ Object new'.
+		browser handleMethodModified:
+			(MethodModified methodChangedFrom: method to: self class >> #methodForTest oldProtocol: method protocol).
+
+		self deny: (browser methods includes: method) ] ensure: [
+			self class removeSelector: #methodForTest.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodRemovedRemovesMatchingMethod [
 
 	| window browser method announcement initialSize |
@@ -184,6 +224,7 @@ StMethodBrowserTest >> testWindowTitleWithFilterRatio [
 		browser filterPresenter filterInputPresenter text: 'print'.
 		filtered := browser methodList numberOfElements.
 
-		filtered < total ifTrue: [ self assert: (browser windowTitle includesSubstring: '/') ] ] ensure: [
+		self assert: filtered < total.
+		self assert: (browser windowTitle includesSubstring: filtered asString , '/' , total asString) ] ensure: [
 		window ifNotNil: [ window delete ] ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -99,6 +99,24 @@ StMethodBrowserTest >> testExplicitBrowseSenders [
 		self assert: window presenter methods size equals: 1 ] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
+{ #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodRemovedRemovesMatchingMethod [
+
+	| window browser method announcement initialSize |
+	[
+		window := StMethodBrowser browseImplementorsOf: #printOn:.
+		browser := window presenter.
+
+		method := browser methods anyOne.
+		initialSize := browser methods size.
+
+		announcement := MethodRemoved new method: method compiledMethod.
+
+		browser handleMethodRemoved: announcement.
+
+		self assert: browser methods size equals: initialSize - 1 ] ensure: [ window ifNotNil: [ window delete ] ]
+]
+
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testMethodBrowserImplementors [
 
@@ -135,4 +153,21 @@ StMethodBrowserTest >> testRefreshingBlockWithLiteralString [
 		browser := window presenter.
 		methodToAdd := (self class >> #dataMethodForTest) copy.
 		self assert: (browser refreshingBlock value: methodToAdd) ] ensure: [ window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserTest >> testWindowTitleWithFilterRatio [
+
+	| window browser total filtered |
+	[
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+
+		total := browser methods size.
+
+		browser filterPresenter filterInputPresenter text: 'print'.
+		filtered := browser methodList numberOfElements.
+
+		filtered < total ifTrue: [ self assert: (browser windowTitle includesSubstring: '/') ] ] ensure: [
+		window ifNotNil: [ window delete ] ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -117,6 +117,22 @@ StMethodBrowserTest >> testHandleMethodRemovedRemovesMatchingMethod [
 		self assert: browser methods size equals: initialSize - 1 ] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
+{ #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
+
+	| window browser method |
+	[
+		window := StMethodBrowser browseImplementorsOf: #printOn:.
+		browser := window presenter.
+
+		method := browser methods second.
+		browser selectIndex: 2.
+
+		browser handleMethodRemoved: (MethodRemoved new method: method compiledMethod).
+		World doOneCycle.
+		self assert: (browser methods indexOf: browser selectedMethod) equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
+]
+
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testMethodBrowserImplementors [
 


### PR DESCRIPTION
I added mulitple tests, as well of announcement handle fix for the `MethodBrowser`:
-Fix handleMethodAdded:: Added a check to prevent duplicate entries if a method is already present in the browser list.

Test Suite Enhancements:
-Added tests for MethodAdded (ensuring correct filtering/adding).
-Added tests for MethodModified (ensuring removal of stale references).
-Added tests for MethodRemoved (ensuring list consistency and selection updates).
-Added a UI test for the window title filtering ratio.