### PR TITLE
[Refactoring Spec Command] Class side registry for commands

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -39,19 +39,6 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		         beDisplayedAsSubMenu;
 		         iconName: #smallAuthoringTools;
 		         yourself.
-	{
-		StRenameClassCommand.
-		StExtractTempCommand.
-		StConvertTempToInstVarCommand.
-		StInlineMethodCommand.
-		StRenameArgOrTempCommand.
-		StGenerateVariableAccessorCommand.
-		StMoveInstanceVariableToClassSideCommand.
-		StPushUpVariableCommand.
-		StPushDownVariableCommand.
-		StRemoveVariableCommand.
-		StProtectVariableCommand.
-		StRenameVariableCommand.
-		StExtractMethodCommand } do: [ :cmdClass | group register: (cmdClass forSpecContext: methodBrowser) ].
+	StRefactoringCommandRegistry commands do: [ :cmdClass | group register: (cmdClass forSpecContext: self methodBrowser) ].
 	^ group
 ]

--- a/src/NewTools-MethodBrowsers/StRefactoringCommandRegistry.class.st
+++ b/src/NewTools-MethodBrowsers/StRefactoringCommandRegistry.class.st
@@ -1,0 +1,41 @@
+"
+I represent a registry for refactoring commands.
+
+These commands are sorted by priority
+"
+Class {
+	#name : 'StRefactoringCommandRegistry',
+	#superclass : 'Object',
+	#classVars : [
+		'Commands'
+	],
+	#category : 'NewTools-MethodBrowsers-Base',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Base'
+}
+
+{ #category : 'public-api' }
+StRefactoringCommandRegistry class >> commands [
+
+	^ Commands 
+]
+
+{ #category : 'class initialization' }
+StRefactoringCommandRegistry class >> initialize [
+
+	Commands := SortedCollection sortBlock: [ :a :b | a priority < b priority ]
+]
+
+{ #category : 'actions' }
+StRefactoringCommandRegistry class >> registerCommand: aCommandClass [
+
+	Commands ifNil: [ self initialize ].
+	Commands add: aCommandClass
+]
+
+{ #category : 'class initialization' }
+StRefactoringCommandRegistry class >> reset [
+
+	<script>
+	self initialize
+]

--- a/src/NewTools-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StConvertTempToInstVarCommand.class.st
@@ -26,6 +26,12 @@ StConvertTempToInstVarCommand class >> defaultName [
 	^ '(R) Convert to Instance Var'
 ]
 
+{ #category : 'accessing' }
+StConvertTempToInstVarCommand class >> priority [
+
+	^ 6
+]
+
 { #category : 'testing' }
 StConvertTempToInstVarCommand >> canBeExecuted [
 

--- a/src/NewTools-Refactoring-Commands/StExtractMethodCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StExtractMethodCommand.class.st
@@ -26,6 +26,12 @@ StExtractMethodCommand class >> defaultName [
 	^ '(R) Extract method (no occurrences)'
 ]
 
+{ #category : 'accessing' }
+StExtractMethodCommand class >> priority [
+
+	^ 4
+]
+
 { #category : 'executing' }
 StExtractMethodCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StExtractTempCommand.class.st
@@ -23,7 +23,13 @@ StExtractTempCommand class >> defaultIconName [
 { #category : 'default' }
 StExtractTempCommand class >> defaultName [
 
-	^ 'Extract temp'
+	^ '(R) Extract temp'
+]
+
+{ #category : 'accessing' }
+StExtractTempCommand class >> priority [
+
+	^ 5
 ]
 
 { #category : 'testing' }

--- a/src/NewTools-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StGenerateVariableAccessorCommand.class.st
@@ -26,6 +26,12 @@ StGenerateVariableAccessorCommand class >> defaultName [
 	^ '(T) Generate accessor'
 ]
 
+{ #category : 'accessing' }
+StGenerateVariableAccessorCommand class >> priority [
+
+	^ 8
+]
+
 { #category : 'executing' }
 StGenerateVariableAccessorCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StInlineMethodCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StInlineMethodCommand.class.st
@@ -22,7 +22,13 @@ StInlineMethodCommand class >> defaultIconName [
 { #category : 'default' }
 StInlineMethodCommand class >> defaultName [
 
-	^ 'Inline method'
+	^ '(R) Inline method'
+]
+
+{ #category : 'accessing' }
+StInlineMethodCommand class >> priority [
+
+	^ 7
 ]
 
 { #category : 'testing' }

--- a/src/NewTools-Refactoring-Commands/StMoveInstanceVariableToClassSideCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StMoveInstanceVariableToClassSideCommand.class.st
@@ -25,6 +25,12 @@ StMoveInstanceVariableToClassSideCommand class >> defaultName [
 	^ '(T) Move to class side'
 ]
 
+{ #category : 'accessing' }
+StMoveInstanceVariableToClassSideCommand class >> priority [
+
+	^ 9
+]
+
 { #category : 'executing' }
 StMoveInstanceVariableToClassSideCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StProtectVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StProtectVariableCommand.class.st
@@ -26,6 +26,12 @@ StProtectVariableCommand class >> defaultName [
 	^ '(R) Protect'
 ]
 
+{ #category : 'accessing' }
+StProtectVariableCommand class >> priority [
+
+	^ 13
+]
+
 { #category : 'executing' }
 StProtectVariableCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StPushDownVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StPushDownVariableCommand.class.st
@@ -26,6 +26,12 @@ StPushDownVariableCommand class >> defaultName [
 	^ '(R) Push down'
 ]
 
+{ #category : 'accessing' }
+StPushDownVariableCommand class >> priority [
+
+	^ 11
+]
+
 { #category : 'executing' }
 StPushDownVariableCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StPushUpVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StPushUpVariableCommand.class.st
@@ -25,6 +25,12 @@ StPushUpVariableCommand class >> defaultName [
 	^'(R) Push up'
 ]
 
+{ #category : 'accessing' }
+StPushUpVariableCommand class >> priority [
+
+	^ 10
+]
+
 { #category : 'executing' }
 StPushUpVariableCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -16,7 +16,7 @@ StRefactoringCommand class >> priority [
 ]
 
 { #category : 'ctions' }
-StRefactoringCommand class >> registerInMethodBrowser [
+StRefactoringCommand class >> registerInEditor [
 
 	StRefactoringCommandRegistry registerCommand: self
 ]

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -10,6 +10,18 @@ Class {
 }
 
 { #category : 'accessing' }
+StRefactoringCommand class >> priority [
+
+	^ 100
+]
+
+{ #category : 'ctions' }
+StRefactoringCommand class >> registerInMethodBrowser [
+
+	StRefactoringCommandRegistry registerCommand: self
+]
+
+{ #category : 'accessing' }
 StRefactoringCommand >> codePresenter [
 
 	^ context codeEditor codePresenter

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -9,6 +9,12 @@ Class {
 	#package : 'NewTools-Refactoring-Commands'
 }
 
+{ #category : 'class initialization' }
+StRefactoringCommand class >> initialize [
+
+	self registerInEditor
+]
+
 { #category : 'accessing' }
 StRefactoringCommand class >> priority [
 

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -24,7 +24,7 @@ StRefactoringCommand class >> priority [
 { #category : 'ctions' }
 StRefactoringCommand class >> registerInEditor [
 
-	StRefactoringCommandRegistry registerCommand: self
+	(Smalltalk at: #StRefactoringCommandRegistry ifAbsent: [ ^ self ]) registerCommand: self
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands/StRemoveVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRemoveVariableCommand.class.st
@@ -28,6 +28,12 @@ StRemoveVariableCommand class >> defaultName [
 	^ '(R) Remove'
 ]
 
+{ #category : 'accessing' }
+StRemoveVariableCommand class >> priority [
+
+	^ 12
+]
+
 { #category : 'executing' }
 StRemoveVariableCommand >> prepareDriver [
 

--- a/src/NewTools-Refactoring-Commands/StRenameArgOrTempCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameArgOrTempCommand.class.st
@@ -28,6 +28,12 @@ StRenameArgOrTempCommand class >> defaultName [
 	^ '(R) Rename temp'
 ]
 
+{ #category : 'accessing' }
+StRenameArgOrTempCommand class >> priority [
+
+	^ 3
+]
+
 { #category : 'testing' }
 StRenameArgOrTempCommand >> canBeExecuted [
 

--- a/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
@@ -23,7 +23,7 @@ StRenameClassCommand class >> defaultIconName [
 { #category : 'default' }
 StRenameClassCommand class >> defaultName [
 
-	^ '(R) Rename'
+	^ '(R) Rename class'
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameClassCommand.class.st
@@ -26,6 +26,12 @@ StRenameClassCommand class >> defaultName [
 	^ '(R) Rename'
 ]
 
+{ #category : 'accessing' }
+StRenameClassCommand class >> priority [
+
+	^ 2
+]
+
 { #category : 'testing' }
 StRenameClassCommand >> canBeExecuted [
 

--- a/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
@@ -22,7 +22,7 @@ StRenameVariableCommand class >> defaultIconName [
 { #category : 'default' }
 StRenameVariableCommand class >> defaultName [
 
-	^ '(R) Rename'
+	^ '(R) Rename variable'
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRenameVariableCommand.class.st
@@ -22,7 +22,13 @@ StRenameVariableCommand class >> defaultIconName [
 { #category : 'default' }
 StRenameVariableCommand class >> defaultName [
 
-	^ 'Rename'
+	^ '(R) Rename'
+]
+
+{ #category : 'accessing' }
+StRenameVariableCommand class >> priority [
+
+	^ 1
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
- Instead of hardcoded commands in an array, commands can now register themselves via a registry. It allows a user to configurate its own commands in an easier way
- These commands are also sorted by priority 
- Precised existing spec command name (R/T to know if it is refactoring/transformation