### PR TITLE
[Refactoring command Spec] Contributions to the migration

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -53,6 +53,7 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		StProtectVariableCommand.
 		StRenameVariableCommand.
 		StExtractMethodCommand.
-		StRemoveMessageArgumentCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+		StRemoveMessageArgumentCommand.
+		StAbstractAllInstVarAccessorsCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -52,6 +52,7 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		StRemoveVariableCommand.
 		StProtectVariableCommand.
 		StRenameVariableCommand.
-		StExtractMethodCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+		StExtractMethodCommand.
+		StRemoveMessageArgumentCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -54,6 +54,7 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		StRenameVariableCommand.
 		StExtractMethodCommand.
 		StRemoveMessageArgumentCommand.
-		StAbstractAllInstVarAccessorsCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+		StAbstractAllInstVarAccessorsCommand.
+		StRenameMethodCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-Refactoring-Commands-Tests/ReRenameMethodCommandTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReRenameMethodCommandTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'ReRenameMethodCommandTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReRenameMethodCommandTest >> testRenameMethodCommandSuccess [
+
+	| driver command context node method ast dialog |
+	method := RBClassDataForRefactoringTest >> #caller1.
+	ast := OpalCompiler new parse: method sourceCode.
+	node := ast allChildren detect: [ :n | n isMessage and: [ n selector = 'called:on1:' ] ].
+
+	context := StCommandContextMock new
+		           selectedNode: node;
+		           behavior: RBClassDataForRefactoringTest;
+		           yourself.
+
+	command := StRenameMethodCommand new.
+	command context: context.
+	driver := command prepareDriver.
+
+	dialog := MockObject new.
+	dialog on: #cancelled respond: false.
+	dialog on: #methodName respond: (RBMethodName selector: #renamedCalled:on1: arguments: #( 'anObject' 'anArg' )).
+	driver requestDialog: dialog.
+
+	driver
+		forTesting: true;
+		runRefactoring.
+	self assert: driver changes changes size equals: 5
+]

--- a/src/NewTools-Refactoring-Commands/StAbstractAllInstVarAccessorsCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StAbstractAllInstVarAccessorsCommand.class.st
@@ -1,0 +1,44 @@
+"
+I command to launch the Abstract refactorings: create accessors and abstract the direct instance variable uses into accessors. 
+"
+Class {
+	#name : 'StAbstractAllInstVarAccessorsCommand',
+	#superclass : 'StRefactoringClassCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'accessing' }
+StAbstractAllInstVarAccessorsCommand class >> defaultIconName [
+
+	^ #smallAdd
+]
+
+{ #category : 'default' }
+StAbstractAllInstVarAccessorsCommand class >> defaultName [
+
+	^ 'Abstract instance variables'
+]
+
+{ #category : 'executing' }
+StAbstractAllInstVarAccessorsCommand >> execute [
+
+	self prepareDriver execute
+]
+
+{ #category : 'executing' }
+StAbstractAllInstVarAccessorsCommand >> prepareDriver [
+
+	| vars dialog refactoring |
+	vars := self codePresenter selectedNode variable value slots asOrderedCollection.
+	dialog := (StVariablesSelectionPresenter newApplication: self application)
+		          label: self codePresenter selectedNode name , ' - Select all variables to convert abstract'
+		          withItems: vars
+		          selecting: vars.
+	self codePresenter selectedNode -> dialog selectedItems.
+
+
+	vars collect: [ :var |
+		refactoring := var createRefactoring: ReAbstractInstanceVariableRefactoring for: self codePresenter selectedNode variable key ].
+	^ refactoring
+]

--- a/src/NewTools-Refactoring-Commands/StAbstractAllInstVarAccessorsCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StAbstractAllInstVarAccessorsCommand.class.st
@@ -38,7 +38,7 @@ StAbstractAllInstVarAccessorsCommand >> prepareDriver [
 	self codePresenter selectedNode -> dialog selectedItems.
 
 
-	vars collect: [ :var |
+	vars do: [ :var |
 		refactoring := var createRefactoring: ReAbstractInstanceVariableRefactoring for: self codePresenter selectedNode variable key ].
 	^ refactoring
 ]

--- a/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
@@ -26,12 +26,6 @@ StExtractTempCommand class >> defaultName [
 	^ 'Extract temp'
 ]
 
-{ #category : 'testing' }
-StExtractTempCommand >> canBeExecuted [
-
-	^ self codePresenter selectionInterval isNotEmpty
-]
-
 { #category : 'executing' }
 StExtractTempCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StRefactoringClassCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringClassCommand.class.st
@@ -1,0 +1,17 @@
+"
+I am a base class for command which perform particular kind refactoring on given class.
+"
+Class {
+	#name : 'StRefactoringClassCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'testing' }
+StRefactoringClassCommand >> canBeExecuted [
+
+	| node |
+	node := self codePresenter selectedNode.
+	^ node isGlobalVariable and: [ node binding value isClass ]
+]

--- a/src/NewTools-Refactoring-Commands/StRemoveMessageArgumentCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRemoveMessageArgumentCommand.class.st
@@ -1,0 +1,89 @@
+"
+I am a command to remove existing argument from the message.
+"
+Class {
+	#name : 'StRemoveMessageArgumentCommand',
+	#superclass : 'StRefactoringCommand',
+	#instVars : [
+		'methodName'
+	],
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRemoveMessageArgumentCommand class >> defaultDescription [
+
+	^ 'Remove argument for the selected message'
+]
+
+{ #category : 'accessing' }
+StRemoveMessageArgumentCommand class >> defaultIconName [
+	^#remove
+]
+
+{ #category : 'default' }
+StRemoveMessageArgumentCommand class >> defaultName [
+
+	^ 'Remove argument'
+]
+
+{ #category : 'testing' }
+StRemoveMessageArgumentCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isMessage and: [ self codePresenter selectedNode arguments isNotEmpty ]
+]
+
+{ #category : 'private' }
+StRemoveMessageArgumentCommand >> computeArgumentName [
+
+	^ (self codePresenter selectedNode argumentPartStrings reject: [ :arg | (self methodName arguments indexOf: arg) > 0 ]) first
+]
+
+{ #category : 'executing' }
+StRemoveMessageArgumentCommand >> execute [
+
+	self prepareDriver execute
+]
+
+{ #category : 'private' }
+StRemoveMessageArgumentCommand >> informArgumentError [
+
+	self inform: 'Argument not found in method ''' , self codePresenter selectedNode selector , ''''
+]
+
+{ #category : 'accessing' }
+StRemoveMessageArgumentCommand >> methodName [
+
+	^ methodName ifNil: [
+		  methodName := RBMethodName
+			                selector: self codePresenter selectedNode selector
+			                arguments: self codePresenter selectedNode argumentPartStrings ]
+]
+
+{ #category : 'executing' }
+StRemoveMessageArgumentCommand >> prepareDriver [
+
+	| dialog argumentName |
+	dialog := SycMethodArgumentsRemoverPresenter openOn: self methodName.
+	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
+
+	argumentName := self computeArgumentName.
+
+	(self codePresenter selectedNode argumentPartStrings includes: argumentName) ifFalse: [
+			self informArgumentError.
+			CmdCommandAborted signal ].
+		
+	^ (RBRemoveParameterRefactoring
+		   model: (RBNamespace onEnvironment: context allScopes first)
+		   removeParameter: argumentName
+		   in: self codePresenter behavior
+		   selector: self codePresenter selectedNode selector
+		   index: (self codePresenter selectedNode argumentPartStrings indexOf: argumentName)) newSelector: self resultMessageSelector
+]
+
+{ #category : 'execution' }
+StRemoveMessageArgumentCommand >> resultMessageSelector [
+
+	^ self methodName selector
+]

--- a/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
@@ -3,7 +3,7 @@ Rename selected class from a code presenter
 "
 Class {
 	#name : 'StRenameClassCommand',
-	#superclass : 'StRefactoringCommand',
+	#superclass : 'StRefactoringClassCommand',
 	#category : 'NewTools-Refactoring-Commands',
 	#package : 'NewTools-Refactoring-Commands'
 }
@@ -24,14 +24,6 @@ StRenameClassCommand class >> defaultIconName [
 StRenameClassCommand class >> defaultName [
 
 	^ '(R) Rename'
-]
-
-{ #category : 'testing' }
-StRenameClassCommand >> canBeExecuted [
-
-	| node |
-	node := self codePresenter selectedNode.
-	^ node isGlobalVariable and: [ node binding value isClass ]
 ]
 
 { #category : 'executing' }

--- a/src/NewTools-Refactoring-Commands/StRenameMethodCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameMethodCommand.class.st
@@ -1,0 +1,43 @@
+"
+Call the rename method refactoring 
+"
+Class {
+	#name : 'StRenameMethodCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StRenameMethodCommand class >> defaultDescription [
+
+	^ 'Rename selected method'
+]
+
+{ #category : 'accessing' }
+StRenameMethodCommand class >> defaultIconName [
+
+	^ #edit
+]
+
+{ #category : 'default' }
+StRenameMethodCommand class >> defaultName [
+
+	^ '(R) Rename method'
+]
+
+{ #category : 'testing' }
+StRenameMethodCommand >> canBeExecuted [
+
+	^ self codePresenter selectedNode isMessage | self codePresenter selectedNode isMethod
+]
+
+{ #category : 'executing' }
+StRenameMethodCommand >> prepareDriver [
+
+	^ (ReRenameMethodDriver newApplication: self application)
+		  scopes: context allScopes
+		  model: (RBNamespace onEnvironment: context allScopes first)
+		  renameMethodSignature: self codePresenter selectedNode
+		  in: self codePresenter behavior
+]


### PR DESCRIPTION
- `Remove message argument` command implemented, no tests since there is no driver.
- `Extract temp` can be executed anywhere in the source code so I removed `canBeExecuted`
- Refactored command code for classes
- `Abstract all instance variables` command migrated, no driver too
- `Rename method` command implemented, need https://github.com/pharo-project/pharo/pull/19620 to be merged to work.