### PR TITLE
feat: added resume button to StProcessBrowser

### DIFF
--- a/src/NewTools-ProcessBrowser/StProcessBrowser.class.st
+++ b/src/NewTools-ProcessBrowser/StProcessBrowser.class.st
@@ -217,7 +217,7 @@ StProcessBrowser >> buildProcessToolbarActions [
 		yourself
 ]
 
-{ #category : 'testing' }
+{ #category : 'actions' }
 StProcessBrowser >> canResumeSelectedProcess [
 
 	| process |
@@ -460,7 +460,7 @@ StProcessBrowser >> refreshProcessList [
 	processListPresenter updateItemsKeepingSelection: self model processList
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'actions' }
 StProcessBrowser >> resumeSelectedProcess [
 
 	| process |

--- a/src/NewTools-ProcessBrowser/StProcessBrowser.class.st
+++ b/src/NewTools-ProcessBrowser/StProcessBrowser.class.st
@@ -174,6 +174,13 @@ StProcessBrowser >> buildProcessToolbarActions [
 			action: [ self suspendSelectedProcess ];
 			actionEnabled: [ self selectedProcess notNil ] ];
 		addActionWith: [ :action | action 
+			name: 'Resume';
+			iconName: #smallForward ; 
+			description: 'Resume selected process.';
+			shortcutKey: $r actionModifier;
+			action: [ self resumeSelectedProcess ];
+			actionEnabled: [ self canResumeSelectedProcess ] ];
+		addActionWith: [ :action | action 
 			name: 'Signal';
 			iconName: #play;
 			description: 'Signal this process semaphore.';
@@ -208,6 +215,14 @@ StProcessBrowser >> buildProcessToolbarActions [
 			action: [ self inspectSelectedProcess ];
 			actionEnabled: [ self selectedProcess notNil ] ];
 		yourself
+]
+
+{ #category : 'testing' }
+StProcessBrowser >> canResumeSelectedProcess [
+
+	| process |
+	process := self selectedProcess.
+	^ process notNil and: [ process isSuspended ]
 ]
 
 { #category : 'actions' }
@@ -443,6 +458,18 @@ StProcessBrowser >> refreshProcessList [
 
 	self model updateProcessList.
 	processListPresenter updateItemsKeepingSelection: self model processList
+]
+
+{ #category : 'as yet unclassified' }
+StProcessBrowser >> resumeSelectedProcess [
+
+	| process |
+	(process := self selectedProcess) ifNil: [ ^ self ].
+	process isSuspended
+		ifTrue: [
+				process resume.
+				self refreshProcessList ]
+		ifFalse: [ self inform: 'Process is not suspended' ]
 ]
 
 { #category : 'private - accessing' }


### PR DESCRIPTION
A use case below of a digit clock morph can suspend and resume from playground but not process browser

morph := StringMorph new.
morph openInWorld. 
process := [ [ true ] whileTrue: [ 
    morph contents: Time now print24.
    1 second wait 
] ] forkAt: Processor systemBackgroundPriority .
process suspend.
process resume.
process terminate.
morph delete.