### PR TITLE
[Method browser] Add deprecation display for method

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -60,8 +60,8 @@ StMethodBrowserTest >> testDeprecatedMethodDisplayedStruckOut [
 		label := SpLabelPresenter new.
 		column bindAction value: label value: deprecatedMethod.
 
-		self assert: (label label isKindOf: Text).
-		self assert: ((label label attributesAt: 1) includes: TextEmphasis struckOut) ] ensure: [
+
+		self assert: (label displayStrikethrough cull: deprecatedMethod) ] ensure: [
 			self class removeSelector: #tmpDeprecatedMethod.
 			window ifNotNil: [ window delete ] ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -43,6 +43,30 @@ StMethodBrowserTest >> testBrowseReferencesToVariableInClass [
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testDeprecatedMethodDisplayedStruckOut [
+
+	| window browser deprecatedMethod label column |
+	[
+		self class
+			compile: 'tmpDeprecatedMethod
+            self deprecated: ''Use something else''.
+            ^ self'
+			classified: 'tests-protocol'.
+		deprecatedMethod := self class >> #tmpDeprecatedMethod.
+
+		window := StMethodBrowser browseImplementorsOf: #tmpDeprecatedMethod.
+		browser := window presenter.
+		column := browser methodList listPresenter contentView columns detect: [ :col | col title = 'Selector' ].
+		label := SpLabelPresenter new.
+		column bindAction value: label value: deprecatedMethod.
+
+		self assert: (label label isKindOf: Text).
+		self assert: ((label label attributesAt: 1) includes: TextEmphasis struckOut) ] ensure: [
+			self class removeSelector: #tmpDeprecatedMethod.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testExplicitBrowseClassNameAsClass [
 
 	| window |

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -290,17 +290,10 @@ StMethodListPresenter >> initializePresenters [
 		addColumn: (SpColumnViewColumn new
 				 title: 'Selector';
 				 sortFunction: #selector ascending;
-				 bind: [ :p :item |
-						 | label |
-						 label := self selectorOf: item.
-
-						 item isDeprecated
-							 ifTrue: [
-									 p label: (label asText
-												  addAttribute: TextEmphasis struckOut;
-												  addAttribute: (TextColor color: Color gray);
-												  yourself) ]
-							 ifFalse: [ p label: label ] ];
+				 bind: [ :labelPresenter :item |
+						 labelPresenter label: (self selectorOf: item).
+						 labelPresenter displayStrikethrough: [ item isDeprecated ].
+						 labelPresenter displayColor: [ item isDeprecated ifTrue: [ Color gray ] ] ];
 				 yourself);
 		addColumn: (SpColumnViewColumn new
 				 title: 'Package';

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -290,7 +290,17 @@ StMethodListPresenter >> initializePresenters [
 		addColumn: (SpColumnViewColumn new
 				 title: 'Selector';
 				 sortFunction: #selector ascending;
-				 bind: [ :p :item | p label: (self selectorOf: item) ];
+				 bind: [ :p :item |
+						 | label |
+						 label := self selectorOf: item.
+
+						 item isDeprecated
+							 ifTrue: [
+									 p label: (label asText
+												  addAttribute: TextEmphasis struckOut;
+												  addAttribute: (TextColor color: Color gray);
+												  yourself) ]
+							 ifFalse: [ p label: label ] ];
 				 yourself);
 		addColumn: (SpColumnViewColumn new
 				 title: 'Package';

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -292,8 +292,7 @@ StMethodListPresenter >> initializePresenters [
 				 sortFunction: #selector ascending;
 				 bind: [ :labelPresenter :item |
 						 labelPresenter label: (self selectorOf: item).
-						 labelPresenter displayStrikethrough: [ item isDeprecated ].
-						 labelPresenter displayColor: [ item isDeprecated ifTrue: [ Color gray ] ] ];
+						 labelPresenter displayStrikethrough: [ item isDeprecated ] ];
 				 yourself);
 		addColumn: (SpColumnViewColumn new
 				 title: 'Package';


### PR DESCRIPTION
- Deprecated methods are now marked like they were in Calypso
- Added a regression test!
- Fixes https://github.com/pharo-project/pharo/issues/19531