### PR TITLE
[Method Browser] Fix crash on scope switch

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -13,14 +13,15 @@ Class {
 { #category : 'initialization' }
 StMethodBrowserToolbarPresenter >> connectPresenters [
 
-	scopeList whenSelectedItemChangedDo: [ : scopeEnvironment | 
+	scopeList whenSelectedItemChangedDo: [ :scopeEnvironment |
 		scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
-	
-	messageList whenSelectedDo: [ : item |
-		item ifNotNil: [
-			messageList updateVisitedScopesFrom: item.
-			scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ] ] ]
 
+	messageList whenSelectedDo: [ :item |
+			item ifNotNil: [
+					messageList updateVisitedScopesFrom: item.
+					scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ] ] ].
+	scopeList items: messageList allScopes.
+	
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -512,7 +512,7 @@ StMethodListPresenter >> sortingBlock: aBlock [
 StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [ 
 	"Private - Callback to scope selection from the user"
 
-	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages)
+	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages) asArray
 
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -141,12 +141,12 @@ StMethodToolbarPresenter >> initializePresenters [
 		icon: (self iconNamed: #history);
 		help: 'Browse versions of current selected method';
 		action: [ self doBrowseVersions ].
-	(runTestsButton := self newToolbarButton )
-		label: 'Run Tests'; 
+	(runTestsButton := self newToolbarButton)
+		label: 'Run Tests';
 		icon: (self iconNamed: #testGreen);
 		help: 'Run all test methods in the list';
 		action: [ self doRunTests ].
-		
+
 	reuseWindowButton := self newToolbarToggleButton
 		                     label: 'Reuse window';
 		                     help: 'If checked, new searches will replace current results.';
@@ -166,14 +166,13 @@ StMethodToolbarPresenter >> initializePresenters [
 		                    add: implementorsButton;
 		                    add: versionButton;
 		                    add: reuseWindowButton;
-                        add: runTestsButton;
+		                    add: runTestsButton;
 		                    yourself.
 
 	dropList := self newDropList
 		            display: [ :item | item label ];
 		            whenSelectedItemChangedDo: [ :item | item value ];
-		            yourself.
-
+		            yourself
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -172,7 +172,8 @@ StMethodToolbarPresenter >> initializePresenters [
 	dropList := self newDropList
 		            display: [ :item | item label ];
 		            whenSelectedItemChangedDo: [ :item | item value ];
-		            yourself
+		            yourself.
+
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- Fix IdentitySet not indexable error when switching scopes: method collections are now converted to Array before being passed to the list presenter.
- Fix scope droplist not being populated on initial open: scopeList items is now initialized in `connectPresenters`.
- Fixes https://github.com/pharo-spec/Spec/issues/1904