### PR TITLE
[Method Browser] Fix method list desync when filter is active during method announcements

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -439,7 +439,7 @@ StMethodBrowser >> handleClassRenamed: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
-	| item sel text boolean |
+	| item sel text boolean  |
 	self isDisplayed ifFalse: [ ^ self ].
 	refreshingBlock ifNil: [ ^ self ].
 
@@ -452,13 +452,15 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 	boolean ifTrue: [ text := textPresenter pendingText ].
 
 	sel := self selectedMethod.
-	(self methods includes: item) ifFalse: [
-			self methods: (self methods
-					 add: item asFullRingDefinition;
-					 yourself) ].
 
-	self defer: [ self selectIndex: (self methods indexOf: sel) ].
-	self selectedMessage: sel.
+	(filterPresenter unfilteredItems includes: item) ifFalse: [
+		self methods: (filterPresenter unfilteredItems copy
+			add: item asFullRingDefinition;
+			yourself) ].
+
+	self defer: [ self selectIndex: ((self methods indexOf: sel) max: 1) ].
+	sel ifNotNil: [ self selectedMessage: sel ].
+
 
 	boolean ifTrue: [ textPresenter pendingText: text ]
 ]
@@ -486,9 +488,8 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 	edits ifTrue: [ text := textPresenter pendingText ].
 	index := methodList selectedIndex.
 
-	list := self methods
-		        remove: matchingItem ifAbsent: [ ];
-		        yourself.
+	list := filterPresenter unfilteredItems copy.
+	list remove: matchingItem ifAbsent: [ ].
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
 			self methods: list.
 			self defer: [ self selectIndex: (index min: self methods size) ].
@@ -515,8 +516,6 @@ StMethodBrowser >> handleMethodRemoved: anAnnouncement [
 	matchingItem := self methods
 		                detect: [ :m | m methodClass = item methodClass and: [ m selector = item selector ] ]
 		                ifNone: [ ^ self ].
-
-	selection := methodList selectedIndex.
 	selectedMethod := self selectedMethod.
 	self methods: (self methods
 			 remove: matchingItem ifAbsent: [ ];
@@ -674,7 +673,6 @@ StMethodBrowser >> methods: compiledMethods asImplementorsOf: aSymbol [
 
 { #category : 'api - instance side' }
 StMethodBrowser >> methods: compiledMethods asReferenceTo: aClassName [
-	"Create without opening it a method browsers for the implementors of a Symbol"
 
 	self
 		setRefreshingBlockForClassReferencesOf: aClassName;
@@ -858,7 +856,7 @@ StMethodBrowser >> setRefreshingBlockForImplementorsOf: aSelector [
 	self refreshingBlock: [ :message | message selector = aSelector ]
 ]
 
-{ #category : 'initialization' }
+{ #category : 'api' }
 StMethodBrowser >> setRefreshingBlockForReferencesToSlot: aSlot [
 
 	self refreshingBlock: [ :method | method accessesSlot: aSlot ]
@@ -983,6 +981,7 @@ StMethodBrowser >> windowTitle [
 
 	| msg total |
 	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
+	self methods ifEmpty: [ ^ 'No Results' ].
 	total := filterPresenter unfilteredItems size.
 	msg := methodList ifNil: [ '' ] ifNotNil: [
 			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -120,6 +120,27 @@ StMethodBrowserTest >> testHandleMethodAddedAddsMatchingSender [
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems [
+
+	| window browser total newMethod |
+	[
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+
+		total := browser filterPresenter unfilteredItems size.
+		self assert: total > 0.
+		browser filterPresenter filterInputPresenter text: 'zzznomatch'.
+		self assert: browser methodList numberOfElements equals: 0.
+		self class compile: 'tmpSenderMethodForTest ^ self printOn: String new' classified: 'tests-protocol'.
+		newMethod := self class >> #tmpSenderMethodForTest.
+		browser handleMethodAdded: (MethodAdded method: newMethod).
+
+		self assert: browser filterPresenter unfilteredItems size > total ] ensure: [
+			self class removeSelector: #tmpSenderMethodForTest.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodModifiedRemovesSenderWhenNoLongerMatching [
 
 	| window browser method |


### PR DESCRIPTION
`handleMethodAdded:` and `handleMethodModified:` were operating on the filtered list (self methods) instead of the unfilteredItems, causing methods outside the current filter to be silently dropped when a code change was announced. 
Fixed by always reading/writing through unfilteredItems and working on a copy before calling self methods:

And of course new test to deny regression on this behavior

Also fixed:
- duplicate selectedIndex assignment in handleMethodRemoved:
- windowTitle now shows 'No results' when the list is empty
- cleaning code comment and protocol