### PR TITLE
[Method Browser] Use `debug` instead of `run` for tests

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -247,10 +247,7 @@ StMethodListPresenter >> executeTestFor: aMethod [
 
 	testClasses do: [ :each | suite addTest: (each selector: selector) ].
 
-	result := TestResult new.
-	suite runWith: [ :test | test debug: result ].
-	result dispatchResultsIntoHistory.
-	suite testSuiteAnnouncer announce: (TestSuiteEnded result: result).
+	result := suite debug.
 	result updateResultsInHistory.
 
 	self application inform: result printString.

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -228,11 +228,11 @@ StMethodListPresenter >> doRunTests [
 	testMethods ifEmpty: [
 			self application inform: 'No test found in the list.'.
 			^ self ].
-	testMethods do: [ :m | self executeTestFor: m ]
+	testMethods do: [ :m | self executeTestFor: m debug: false ]
 ]
 
 { #category : 'execution' }
-StMethodListPresenter >> executeTestFor: aMethod [
+StMethodListPresenter >> executeTestFor: aMethod debug: shouldDebug [
 
 	| selector testClasses suite result |
 	aMethod ifNil: [ ^ self ].
@@ -247,7 +247,9 @@ StMethodListPresenter >> executeTestFor: aMethod [
 
 	testClasses do: [ :each | suite addTest: (each selector: selector) ].
 
-	result := suite debug.
+	result := shouldDebug
+		          ifTrue: [ suite debug ]
+		          ifFalse: [ suite run ].
 	result updateResultsInHistory.
 
 	self application inform: result printString.
@@ -281,7 +283,7 @@ StMethodListPresenter >> initializePresenters [
 				 bind: [ :p :item | p label: (self locationOf: item) ];
 				 yourself);
 		addColumn: (StTestIconColumnView new
-				 executeBlock: [ :method | self executeTestFor: method ];
+				 executeBlock: [ :method | self executeTestFor: method debug: true ];
 				 cellPresenterClass: StTestIconCellPresenter;
 				 width: 20;
 				 yourself);

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -247,7 +247,10 @@ StMethodListPresenter >> executeTestFor: aMethod [
 
 	testClasses do: [ :each | suite addTest: (each selector: selector) ].
 
-	result := suite run.
+	result := TestResult new.
+	suite runWith: [ :test | test debug: result ].
+	result dispatchResultsIntoHistory.
+	suite testSuiteAnnouncer announce: (TestSuiteEnded result: result).
 	result updateResultsInHistory.
 
 	self application inform: result printString.

--- a/src/NewTools-MethodBrowsers/StRemoveMethodCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRemoveMethodCommand.class.st
@@ -21,8 +21,16 @@ StRemoveMethodCommand class >> defaultShortcut [
 	^ $x actionModifier
 ]
 
+{ #category : 'testing' }
+StRemoveMethodCommand >> canBeExecuted [
+
+	^ context selectedMethod isNotNil
+]
+
 { #category : 'executing' }
 StRemoveMethodCommand >> execute [
 	
-	context doRemoveMethod
+	(ReRemoveMethodDriver new
+				 scopes: context owner allScopes
+				 methods: {context selectedMethod}) runRefactoring
 ]

--- a/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StRunMethodTestCommand.class.st
@@ -33,5 +33,5 @@ StRunMethodTestCommand >> canBeExecuted [
 { #category : 'executing' }
 StRunMethodTestCommand >> execute [
 
-	self context executeTestFor: self context selectedMethod
+	self context executeTestFor: self context selectedMethod debug: true
 ]


### PR DESCRIPTION
- It allows for the user to directly interact with failing/breaking tests instead of browsing them by himself.
- Also updated the remove method command in the method browser, now it calls the refactoring ( with the conditions)

Fixes #1412