### PR TITLE
1398-StDebuggerContextInteractionModelinitialize-needs-to-be-categorized 

### DIFF
--- a/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
+++ b/src/NewTools-Debugger/StDebuggerContextInteractionModel.class.st
@@ -78,7 +78,7 @@ StDebuggerContextInteractionModel >> hasBindingOf: aString [
 		  self hasBindingInInteractionModelOf: aString ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'initialization' }
 StDebuggerContextInteractionModel >> initialize [
 
 	super initialize.


### PR DESCRIPTION
Fix the category of #initialize