### PR TITLE
[Method Browser] Navigate in place feature

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -18,9 +18,11 @@ Class {
 		'refreshingBlock',
 		'textPresenter',
 		'highlight',
-		'filterPresenter'
+		'filterPresenter',
+		'reuseWindowCheckbox'
 	],
 	#classVars : [
+		'NavigateInPlace',
 		'UsingLayout'
 	],
 	#category : 'NewTools-MethodBrowsers-Senders',
@@ -121,7 +123,7 @@ StMethodBrowser class >> browseImplementorsOfAll: aCollectionOfSymbols [
 
 	| methods |
 	methods := aCollectionOfSymbols flatCollect: [ :sym | self implementorsOf: sym ].
-	^ self browse: methods asArray
+	^ self browse: methods asArray title: 'Implementors of ' , (', ' join: aCollectionOfSymbols)
 ]
 
 { #category : 'opening' }
@@ -208,6 +210,30 @@ StMethodBrowser class >> methods: methods [
 	^ self new
 		  methods: methods;
 		  yourself
+]
+
+{ #category : 'private' }
+StMethodBrowser class >> navigateInPlace [
+
+	^ NavigateInPlace ifNil: [ NavigateInPlace := false ]  
+]
+
+{ #category : 'private' }
+StMethodBrowser class >> navigateInPlace: aBoolean [
+
+	NavigateInPlace := aBoolean 
+]
+
+{ #category : 'private' }
+StMethodBrowser class >> navigateInPlaceSettingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #navigateInPlace)
+		label: 'Navigate in place in Method Browser';
+		description:
+			'When browsing senders/implementors/references from a Method Browser, reuse the current window instead of opening a new one';
+		target: self;
+		parent: #tools
 ]
 
 { #category : 'opening - old' }
@@ -337,7 +363,7 @@ StMethodBrowser >> connectPresenters [
 	methodList
 		whenSelectionChangedDo: [ :selection | self selectItem: selection selectedItem ];
 		whenModelChangedDo: [ self updateTitle ].
-
+	methodList navigationBlock: [ :type :val | self navigateTo: type value: val ].
 	textPresenter
 		whenSubmitDo: [ :text | self accept: text notifying: nil ];
 		whenResetDo: [ self selectItem: methodList selectedMethod ].
@@ -518,6 +544,7 @@ StMethodBrowser >> horizontalLayout [
 				   add: (SpBoxLayout newTopToBottom
 						    add: methodList;
 						    add: filterPresenter filterInputPresenter expand: false;
+						    add: reuseWindowCheckbox expand: false;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
 						    add: textPresenter;
@@ -551,7 +578,11 @@ StMethodBrowser >> initializePresenters [
 	filterPresenter := self instantiate: SpFilteringListPresenter.
 	filterPresenter matchSubstring.
 	filterPresenter display: [ :m | (self methodClassNameForItem: m) , ' >> ' , m selector ].
-
+	reuseWindowCheckbox := self newCheckBox
+		                       label: 'Reuse window';
+		                       help: 'If checked, new searches will replace current results.';
+		                       state: self class navigateInPlace;
+		                       whenChangedDo: [ :state | self class navigateInPlace: state ].
 	self initializeDropList
 ]
 
@@ -559,7 +590,8 @@ StMethodBrowser >> initializePresenters [
 StMethodBrowser >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ]
+	aWindowPresenter whenClosedDo: [ TestCase historyAnnouncer unsubscribe: methodList ].
+
 ]
 
 { #category : 'private' }
@@ -681,6 +713,28 @@ StMethodBrowser >> methods: compiledMethods asSendersOfAll: aCollectionOfSymbols
 		highlight: aCollectionOfSymbols;
 		methods: compiledMethods;
 		title: 'Senders of ' , (', ' join: aCollectionOfSymbols)
+]
+
+{ #category : 'private' }
+StMethodBrowser >> navigateInPlace [
+
+	^ self class navigateInPlace
+]
+
+{ #category : 'private' }
+StMethodBrowser >> navigateTo: aType value: anObject [
+
+	self navigateInPlace ifFalse: [
+			aType == #implementors ifTrue: [ ^ self class browseImplementorsOf: anObject ].
+			aType == #senders ifTrue: [ ^ self class browseSendersOf: anObject ].
+			aType == #references ifTrue: [ ^ self class browseReferencesOf: anObject ].
+			^ self ].
+
+	aType == #implementors ifTrue: [ self methods: (self class implementorsOf: anObject) asImplementorsOf: anObject ].
+
+	aType == #senders ifTrue: [ self methods: (self class sendersOf: anObject) asSendersOf: anObject ].
+
+	aType == #references ifTrue: [ self methods: (self class referencesOf: anObject) asReferenceTo: anObject ]
 ]
 
 { #category : 'initialization' }
@@ -897,6 +951,7 @@ StMethodBrowser >> verticalLayout [
 				   add: (SpBoxLayout newTopToBottom
 						    add: methodList;
 						    add: filterPresenter filterInputPresenter expand: false;
+						    add: reuseWindowCheckbox expand: false;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
 						    add: textPresenter;

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -212,6 +212,19 @@ StMethodBrowserTest >> testRefreshingBlockWithLiteralString [
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testReuseWindowCheckboxInitialState [
+
+	| presenter |
+	[
+		StMethodBrowser navigateInPlace: true.
+		presenter := StMethodBrowser new.
+		self assert: (presenter instVarNamed: #reuseWindowCheckbox) state.
+		StMethodBrowser navigateInPlace: false.
+		presenter := StMethodBrowser new.
+		self deny: (presenter instVarNamed: #reuseWindowCheckbox) state ] ensure: [ presenter ifNotNil: [ presenter delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testWindowTitleWithFilterRatio [
 
 	| window browser total filtered |

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -23,7 +23,8 @@ Class {
 		'listPresenter',
 		'scopes',
 		'allMessages',
-		'visitedScopes'
+		'visitedScopes',
+		'navigationBlock'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -163,8 +164,12 @@ StMethodListPresenter >> defaultScopes [
 
 { #category : 'private - actions' }
 StMethodListPresenter >> doBrowseImplementors [
-		
-	StMethodBrowser browseImplementorsOf: self selectedMethod selector
+
+	| selector |
+	selector := self selectedMethod selector.
+	navigationBlock
+		ifNotNil: [ navigationBlock value: #implementors value: selector ]
+		ifNil: [ StMethodBrowser browseImplementorsOf: selector ]
 ]
 
 { #category : 'private - actions' }
@@ -176,13 +181,21 @@ StMethodListPresenter >> doBrowseMethod [
 { #category : 'private - actions' }
 StMethodListPresenter >> doBrowseSenders [
 
-	StMethodBrowser browseSendersOf: self selectedMethod selector
+	| selector |
+	selector := self selectedMethod selector.
+	navigationBlock
+		ifNotNil: [ navigationBlock value: #senders value: selector ]
+		ifNil: [ StMethodBrowser browseSendersOf: selector ]
 ]
 
 { #category : 'private - actions' }
 StMethodListPresenter >> doBrowseUsers [
-		
-	self systemNavigation browseAllUsersOfClassOrTrait: self selectedMethod methodClass
+
+	| class |
+	class := self selectedMethod methodClass.
+	navigationBlock
+		ifNotNil: [ navigationBlock value: #references value: class ]
+		ifNil: [ self systemNavigation browseAllUsersOfClassOrTrait: class ]
 ]
 
 { #category : 'private - actions' }
@@ -339,6 +352,12 @@ StMethodListPresenter >> methods: aCollection [
 	allMessages := listPresenter items.
 
 	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]
+]
+
+{ #category : 'accessing' }
+StMethodListPresenter >> navigationBlock: aBlock [
+
+	navigationBlock := aBlock
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- This contribution allows any user to stay in the same method browser when browsing senders/implementors/users from a method browser if they want.
- New checkbox for the UX, triggering a class variable of the method browser to know if we open a new window or not (available in the Pharo settings) -New test for this feature + fix the title when browsing implementors of all

A next step could be to be able to navigate between the search results of the user

(Note: If a user look for something in the code presenter, it will ignore the `Reuse window` setting since the `SpCodePresenter` has its own methods to browse things)