### PR TITLE
[Method Browser] Cleaning code and adding button feature

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -198,7 +198,7 @@ StMethodBrowser class >> browseWritersOfVariables: variables [
 StMethodBrowser class >> implementorsOf: aSymbol [
 	"Do not use aSymbol implementors because it is a disguised global"
 
-	^ (SystemNavigation new allImplementorsOf: aSymbol) reject: [ :m | m isFromTrait ]
+	^ (SystemNavigation default allImplementorsOf: aSymbol) reject: [ :m | m isFromTrait ]
 ]
 
 { #category : 'instance creation' }
@@ -210,41 +210,24 @@ StMethodBrowser class >> methods: methods [
 		  yourself
 ]
 
-{ #category : 'opening - old' }
-StMethodBrowser class >> openMessageList: messageList name: aString autoSelect: aSelector refreshingBlockSelector: aRefreshingBlockSelector [
-	
-	| browser |
-	browser := self new
-		methods: messageList;
-		title: aString;
-		autoSelect: aSelector;
-		yourself.
-		
-	aRefreshingBlockSelector ifNotNil:[(browser perform: aRefreshingBlockSelector with: aSelector)].
-	^browser open
-	
-				
-
-]
-
 { #category : 'private' }
 StMethodBrowser class >> referencesOf: aSymbol [
 	"Do not use aSymbol implementors because it is a disguised global"
 	
-	^ SystemNavigation new allReferencesTo: aSymbol 
+	^ SystemNavigation default allReferencesTo: aSymbol 
 ]
 
 { #category : 'private' }
 StMethodBrowser class >> referencesToClass: aClass [
 	
-	^ SystemNavigation new allReferencesTo: aClass binding
+	^ SystemNavigation default allReferencesTo: aClass binding
 ]
 
 { #category : 'private' }
 StMethodBrowser class >> referencesToLiteral: aLiteral [
 	"Do not use aSymbol implementors because it is a disguised global"
 
-	^ SystemNavigation new allReferencesTo: aLiteral
+	^ SystemNavigation default allReferencesTo: aLiteral
 ]
 
 { #category : 'private' }
@@ -316,12 +299,6 @@ StMethodBrowser >> addHighlightedSegments [
 			textPresenter addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
 					 interval: (highlightInterval first to: highlightInterval last + 1);
 					 yourself) ]
-]
-
-{ #category : 'to remove' }
-StMethodBrowser >> autoSelect: aString [
-	"this is just to absorb system navigation for now"
-	"once we remove the old message browser we should remove this empty method."
 ]
 
 { #category : 'announcements' }
@@ -559,11 +536,9 @@ StMethodBrowser >> initializePresenters [
 StMethodBrowser >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter whenWillCloseDo: [ :ann |
-			textPresenter hasUnacceptedEdits ifTrue: [
-					(self application confirm: 'Changes have not been saved.
-Is it OK to discard changes?') ifFalse: [ ann denyClose ] ] ].
-	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ]
+	aWindowPresenter whenClosedDo: [
+			TestCase historyAnnouncer unsubscribe: methodList.
+			self class codeChangeAnnouncer unsubscribe: self ]
 ]
 
 { #category : 'private' }
@@ -919,12 +894,6 @@ StMethodBrowser >> windowIcon [
 
 	^ self iconNamed: self class taskbarIconName
 		
-]
-
-{ #category : 'private' }
-StMethodBrowser >> windowIsClosing [
-
-	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'private' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -201,9 +201,21 @@ StMethodListPresenter >> doInspectMethod [
 StMethodListPresenter >> doRemoveMethod [
 
 	self selectedMethod ifNotNil: [ :aMethod |
-		SystemNavigation new 
+		SystemNavigation default 
 			removeMethod: aMethod 
 			inClass: aMethod methodClass ]
+]
+
+{ #category : 'private - actions' }
+StMethodListPresenter >> doRunTests [
+
+	| testMethods |
+	testMethods := self methods select: [ :each | each isTestMethod ].
+
+	testMethods ifEmpty: [
+			self application inform: 'No test found in the list.'.
+			^ self ].
+	testMethods do: [ :m | self executeTestFor: m ]
 ]
 
 { #category : 'execution' }

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -15,7 +15,8 @@ Class {
 		'versionButton',
 		'dropList',
 		'toolbarPresenter',
-		'messageList'
+		'messageList',
+		'runTestsButton'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -91,6 +92,12 @@ StMethodToolbarPresenter >> doBrowseVersions [
 	messageList doBrowseVersions
 ]
 
+{ #category : 'private - actions' }
+StMethodToolbarPresenter >> doRunTests [
+
+	messageList doRunTests
+]
+
 { #category : 'accessing' }
 StMethodToolbarPresenter >> emptyDropList [
 	
@@ -125,6 +132,11 @@ StMethodToolbarPresenter >> initializePresenters [
 		icon: (self iconNamed: #history);
 		help: 'Browse versions of current selected method';
 		action: [ self doBrowseVersions ].
+	(runTestsButton := self newToolbarButton )
+		label: 'Run Tests'; 
+		icon: (self iconNamed: #testGreen);
+		help: 'Run all test methods in the list';
+		action: [ self doRunTests ].
 		
  	toolbarPresenter := self newToolbar
 		displayMode: self application toolbarDisplayMode;
@@ -133,6 +145,7 @@ StMethodToolbarPresenter >> initializePresenters [
 		add: sendersButton;
 		add: implementorsButton;
 		add: versionButton;
+		add: runTestsButton;
 		yourself.
 		
 	dropList := self newDropList


### PR DESCRIPTION
- Removed unused method for technical debt
- Some methods used `System Navigation new` instead of the default one, fixed
- New `Run Tests` button in the toolbar to run all test methods present in the browser instance
- Removed `windowIsClosing`, there was 2 different call sites to handle window closing in the code, I moved all the logic in `initializeWindow:`