### PR TITLE
[Method Browser] Proposing to save changes for dirty methods

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -559,6 +559,10 @@ StMethodBrowser >> initializePresenters [
 StMethodBrowser >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
+	aWindowPresenter whenWillCloseDo: [ :ann |
+			textPresenter hasUnacceptedEdits ifTrue: [
+					(self application confirm: 'Changes have not been saved.
+Is it OK to discard changes?') ifFalse: [ ann denyClose ] ] ].
 	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ]
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -560,7 +560,7 @@ StMethodBrowser >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
 	aWindowPresenter whenWillCloseDo: [ :ann |
-			textPresenter hasUnacceptedEdits ifTrue: [
+			textPresenter isDirty ifTrue: [
 					(self application confirm: 'Changes have not been saved.
 Is it OK to discard changes?') ifFalse: [ ann denyClose ] ] ].
 	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ]


### PR DESCRIPTION
This code will work when all the `SpCodePresenter` stuff will be able to handle it, for now it don't understand when a method is dirty.  I just prepared the ground. 
However as Esteban said: "My intention is to create a meta-code-presenter (SpPharoEditorPresenter) that will handle all higher level stuff that can be modeled composing presenters", I will not propose a quick solution here, his idea is way better. 
Since he has a prototype, I think we can wait.

Fixes [#19553](https://github.com/pharo-project/pharo/issues/19553)