### PR TITLE
Lookup for dnu entry point methods when creating DNU

### DIFF
--- a/src/NewTools-Debugger/MessageNotUnderstood.extension.st
+++ b/src/NewTools-Debugger/MessageNotUnderstood.extension.st
@@ -2,7 +2,9 @@ Extension { #name : 'MessageNotUnderstood' }
 
 { #category : '*NewTools-Debugger' }
 MessageNotUnderstood >> contextForMethodImplementation: methodCreator [
-	^methodCreator interruptedContext 
+	
+	^ methodCreator interruptedContext findContextSuchThat: [ :e |
+		e method hasPragmaNamed: #dnuEntryPoint ]
 ]
 
 { #category : '*NewTools-Debugger' }


### PR DESCRIPTION
Depends on https://github.com/pharo-project/pharo/pull/19567.

We mark the DNU methods to be able to find them and rewrite them when clicking the "implement missing method" in the debugger.