### PR TITLE
[Method Browser] Refreshing block for `Implementors of all`

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -53,6 +53,14 @@ StMethodBrowser class >> browse: compiledMethods asImplementorsOf: aSymbol [
 ]
 
 { #category : 'opening explicit' }
+StMethodBrowser class >> browse: compiledMethods asImplementorsOfAll: aCollectionOfSymbols [
+
+	^ self new
+		  methods: compiledMethods asImplementorsOfAll: aCollectionOfSymbols;
+		  open
+]
+
+{ #category : 'opening explicit' }
 StMethodBrowser class >> browse: compiledMethods asReferencesToClass: aClass [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
@@ -123,7 +131,7 @@ StMethodBrowser class >> browseImplementorsOfAll: aCollectionOfSymbols [
 
 	| methods |
 	methods := aCollectionOfSymbols flatCollect: [ :sym | self implementorsOf: sym ].
-	^ self browse: methods asArray title: 'Implementors of ' , (', ' join: aCollectionOfSymbols)
+	^ self browse: methods asArray asImplementorsOfAll: aCollectionOfSymbols
 ]
 
 { #category : 'opening' }
@@ -673,6 +681,16 @@ StMethodBrowser >> methods: compiledMethods asImplementorsOf: aSymbol [
 ]
 
 { #category : 'api - instance side' }
+StMethodBrowser >> methods: compiledMethods asImplementorsOfAll: aCollectionOfSymbols [
+
+	self
+		setRefreshingBlockForImplementorsOfAll: aCollectionOfSymbols;
+		highlight: aCollectionOfSymbols;
+		methods: compiledMethods;
+		title: 'Implementors of ' , (', ' join: aCollectionOfSymbols)
+]
+
+{ #category : 'api - instance side' }
 StMethodBrowser >> methods: compiledMethods asReferenceTo: aClassName [
 	"Create without opening it a method browsers for the implementors of a Symbol"
 
@@ -856,6 +874,12 @@ StMethodBrowser >> setRefreshingBlockForClassReferencesOf: aString [
 StMethodBrowser >> setRefreshingBlockForImplementorsOf: aSelector [
 
 	self refreshingBlock: [ :message | message selector = aSelector ]
+]
+
+{ #category : 'api' }
+StMethodBrowser >> setRefreshingBlockForImplementorsOfAll: aCollectionOfSymbols [
+
+	self refreshingBlock: [ :message | aCollectionOfSymbols anySatisfy: [ :sel | message selector = sel ] ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
There was no check for any item when doing `Implementors of all`, meaning every method added/modified was included in the items after the refresh, even if they had no link with the context.