### PR TITLE
New opening messages for Trait/Pool users

### DIFF
--- a/src/NewTools-MethodBrowsers/StAbstractMethodCentricBrowserPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StAbstractMethodCentricBrowserPresenter.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : 'accessing' }
 StAbstractMethodCentricBrowserPresenter class >> defaultPreferredExtent [
 
-	^ 900 @ 600
+	^ 1150 @ 620 
 ]
 
 { #category : 'testing' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -195,6 +195,35 @@ StMethodBrowser class >> browseSendersOfAll: aCollectionOfSymbols [
 ]
 
 { #category : 'opening' }
+StMethodBrowser class >> browseUsersOfSharedPool: aPoolClass [
+
+	| methods classes poolVarNames |
+	classes := aPoolClass poolUsers.
+	poolVarNames := aPoolClass classVarNames.
+
+	methods := classes flatCollect: [ :cls |
+		           cls methods select: [ :m | poolVarNames anySatisfy: [ :varName | m ast references: varName ] ] ].
+
+	self new
+		methods: methods asArray;
+		title: 'Users of pool ' , aPoolClass name;
+		open
+]
+
+{ #category : 'opening' }
+StMethodBrowser class >> browseUsersOfTrait: aTrait [
+
+	| methods classes |
+	classes := aTrait traitUsers.
+	methods := classes flatCollect: [ :cls | cls methods select: [ :m | m origin = aTrait ] ].
+
+	self new
+		methods: methods asArray;
+		title: 'Users of trait ' , aTrait name;
+		open
+]
+
+{ #category : 'opening' }
 StMethodBrowser class >> browseWritersOfVariables: variables [
 
 	| methods |


### PR DESCRIPTION
- Created 2 opening methods looking for  users of a trait and of a shared pool
- As well increased the default extent of the browser, since it can contain very large names