### PR TITLE
[Method Browser] Refactoring command migration

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -343,6 +343,12 @@ StMethodBrowser >> addHighlightedSegments [
 					 yourself) ]
 ]
 
+{ #category : 'private - scopes' }
+StMethodBrowser >> allScopes [ 
+	
+	^ methodList allScopes
+]
+
 { #category : 'to remove' }
 StMethodBrowser >> autoSelect: aString [
 	"this is just to absorb system navigation for now"
@@ -354,6 +360,12 @@ StMethodBrowser >> classRenamed: anAnnouncement [
 	"this method forces the announcement to be handled in the UI process"
 	self defer: [ 
 		self handleClassRenamed: anAnnouncement ]
+]
+
+{ #category : 'accessing' }
+StMethodBrowser >> codePresenter [
+
+	^ textPresenter
 ]
 
 { #category : 'initialization' }
@@ -571,7 +583,8 @@ StMethodBrowser >> initializePresenters [
 
 	super initializePresenters.
 
-	textPresenter := self newCode.
+	textPresenter := self instantiate: StMethodCodePresenter.
+	textPresenter methodBrowser: self.
 	refreshingBlock := [ :item | true ].
 	filterPresenter := self instantiate: SpFilteringListPresenter.
 	filterPresenter matchSubstring.

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -18,8 +18,7 @@ Class {
 		'refreshingBlock',
 		'textPresenter',
 		'highlight',
-		'filterPresenter',
-		'reuseWindowCheckbox'
+		'filterPresenter'
 	],
 	#classVars : [
 		'NavigateInPlace',
@@ -544,7 +543,6 @@ StMethodBrowser >> horizontalLayout [
 				   add: (SpBoxLayout newTopToBottom
 						    add: methodList;
 						    add: filterPresenter filterInputPresenter expand: false;
-						    add: reuseWindowCheckbox expand: false;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
 						    add: textPresenter;
@@ -578,11 +576,7 @@ StMethodBrowser >> initializePresenters [
 	filterPresenter := self instantiate: SpFilteringListPresenter.
 	filterPresenter matchSubstring.
 	filterPresenter display: [ :m | (self methodClassNameForItem: m) , ' >> ' , m selector ].
-	reuseWindowCheckbox := self newCheckBox
-		                       label: 'Reuse window';
-		                       help: 'If checked, new searches will replace current results.';
-		                       state: self class navigateInPlace;
-		                       whenChangedDo: [ :state | self class navigateInPlace: state ].
+
 	self initializeDropList
 ]
 
@@ -951,7 +945,6 @@ StMethodBrowser >> verticalLayout [
 				   add: (SpBoxLayout newTopToBottom
 						    add: methodList;
 						    add: filterPresenter filterInputPresenter expand: false;
-						    add: reuseWindowCheckbox expand: false;
 						    yourself);
 				   add: (SpBoxLayout newTopToBottom
 						    add: textPresenter;

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -214,14 +214,17 @@ StMethodBrowserTest >> testRefreshingBlockWithLiteralString [
 { #category : 'tests' }
 StMethodBrowserTest >> testReuseWindowCheckboxInitialState [
 
-	| presenter |
+	| presenter initialSetting |
+	initialSetting := StMethodBrowser navigateInPlace.
 	[
 		StMethodBrowser navigateInPlace: true.
 		presenter := StMethodBrowser new.
-		self assert: (presenter instVarNamed: #reuseWindowCheckbox) state.
+		self assert: presenter toolbarPresenter reuseWindowButton state.
 		StMethodBrowser navigateInPlace: false.
 		presenter := StMethodBrowser new.
-		self deny: (presenter instVarNamed: #reuseWindowCheckbox) state ] ensure: [ presenter ifNotNil: [ presenter delete ] ]
+		self deny: presenter toolbarPresenter reuseWindowButton state ] ensure: [
+			StMethodBrowser navigateInPlace: initialSetting.
+			presenter ifNotNil: [ presenter delete ] ]
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -39,6 +39,9 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		         beDisplayedAsSubMenu;
 		         iconName: #smallAuthoringTools;
 		         yourself.
-	{ StRenameClassCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+	{
+		StRenameClassCommand.
+		StExtractTempCommand.
+		StConvertTempToInstVarCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -1,0 +1,44 @@
+"
+I represent a code presenter used for the method browser, as I provide a refactoring command group
+"
+Class {
+	#name : 'StMethodCodePresenter',
+	#superclass : 'SpCodePresenter',
+	#instVars : [
+		'methodBrowser'
+	],
+	#category : 'NewTools-MethodBrowsers-Base',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Base'
+}
+
+{ #category : 'commands' }
+StMethodCodePresenter class >> buildCommandsGroupWith: presenter forRoot: aCmCommandsGroup [
+
+	presenter methodBrowser ifNotNil: [ aCmCommandsGroup register: presenter refactoringCommandsGroup ].
+	super buildCommandsGroupWith: presenter forRoot: aCmCommandsGroup
+]
+
+{ #category : 'accessing' }
+StMethodCodePresenter >> methodBrowser [
+
+	^ methodBrowser
+]
+
+{ #category : 'accessing' }
+StMethodCodePresenter >> methodBrowser: aBrowser [
+
+	methodBrowser := aBrowser
+]
+
+{ #category : 'intialization' }
+StMethodCodePresenter >> refactoringCommandsGroup [
+
+	| group |
+	group := (CmCommandGroup named: 'Source Code') asSpecGroup
+		         beDisplayedAsSubMenu;
+		         iconName: #smallAuthoringTools;
+		         yourself.
+	{ StRenameClassCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+	^ group
+]

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -15,7 +15,8 @@ Class {
 		'versionButton',
 		'dropList',
 		'toolbarPresenter',
-		'messageList'
+		'messageList',
+		'reuseWindowButton'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -97,48 +98,67 @@ StMethodToolbarPresenter >> emptyDropList [
 	dropList emptyList
 ]
 
+{ #category : 'as yet unclassified' }
+StMethodToolbarPresenter >> iconForReuseState: aBoolean [
+
+	^ aBoolean
+		  ifTrue: [ self iconNamed: #checkboxSelected ]
+		  ifFalse: [ self iconNamed: #checkboxUnselected ]
+]
+
 { #category : 'initialization' }
 StMethodToolbarPresenter >> initializePresenters [
 
 	(browseButton := self newToolbarButton)
-		label: 'Browse'; 
+		label: 'Browse';
 		icon: (self iconNamed: #smallSystemBrowser);
 		help: 'Browse current selected method';
 		action: [ self doBrowseMethod ].
-	(usersButton := self newToolbarButton) 
-		label: 'References'; 
+	(usersButton := self newToolbarButton)
+		label: 'References';
 		icon: (self iconNamed: #smallFind);
 		help: 'Browse references of current selected class';
 		action: [ self doBrowseUsers ].
-	(sendersButton := self newToolbarButton) 
-		label: 'Senders'; 
+	(sendersButton := self newToolbarButton)
+		label: 'Senders';
 		icon: (self iconNamed: #smallFind);
 		help: 'Browse senders of current selected method';
 		action: [ self doBrowseSenders ].
-	(implementorsButton := self newToolbarButton) 
-		label: 'Implementors'; 
+	(implementorsButton := self newToolbarButton)
+		label: 'Implementors';
 		icon: (self iconNamed: #smallFind);
 		help: 'Browse implementors of current selected method';
 		action: [ self doBrowseImplementors ].
-	(versionButton := self newToolbarButton) 
-		label: 'Versions'; 
+	(versionButton := self newToolbarButton)
+		label: 'Versions';
 		icon: (self iconNamed: #history);
 		help: 'Browse versions of current selected method';
 		action: [ self doBrowseVersions ].
-		
- 	toolbarPresenter := self newToolbar
-		displayMode: self application toolbarDisplayMode;
-		add: browseButton;
-		add: usersButton;
-		add: sendersButton;
-		add: implementorsButton;
-		add: versionButton;
-		yourself.
-		
+	reuseWindowButton := self newToolbarToggleButton
+		                     label: 'Reuse window';
+		                     help: 'If checked, new searches will replace current results.';
+		                     state: StMethodBrowser navigateInPlace;
+		                     icon: (self iconForReuseState: StMethodBrowser navigateInPlace);
+		                     whenActivatedDo: [
+				                     StMethodBrowser navigateInPlace: true.
+				                     reuseWindowButton icon: (self iconForReuseState: true) ];
+		                     whenDeactivatedDo: [
+				                     StMethodBrowser navigateInPlace: false.
+				                     reuseWindowButton icon: (self iconForReuseState: false) ].
+	toolbarPresenter := self newToolbar
+		                    displayMode: self application toolbarDisplayMode;
+		                    add: browseButton;
+		                    add: usersButton;
+		                    add: sendersButton;
+		                    add: implementorsButton;
+		                    add: versionButton;
+		                    add: reuseWindowButton;
+		                    yourself.
+
 	dropList := self newDropList
-		display: [ :item | item label ];
-		whenSelectedItemChangedDo: [ :item | item value ];
-		yourself
+		            display: [ :item | item label ];
+		            whenSelectedItemChangedDo: [ :item | item value ];
+		            yourself
 ]
 
 { #category : 'accessing' }
@@ -164,6 +184,12 @@ StMethodToolbarPresenter >> replaceVersionWithLabel: aString action: aBlock [
 	versionButton 
 		label: aString;
 		action: aBlock
+]
+
+{ #category : 'accessing' }
+StMethodToolbarPresenter >> reuseWindowButton [
+
+	^ reuseWindowButton
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Start of refactoring commands migration from Calypso to Spec !
This is a good setup in order to use them for the MethodBrowser ( not for playground or anything else yet, we need to provide a unified API so the commands don't raise errors).
If there are broken tests it may be because the command classes need to be merged in Spec repository.