### PR TITLE
Refactoring command initialization strategy

### DIFF
--- a/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommand.class.st
@@ -24,7 +24,7 @@ StRefactoringCommand class >> priority [
 { #category : 'ctions' }
 StRefactoringCommand class >> registerInEditor [
 
-	(Smalltalk at: #StRefactoringCommandRegistry ifAbsent: [ ^ self ]) registerCommand: self
+	StRefactoringCommandRegistry registerCommand: self
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands/StRefactoringCommandRegistry.class.st
+++ b/src/NewTools-Refactoring-Commands/StRefactoringCommandRegistry.class.st
@@ -9,28 +9,21 @@ Class {
 	#classVars : [
 		'Commands'
 	],
-	#category : 'NewTools-MethodBrowsers-Base',
-	#package : 'NewTools-MethodBrowsers',
-	#tag : 'Base'
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
 }
 
 { #category : 'public-api' }
 StRefactoringCommandRegistry class >> commands [
 
-	^ Commands 
-]
-
-{ #category : 'class initialization' }
-StRefactoringCommandRegistry class >> initialize [
-
-	Commands := SortedCollection sortBlock: [ :a :b | a priority < b priority ]
+	Commands ifNil: [ Commands := SortedCollection sortBlock: [ :a :b | a priority < b priority ] ].
+	^ Commands
 ]
 
 { #category : 'actions' }
 StRefactoringCommandRegistry class >> registerCommand: aCommandClass [
 
-	Commands ifNil: [ self initialize ].
-	Commands add: aCommandClass
+	self commands add: aCommandClass
 ]
 
 { #category : 'class initialization' }


### PR DESCRIPTION
- Moved the command registry to the command package
- Lazy init for the commands in the getter instead of `initialize`