### PR TITLE
[Method Browser] Sort columns with new implementation

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -252,7 +252,7 @@ StMethodListPresenter >> initializePresenters [
 	listPresenter
 		addColumn: (SpColumnViewColumn new
 				 title: 'Location';
-				 sortFunction: [ :a :b | self sortClassesInCachedHierarchy: a b: b  ];
+				 sortFunction: [ :item | self locationOf: item ] ascending;
 				 bind: [ :p :item | p label: (self locationOf: item) ];
 				 yourself);
 		addColumn: (StTestIconColumnView new
@@ -262,12 +262,12 @@ StMethodListPresenter >> initializePresenters [
 				 yourself);
 		addColumn: (SpColumnViewColumn new
 				 title: 'Selector';
-				 sortFunction: [ :a :b | (self selectorOf: a) <= (self selectorOf: b) ];
+				 sortFunction: #selector ascending;
 				 bind: [ :p :item | p label: (self selectorOf: item) ];
 				 yourself);
 		addColumn: (SpColumnViewColumn new
 				 title: 'Package';
-				 sortFunction: [ :a :b | (self packageNameOf: a) <= (self packageNameOf: b) ];
+				 sortFunction: [ :item | self packageNameOf: item ] ascending;
 				 bind: [ :p :item | p label: (self packageNameOf: item) ];
 				 yourself);
 		beResizable.

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -250,15 +250,26 @@ StMethodListPresenter >> initializePresenters [
 
 	listPresenter := self newEasyColumnView.
 	listPresenter
-		sortingBlock: [ :a :b | self sortClassesInCachedHierarchy: a b: b ];
-		addColumn: (SpStringTableColumn title: 'Location' evaluated: [ :item | self locationOf: item ]);
+		addColumn: (SpColumnViewColumn new
+				 title: 'Location';
+				 sortFunction: [ :a :b | self sortClassesInCachedHierarchy: a b: b  ];
+				 bind: [ :p :item | p label: (self locationOf: item) ];
+				 yourself);
 		addColumn: (StTestIconColumnView new
-				 executeBlock: [ :method | self executeTestFor: method ]; 
+				 executeBlock: [ :method | self executeTestFor: method ];
 				 cellPresenterClass: StTestIconCellPresenter;
 				 width: 20;
 				 yourself);
-		addColumn: (SpStringTableColumn title: 'Selector' evaluated: [ :item | self selectorOf: item ]);
-		addColumn: (SpStringTableColumn title: 'Package' evaluated: [ :item | self packageNameOf: item ]);
+		addColumn: (SpColumnViewColumn new
+				 title: 'Selector';
+				 sortFunction: [ :a :b | (self selectorOf: a) <= (self selectorOf: b) ];
+				 bind: [ :p :item | p label: (self selectorOf: item) ];
+				 yourself);
+		addColumn: (SpColumnViewColumn new
+				 title: 'Package';
+				 sortFunction: [ :a :b | (self packageNameOf: a) <= (self packageNameOf: b) ];
+				 bind: [ :p :item | p label: (self packageNameOf: item) ];
+				 yourself);
 		beResizable.
 
 	listPresenter outputActivationPort transmitDo: [ :aMethod | self doBrowseMethod ].


### PR DESCRIPTION
Since we moved from a table to an easy column view, we needed to implement a `sortFunction` for each column.