### PR TITLE
New command for Spec refactorings

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -27,10 +27,11 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Gtk';
 			
 			"Basic tools (inherited from Spec)"
-			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' 'NewTools-Refactoring-Commands') ];
-			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
 			package: 'NewTools-Refactoring-Commands' with: [ spec requires: #('NewTools-Core' ) ];
 			package: 'NewTools-Refactoring-Commands-Tests' with: [ spec requires: #( 'NewTools-Refactoring-Commands' ) ];
+			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' 'NewTools-Refactoring-Commands') ];
+			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
+		
 			
 			"inspector"
 			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector-Extensions' ) ];

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -29,6 +29,8 @@ BaselineOfNewTools >> baseline: spec [
 			"Basic tools (inherited from Spec)"
 			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
 			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
+			package: 'NewTools-Refactoring-Commands' with: [ spec requires: #('NewTools-Core' ) ];
+			package: 'NewTools-Refactoring-Commands-Tests' with: [ spec requires: #( 'NewTools-Refactoring-Commands' ) ];
 			
 			"inspector"
 			package: 'NewTools-Inspector' with: [ spec requires: #( 'NewTools-Core' 'NewTools-Inspector-Extensions' ) ];
@@ -221,7 +223,9 @@ BaselineOfNewTools >> baseline: spec [
 
 			group: 'Methods' with: #( 'Core' 'NewTools-SpTextPresenterDecorators' 'NewTools-MethodBrowsers' );
 			"Not in the image for the moment, we need a pass on them"
-
+			
+			group: 'Commands' with: #( 'Core' 'NewTools-Refactoring-Commands' 'NewTools-Refactoring-Commands-Tests');
+			 
 			group: 'CritiqueBrowser' with: #( 'NewTools-CodeCritiques' 'NewTools-CodeCritiques-Tests' );
 
 			group: 'FontChooser' with: #( 'Core' 'NewTools-FontChooser' 'NewTools-FontChooser-Tests' );

--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -27,7 +27,7 @@ BaselineOfNewTools >> baseline: spec [
 			package: 'NewTools-Gtk';
 			
 			"Basic tools (inherited from Spec)"
-			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' ) ];
+			package: 'NewTools-MethodBrowsers' with: [ spec requires: #('NewTools-Core' 'NewTools-SpTextPresenterDecorators' 'NewTools-Refactoring-Commands') ];
 			package: 'NewTools-MethodBrowsers-Tests' with: [ spec requires: #( 'NewTools-MethodBrowsers' ) ];
 			package: 'NewTools-Refactoring-Commands' with: [ spec requires: #('NewTools-Core' ) ];
 			package: 'NewTools-Refactoring-Commands-Tests' with: [ spec requires: #( 'NewTools-Refactoring-Commands' ) ];

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -39,6 +39,7 @@ StMethodBrowser class >> beDefaultBrowser [
 
 { #category : 'opening - old' }
 StMethodBrowser class >> browse: aCollection [
+	"Basic version. Opens a browser on the given collection of methods without setting a title or refreshing block."
 
 	^ (self methods: aCollection) open
 ]
@@ -84,6 +85,7 @@ StMethodBrowser class >> browse: compiledMethods asSendersOf: aSymbol [
 
 { #category : 'opening explicit' }
 StMethodBrowser class >> browse: compiledMethods asSendersOfAll: aCollectionOfSymbols [
+	"Specialized version for better UX feedback for senders of all given selectors."
 
 	^ self new
 		  methods: compiledMethods asSendersOfAll: aCollectionOfSymbols;
@@ -102,19 +104,19 @@ StMethodBrowser class >> browse: aCollection title: aString [
 
 { #category : 'opening - old' }
 StMethodBrowser class >> browse: aCollection title: aString highlight: aSelectString [
-	"Special Version that sets the correct refreshing Block for Implentors Browser"
-	
+	"Basic version with limited UX feedback that highlights a specific string in the source code."
+
 	^ self new
-		methods: aCollection;
-		title: aString;
-		highlight: aSelectString;
-		open
+		  methods: aCollection;
+		  title: aString;
+		  highlight: aSelectString;
+		  open
 ]
 
 { #category : 'opening' }
-StMethodBrowser class >> browseImplementorsOf: aSymbol [ 
-	"Special Version that sets the correct refreshing Block for Implentors Browser"
-	
+StMethodBrowser class >> browseImplementorsOf: aSymbol [
+	"Opens a browser on all implementors of aSymbol. Sets the refreshing block to keep the list up to date."
+
 	^ self browse: (self implementorsOf: aSymbol) asImplementorsOf: aSymbol
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -46,6 +46,10 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		StInlineMethodCommand.
 		StRenameArgOrTempCommand.
 		StGenerateVariableAccessorCommand.
-		StMoveInstanceVariableToClassSideCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+		StMoveInstanceVariableToClassSideCommand.
+		StPushUpVariableCommand.
+		StPushDownVariableCommand.
+		StRemoveVariableCommand.
+		StProtectVariableCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReConvertTemporaryToInstanceVariableCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'ReConvertTemporaryToInstanceVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReConvertTemporaryToInstanceVariableCommandTest >> testConvertTempCommandSuccess [
+
+	| driver command context |
+	command := StConvertTempToInstVarCommand new.
+	context := StCommandContextMock new
+		           name: #temp;
+		           behavior: ReClassToConvertTemporaryToInstanceVariable;
+		           selector: #doAction1.
+	context method: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReExtractTempCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReExtractTempCommandTest.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'ReExtractTempCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReExtractTempCommandTest >> testExtractTempCommandSuccess [
+
+	| driver command context dialogMock |
+	command := StExtractTempCommand new.
+	context := StCommandContextMock new
+		           sourceInterval: (63 to: 78);
+		           selector: #rewriteUsing:;
+		           behavior: RBTransformationRuleTestData.
+	context method: context.
+	command context: context.
+
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'tmp22'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReGenerateVariableAccessorCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReGenerateVariableAccessorCommandTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'ReGenerateVariableAccessorCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReGenerateVariableAccessorCommandTest >> testGenerateAccessorCommandSuccess [
+
+	| driver command context |
+	command := StGenerateVariableAccessorCommand new.
+	context := StCommandContextMock new
+		           behavior: RBTransformationRuleTestData;
+		           name: #builder.
+	context method: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReInlineMethodCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'ReInlineMethodCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReInlineMethodCommandTest >> testInlineMethodCommandSuccess [
+
+	| driver command context |
+	command := StInlineMethodCommand new.
+	context := StCommandContextMock new
+		           sourceInterval: (63 to: 78);
+		           selector: #rewriteUsing:;
+		           behavior: RBTransformationRuleTestData.
+	context method: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReMoveInstanceVariableToClassSideTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReMoveInstanceVariableToClassSideTest.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : 'ReMoveInstanceVariableToClassSideTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReMoveInstanceVariableToClassSideTest >> testMoveInstanceVariableToClassSideCommandSuccess [
+
+	| driver command context ast node method |
+	command := StMoveInstanceVariableToClassSideCommand new.
+	method := RBTransformationRuleTestData >> #isEmpty.
+	ast := OpalCompiler new
+		       class: method methodClass;
+		       parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'builder' ] ].
+	context := StCommandContextMock new variable: node variable.
+	context selectedMethod: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReProtectVariableCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReProtectVariableCommandTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'ReProtectVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReProtectVariableCommandTest >> testPushUpVariableToClassSideCommandSuccess [
+
+	| driver command context ast node method |
+	command := StProtectVariableCommand new.
+	method := RBBasicLintRuleTestData >> #result.
+	ast := OpalCompiler new
+		       class: method methodClass;
+		       parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'result' ] ].
+	context := StCommandContextMock new
+		           variable: node variable;
+		           behavior: RBBasicLintRuleTestData.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands-Tests/RePushUpVariableCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/RePushUpVariableCommandTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'RePushUpVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+RePushUpVariableCommandTest >> testPushUpVariableToClassSideCommandSuccess [
+
+	| driver command context ast node method |
+	command := StPushUpVariableCommand new.
+	method := RBTransformationRuleTestData >> #isEmpty.
+	ast := OpalCompiler new
+		       class: method methodClass;
+		       parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'builder' ] ].
+	context := StCommandContextMock new
+		           variable: node variable;
+		           behavior: RBTransformationRuleTestData.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 2
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReRemoveVariableCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReRemoveVariableCommandTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'ReRemoveVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRemoveVariableCommandTest >> testRemoveVariableToClassSideCommandSuccess [
+
+	| driver command context |
+	command := StRemoveVariableCommand new.
+	context := StCommandContextMock new
+		           name: 'foo1';
+		           behavior: RBLintRuleTestData .
+	context variable: context.
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReRenameArgOrTempCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReRenameArgOrTempCommandTest.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'ReRenameArgOrTempCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameArgOrTempCommandTest >> testRenameArgOrTempCommandSuccess [
+
+	| driver command context method ast node dialogMock |
+	method := ReClassToConvertTemporaryToInstanceVariable >> #doAction1.
+	ast := OpalCompiler new parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'temp' ] ].
+
+	command := StRenameArgOrTempCommand new.
+	context := StCommandContextMock new
+		           method: method;
+		           selectedNode: node.
+	command context: context.
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'tmp2'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReRenameClassCommandTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'ReRenameClassCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameClassCommandTest >> testRenameClassCommandSuccess [
+
+	| driver command context dialogMock |
+	command := StRenameClassCommand new.
+	context := StCommandContextMock new name: #ReClassToConvertTemporaryToInstanceVariable.
+	command context: context.
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'NewClassNameForTest'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 6.
+
+]

--- a/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -1,0 +1,167 @@
+Class {
+	#name : 'StCommandContextMock',
+	#superclass : 'Object',
+	#instVars : [
+		'selectedMethod',
+		'name',
+		'sourceInterval',
+		'selector',
+		'origin',
+		'selectedNode',
+		'variable',
+		'behavior',
+		'method'
+	],
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'private - scopes' }
+StCommandContextMock >> allScopes [
+
+	^ { RBBrowserEnvironment default }
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> application [
+
+	^ StPharoApplication new
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> behavior [
+
+	^ behavior
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> behavior: aBehavior [
+
+	behavior := aBehavior
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> codeEditor [
+
+	^ self
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> codePresenter [
+
+^ self
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> interactionModel [
+
+	^ self
+]
+
+{ #category : 'testing' }
+StCommandContextMock >> isClassVariable [
+
+	^ false
+]
+
+{ #category : 'testing' }
+StCommandContextMock >> isInstanceSide [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> method [
+
+	^ method
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> method: anObject [
+
+	method := anObject
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> name [
+
+	^ name
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> name: aName [
+
+	name := aName
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> origin [
+
+	^ origin
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> origin: aClass [
+
+	origin := aClass 
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedMethod [
+
+	^ selectedMethod
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedMethod: aCompiledMethod [
+
+	selectedMethod := aCompiledMethod
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedNode [
+
+	^ selectedNode ifNil: [ self ]
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selectedNode: aNode [
+
+	selectedNode := aNode
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selector [
+
+	^ selector
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> selector: aSelector [
+
+	selector := aSelector
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> sourceInterval [
+
+	^ sourceInterval
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> sourceInterval: anInterval [
+
+	sourceInterval := anInterval
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> variable [
+
+	^ variable
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> variable: aVariable [
+
+	variable := aVariable
+]

--- a/src/NewTools-Refactoring-Commands-Tests/package.st
+++ b/src/NewTools-Refactoring-Commands-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Refactoring-Commands-Tests' }

--- a/src/NewTools-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
@@ -1,0 +1,43 @@
+"
+I am a command to convert a temp variable in instance variable.
+"
+Class {
+	#name : 'StConvertTempToInstVarCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StConvertTempToInstVarCommand class >> defaultDescription [
+
+	^ 'Convert selected temporary variable into a new instance variable'
+]
+
+{ #category : 'accessing' }
+StConvertTempToInstVarCommand class >> defaultIconName [
+
+	^ #smallRedo
+]
+
+{ #category : 'default' }
+StConvertTempToInstVarCommand class >> defaultName [
+
+	^ '(R) Convert to Instance Var'
+]
+
+{ #category : 'testing' }
+StConvertTempToInstVarCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isTempVariable
+]
+
+{ #category : 'executing' }
+StConvertTempToInstVarCommand >> prepareDriver [
+
+	^ (ReConvertTemporaryToInstanceVariableDriver newApplication: self application)
+		  scopes: context allScopes
+		  class: self codePresenter behavior
+		  selector: self codePresenter interactionModel method selector
+		  variable: self codePresenter selectedNode name
+]

--- a/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
@@ -1,0 +1,43 @@
+"
+Extract selected interval into a temporary variable from a code presenter 
+"
+Class {
+	#name : 'StExtractTempCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StExtractTempCommand class >> defaultDescription [
+
+	^ 'Extract the selected code into a new temporary variable'
+]
+
+{ #category : 'accessing' }
+StExtractTempCommand class >> defaultIconName [
+
+	^ #smallUpdate
+]
+
+{ #category : 'default' }
+StExtractTempCommand class >> defaultName [
+
+	^ 'Extract temp'
+]
+
+{ #category : 'testing' }
+StExtractTempCommand >> canBeExecuted [
+
+	^ self codePresenter selectionInterval isNotEmpty
+]
+
+{ #category : 'executing' }
+StExtractTempCommand >> prepareDriver [
+
+	^ (ReExtractTempDriver newApplication: self application)
+		  extract: self codePresenter selectedNode sourceInterval
+		  from: self codePresenter interactionModel method selector
+		  in: self codePresenter behavior;
+		  scopes: context allScopes
+]

--- a/src/NewTools-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
@@ -1,0 +1,37 @@
+"
+I am a command to generate accessors for given variables
+"
+Class {
+	#name : 'StGenerateVariableAccessorCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StGenerateVariableAccessorCommand class >> defaultDescription [
+
+	^ 'Generate accessor for the selected instance variable'
+]
+
+{ #category : 'default' }
+StGenerateVariableAccessorCommand class >> defaultIconName [
+
+	^ #smallAdd
+]
+
+{ #category : 'default' }
+StGenerateVariableAccessorCommand class >> defaultName [
+
+	^ '(T) Generate accessor'
+]
+
+{ #category : 'executing' }
+StGenerateVariableAccessorCommand >> prepareDriver [
+
+	^ (ReGenerateAccessorsDriver newApplication: self application)
+		  targetClass: self codePresenter behavior;
+		  scopes: context allScopes
+		  scopeInstanceSide: self codePresenter behavior isInstanceSide
+		  selectedVariables: { self codePresenter selectedNode name }
+]

--- a/src/NewTools-Refactoring-Commands/StInlineMethodCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StInlineMethodCommand.class.st
@@ -1,0 +1,42 @@
+"
+I am a command to inline ""self send"" method directly into sender method
+"
+Class {
+	#name : 'StInlineMethodCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StInlineMethodCommand class >> defaultDescription [
+
+	^ 'Inline "self send" method directly into sender method'
+]
+
+{ #category : 'accessing' }
+StInlineMethodCommand class >> defaultIconName [
+	^ #smallRightFlush
+]
+
+{ #category : 'default' }
+StInlineMethodCommand class >> defaultName [
+
+	^ 'Inline method'
+]
+
+{ #category : 'testing' }
+StInlineMethodCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isMessage
+]
+
+{ #category : 'executing' }
+StInlineMethodCommand >> prepareDriver [
+
+	^ (ReInlineMethodDriver newApplication: self application)
+		  scopes: context allScopes
+		  interval: self codePresenter selectedNode sourceInterval
+		  selector: self codePresenter interactionModel method selector
+		  class: self codePresenter behavior
+]

--- a/src/NewTools-Refactoring-Commands/StMoveInstanceVariableToClassSideCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StMoveInstanceVariableToClassSideCommand.class.st
@@ -1,0 +1,34 @@
+"
+I am a command to move given instance variable to its class side
+"
+Class {
+	#name : 'StMoveInstanceVariableToClassSideCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StMoveInstanceVariableToClassSideCommand class >> defaultDescription [
+
+	^ 'Move the selected instance variable to the class side of its own class'
+]
+
+{ #category : 'accessing' }
+StMoveInstanceVariableToClassSideCommand class >> defaultIconName [
+	^ #smallRedo
+]
+
+{ #category : 'default' }
+StMoveInstanceVariableToClassSideCommand class >> defaultName [
+
+	^ '(T) Move to class side'
+]
+
+{ #category : 'executing' }
+StMoveInstanceVariableToClassSideCommand >> prepareDriver [
+
+	^ (ReMoveVariablesToClassSideDriver newApplication: self application)
+		  scopes: context allScopes
+		  variables: { self codePresenter selectedNode variable }
+]

--- a/src/NewTools-Refactoring-Commands/StProtectVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StProtectVariableCommand.class.st
@@ -1,0 +1,36 @@
+"
+I am a command to protect given variables
+"
+Class {
+	#name : 'StProtectVariableCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StProtectVariableCommand class >> defaultDescription [
+
+	^ 'Inline all calls of accessors of selected instance variable'
+]
+
+{ #category : 'accessing' }
+StProtectVariableCommand class >> defaultIconName [
+
+	^ #group
+]
+
+{ #category : 'default' }
+StProtectVariableCommand class >> defaultName [
+
+	^ '(R) Protect'
+]
+
+{ #category : 'executing' }
+StProtectVariableCommand >> prepareDriver [
+
+	^ (ReProtectInstanceVariableDriver newApplication: self application)
+		  scopes: context allScopes
+		  variable: self codePresenter selectedNode variable
+		  class: self codePresenter behavior
+]

--- a/src/NewTools-Refactoring-Commands/StPushDownVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StPushDownVariableCommand.class.st
@@ -1,0 +1,35 @@
+"
+I am a command to push down given variables
+"
+Class {
+	#name : 'StPushDownVariableCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StPushDownVariableCommand class >> defaultDescription [
+
+	^ 'Push down the selected instance variable'
+]
+
+{ #category : 'accessing' }
+StPushDownVariableCommand class >> defaultIconName [
+
+	^ #down
+]
+
+{ #category : 'default' }
+StPushDownVariableCommand class >> defaultName [
+
+	^ '(R) Push down'
+]
+
+{ #category : 'executing' }
+StPushDownVariableCommand >> prepareDriver [
+
+	^ (RePushDownInstanceVariableDriver newApplication: self application)
+		  scopes: context allScopes;
+		  variables: {self codePresenter selectedNode variable}
+]

--- a/src/NewTools-Refactoring-Commands/StPushUpVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StPushUpVariableCommand.class.st
@@ -1,0 +1,35 @@
+"
+I am a command to push up given variables
+"
+Class {
+	#name : 'StPushUpVariableCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StPushUpVariableCommand class >> defaultDescription [
+
+	^ 'Push up the selected instance variable'
+]
+
+{ #category : 'accessing' }
+StPushUpVariableCommand class >> defaultIconName [
+
+	^ #up
+]
+
+{ #category : 'default' }
+StPushUpVariableCommand class >> defaultName [
+	^'(R) Push up'
+]
+
+{ #category : 'executing' }
+StPushUpVariableCommand >> prepareDriver [
+
+	^ (RePushUpVariableDriver newApplication: self application)
+		  scopes: context allScopes
+		  variables: {self codePresenter selectedNode variable}
+		  to: self codePresenter behavior superclass
+]

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -1,0 +1,28 @@
+"
+I'm a base command for refactorings. 
+My children will define commands for refactoring support in spec
+"
+Class {
+	#name : 'StRefactoringCommand',
+	#superclass : 'StCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StRefactoringCommand >> codePresenter [
+
+	^ context codeEditor codePresenter
+]
+
+{ #category : 'executing' }
+StRefactoringCommand >> execute [
+
+	self prepareDriver runRefactoring
+]
+
+{ #category : 'executing' }
+StRefactoringCommand >> prepareDriver [
+
+	^ self subclassResponsibility
+]

--- a/src/NewTools-Refactoring-Commands/StRefactoringVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringVariableCommand.class.st
@@ -1,0 +1,21 @@
+"
+I am a base class for command which perform particular kind refactoring on given variable.
+"
+Class {
+	#name : 'StRefactoringVariableCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'testing' }
+StRefactoringVariableCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isInstanceVariable and: [ self codePresenter selectedNode isGlobalVariable not ]
+]
+
+{ #category : 'executing' }
+StRefactoringVariableCommand >> prepareDriver [
+
+	^ self subclassResponsibility 
+]

--- a/src/NewTools-Refactoring-Commands/StRemoveVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRemoveVariableCommand.class.st
@@ -1,0 +1,45 @@
+"
+I am a command that is used for removing variables.
+
+My responsibility is to delegate removal execution to the remove variable driver.
+"
+Class {
+	#name : 'StRemoveVariableCommand',
+	#superclass : 'StRefactoringVariableCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRemoveVariableCommand class >> defaultDescription [
+
+	^ 'Remove selected variable'
+]
+
+{ #category : 'accessing' }
+StRemoveVariableCommand class >> defaultIconName [
+
+	^ #remove
+]
+
+{ #category : 'default' }
+StRemoveVariableCommand class >> defaultName [
+
+	^ '(R) Remove'
+]
+
+{ #category : 'executing' }
+StRemoveVariableCommand >> prepareDriver [
+
+	self codePresenter selectedNode variable isClassVariable
+		ifFalse: [
+				^ ReRemoveInstanceVariablesDriver new
+					  scopes: context allScopes
+					  variables: { self codePresenter selectedNode variable name }
+					  for: self codePresenter behavior ]
+		ifTrue: [
+				^ ReRemoveSharedVariablesDriver new
+					  scopes: context allScopes
+					  variables: { self codePresenter selectedNode variable name }
+					  for: self codePresenter behavior ]
+]

--- a/src/NewTools-Refactoring-Commands/StRenameArgOrTempCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameArgOrTempCommand.class.st
@@ -1,0 +1,45 @@
+"
+I am a command to rename temp variable in given method.
+ 
+
+"
+Class {
+	#name : 'StRenameArgOrTempCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRenameArgOrTempCommand class >> defaultDescription [
+
+	^ 'Rename the selected temporary variable or arg'
+]
+
+{ #category : 'accessing' }
+StRenameArgOrTempCommand class >> defaultIconName [
+
+	^ #edit
+]
+
+{ #category : 'default' }
+StRenameArgOrTempCommand class >> defaultName [
+
+	^ '(R) Rename temp'
+]
+
+{ #category : 'testing' }
+StRenameArgOrTempCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isTempVariable or: [ self codePresenter selectedNode isArgumentVariable ]
+]
+
+{ #category : 'executing' }
+StRenameArgOrTempCommand >> prepareDriver [
+
+	^ ReRenameArgumentOrTemporaryDriver new
+		  sourceNode: self codePresenter selectedNode;
+		  method: self codePresenter interactionModel method;
+		  scopes: context allScopes;
+		  yourself
+]

--- a/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
@@ -1,0 +1,43 @@
+"
+Rename selected class from a code presenter
+"
+Class {
+	#name : 'StRenameClassCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRenameClassCommand class >> defaultDescription [
+
+	^ 'Rename selected class'
+]
+
+{ #category : 'accessing' }
+StRenameClassCommand class >> defaultIconName [
+
+	^ #edit 
+]
+
+{ #category : 'default' }
+StRenameClassCommand class >> defaultName [
+
+	^ '(R) Rename'
+]
+
+{ #category : 'testing' }
+StRenameClassCommand >> canBeExecuted [
+
+	| node |
+	node := self codePresenter selectedNode.
+	^ node isGlobalVariable and: [ node binding value isClass ]
+]
+
+{ #category : 'executing' }
+StRenameClassCommand >> prepareDriver [
+
+	^ (ReRenameClassDriver rename: self codePresenter selectedNode name)
+		  model: RBBrowserEnvironment new;
+		  scopes: context allScopes
+]

--- a/src/NewTools-Refactoring-Commands/package.st
+++ b/src/NewTools-Refactoring-Commands/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'NewTools-Refactoring-Commands' }


### PR DESCRIPTION
Moved all refactoring commands from Spec to New Tools since they inherit from `StCommand`

I also added new commands:
- Push Up/Down variable command
- Remove variable command
- Protect variable command
- Move IV to class side

Also Fixes #1295 by fixing bad method comments and adding ones