### PR TITLE
[Method Browser] Baseline update and fixes

### DIFF
--- a/src/BaselineOfNewTools/BaselineOfNewTools.class.st
+++ b/src/BaselineOfNewTools/BaselineOfNewTools.class.st
@@ -281,7 +281,7 @@ BaselineOfNewTools >> baseline: spec [
 
 			group: 'default'
 				with:
-					#( 'Profile' 'Epicea' 'Playground' 'ProfStef' 'Transcript' 'Inspector' 'ClosedWindows' 'CritiqueBrowser' 'Debugger' 'SystemReporter' 'FontChooser'
+					#( 'Profile' 'Epicea' 'Playground' 'ProfStef' 'Transcript' 'Inspector' 'ClosedWindows' 'Commands' 'CritiqueBrowser' 'Debugger' 'SystemReporter' 'FontChooser'
 					   'Methods' 'Spotter' 'RewriterTools' 'ScopesEditor' 'FileBrowser' 'Finder' 'Profiler' 'SettingsBrowser' 'WelcomeBrowser' 'ShortcutsBrowser'
 					   'ColorPickerGroup' 'ProcessBrowser' 'DependencyAnalyser' )  ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -992,12 +992,12 @@ StMethodBrowser >> windowIcon [
 		
 ]
 
-{ #category : 'private' }
+{ #category : 'accessing' }
 StMethodBrowser >> windowTitle [
 
 	| msg total |
 	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
-	self methods ifEmpty: [ ^title, ': No Results' ].
+	(title isNotNil and: [ self methods isEmpty ])  ifTrue: [ ^ title , ': No Results' ].
 	total := filterPresenter unfilteredItems size.
 	msg := methodList ifNil: [ '' ] ifNotNil: [
 			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -245,7 +245,6 @@ StMethodBrowser class >> navigateInPlaceSettingsOn: aBuilder [
 		parent: #tools
 ]
 
-
 { #category : 'private' }
 StMethodBrowser class >> referencesOf: aSymbol [
 	"Do not use aSymbol implementors because it is a disguised global"
@@ -578,6 +577,7 @@ StMethodBrowser >> initializePresenters [
 
 	textPresenter := self newCodeEditor.
 	textPresenter codePresenter: methodCodePresenter.
+	methodCodePresenter whenTextChangedDo: [ :aString | textPresenter markDirty ].
 	refreshingBlock := [ :item | true ].
 	filterPresenter := self instantiate: SpFilteringListPresenter.
 	filterPresenter matchSubstring.
@@ -997,7 +997,7 @@ StMethodBrowser >> windowTitle [
 
 	| msg total |
 	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
-	self methods ifEmpty: [ ^ 'No Results' ].
+	self methods ifEmpty: [ ^title, ': No Results' ].
 	total := filterPresenter unfilteredItems size.
 	msg := methodList ifNil: [ '' ] ifNotNil: [
 			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -126,7 +126,7 @@ StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems
 	[
 		window := StMethodBrowser browseSendersOf: #printOn:.
 		browser := window presenter.
-
+		StMethodBrowser codeChangeAnnouncer unsubscribe: browser.
 		total := browser filterPresenter unfilteredItems size.
 		self assert: total > 0.
 		browser filterPresenter filterInputPresenter text: 'zzznomatch'.

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -126,7 +126,6 @@ StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems
 	[
 		window := StMethodBrowser browseSendersOf: #printOn:.
 		browser := window presenter.
-		StMethodBrowser codeChangeAnnouncer unsubscribe: browser.
 		total := browser filterPresenter unfilteredItems size.
 		self assert: total > 0.
 		browser filterPresenter filterInputPresenter text: 'zzznomatch'.

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -50,6 +50,7 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		StPushUpVariableCommand.
 		StPushDownVariableCommand.
 		StRemoveVariableCommand.
-		StProtectVariableCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+		StProtectVariableCommand.
+		StRenameVariableCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -430,6 +430,7 @@ StMethodListPresenter >> packageNameOf: anItem [
 StMethodListPresenter >> packageOf: aCompiledMethod [
 	"Answer the <Package> of aCompiledMethod"
 
+	aCompiledMethod ifNil: [ ^ self ].
 	^ self packageOrganizer packageOf: aCompiledMethod methodClass
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -430,7 +430,6 @@ StMethodListPresenter >> packageNameOf: anItem [
 StMethodListPresenter >> packageOf: aCompiledMethod [
 	"Answer the <Package> of aCompiledMethod"
 
-	aCompiledMethod ifNil: [ ^ self ].
 	^ self packageOrganizer packageOf: aCompiledMethod methodClass
 ]
 
@@ -531,9 +530,9 @@ StMethodListPresenter >> topologicSort: anObject [
 StMethodListPresenter >> updateVisitedScopesFrom: aCompiledMethod [
 	"Private - Update the list of the visited scopes"
 
-	visitedScopes 
-		ifNotNil: [ 
-			visitedScopes 
+	aCompiledMethod ifNil: [ ^ self ].
+	visitedScopes ifNotNil: [
+			visitedScopes
 				add: (self packageOf: aCompiledMethod);
 				add: (self classOf: aCompiledMethod);
 				add: (self classHierarchyOf: aCompiledMethod) ]

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -105,7 +105,7 @@ StMethodToolbarPresenter >> emptyDropList [
 	dropList emptyList
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'initialization' }
 StMethodToolbarPresenter >> iconForReuseState: aBoolean [
 
 	^ aBoolean

--- a/src/NewTools-Refactoring-Commands-Tests/ReRenameVariableCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReRenameVariableCommandTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'ReRenameVariableCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameVariableCommandTest >> testRenameVariableCommandSuccess [
+
+	| driver command context ast node method dialogMock |
+	command := StRenameVariableCommand new.
+	method := RBTransformationRuleTestData >> #isEmpty.
+	ast := OpalCompiler new
+		       class: method methodClass;
+		       parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isVariable and: [ n name = 'builder' ] ].
+	context := StCommandContextMock new
+		           name: node name;
+		           behavior: RBTransformationRuleTestData.
+	command context: context.
+	driver := command prepareDriver.
+	dialogMock := StRequestDialogMock new.
+	dialogMock response: 'var'.
+	driver requestDialog: dialogMock.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 1
+]

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -21,6 +21,12 @@ StRefactoringCommand >> execute [
 	self prepareDriver runRefactoring
 ]
 
+{ #category : 'testing' }
+StRefactoringCommand >> isVisible [
+ 
+	^ self canBeExecuted
+]
+
 { #category : 'executing' }
 StRefactoringCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StRefactoringVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringVariableCommand.class.st
@@ -13,9 +13,3 @@ StRefactoringVariableCommand >> canBeExecuted [
 
 	^ self codePresenter selectedNode isInstanceVariable and: [ self codePresenter selectedNode isGlobalVariable not ]
 ]
-
-{ #category : 'executing' }
-StRefactoringVariableCommand >> prepareDriver [
-
-	^ self subclassResponsibility 
-]

--- a/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
@@ -1,0 +1,46 @@
+"
+I am a command to rename a variable. 
+"
+Class {
+	#name : 'StRenameVariableCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRenameVariableCommand class >> defaultDescription [ 
+
+	^ 'Rename variable'
+]
+
+{ #category : 'accessing' }
+StRenameVariableCommand class >> defaultIconName [
+	^ #edit
+]
+
+{ #category : 'default' }
+StRenameVariableCommand class >> defaultName [
+
+	^ 'Rename'
+]
+
+{ #category : 'testing' }
+StRenameVariableCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isLiteralVariable | self codePresenter selectedNode isInstanceVariable and: [
+		  self codePresenter selectedNode isGlobalVariable not ]
+]
+
+{ #category : 'executing' }
+StRenameVariableCommand >> prepareDriver [
+
+	| variable driver |
+	variable := self codePresenter selectedNode.
+
+	driver := variable isClassVariable
+		          ifFalse: [ ReRenameInstanceVariableDriver new ]
+		          ifTrue: [ ReRenameSharedVariableDriver new ].
+
+	^ driver scopes: context allScopes variable: variable name for: self codePresenter behavior
+]


### PR DESCRIPTION
- New spec command: `Rename Variable` + test!
- Refactoring commands are now hidden when they cannot be executed.
- Fixed CI tests.
- Added the refactoring command packages by default in the baseline. 
- Updated initialization so the code editor can be marked dirty. 
- Lastly, precised the title when there is no results (i.e `Implementors of #printOn: No Results`).