### PR TITLE
[Method Browser] Preserving items order after refresh

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -499,13 +499,11 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodModified: anAnnouncement [
-
-	| item oldItem matchingItem index editedText list |
+	| item oldItem matchingItem index editedText list matchingIndex |
 	self isDisplayed ifFalse: [ ^ self ].
 	refreshingBlock ifNil: [ ^ self ].
 	item := anAnnouncement newMethod.
 	oldItem := anAnnouncement oldMethod.
-
 	matchingItem := self methods
 		                detect: [ :m | m methodClass = oldItem methodClass and: [ m selector = oldItem selector ] ]
 		                ifNone: [ nil ].
@@ -515,26 +513,24 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 							 add: item asFullRingDefinition;
 							 yourself) ].
 			^ self ].
-
 	editedText := textPresenter isDirty ifTrue: [ editedText := textPresenter text ].
-
 	index := methodList selectedIndex.
-
 	list := filterPresenter unfilteredItems asOrderedCollection.
-	list remove: matchingItem ifAbsent: [ ].
+	matchingIndex := list indexOf: matchingItem ifAbsent: [ 0 ].
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
+			matchingIndex > 0 ifTrue: [ list removeIndex: matchingIndex ].
 			self methods: list.
 			self defer: [
 					methodList unselectAll.
 					self selectIndex: (index min: self methods size) ].
 			^ self ].
-
-	list add: item asFullRingDefinition.
+	matchingIndex > 0
+		ifTrue: [ list at: matchingIndex put: item asFullRingDefinition ]
+		ifFalse: [ list add: item asFullRingDefinition ].
 	self methods: list.
 	self defer: [
 			methodList unselectAll.
 			self selectIndex: index ].
-
 	editedText ifNotNil: [
 			textPresenter text: editedText.
 			textPresenter markConflict ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -378,6 +378,12 @@ StMethodBrowser >> allScopes [
 	^ methodList allScopes
 ]
 
+{ #category : 'api - private' }
+StMethodBrowser >> canHandleAnnouncement [
+
+	^ self isDisplayed and: [ refreshingBlock isNotNil ]
+]
+
 { #category : 'announcements' }
 StMethodBrowser >> classRenamed: anAnnouncement [ 
 	"this method forces the announcement to be handled in the UI process"
@@ -473,91 +479,100 @@ StMethodBrowser >> handleClassRenamed: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
-	| item selectedMethod editedText |
-	self isDisplayed ifFalse: [ ^ self ].
-	refreshingBlock ifNil: [ ^ self ].
+	| addedMethod ringDefinition previouslySelectedMethod previousEditedText |
+	self canHandleAnnouncement ifFalse: [ ^ self ].
 
-	item := anAnnouncement method.
-	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [ ^ self ].
-	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
+	addedMethod := anAnnouncement method.
+	(self shouldRefreshItem: addedMethod fromAnnouncement: anAnnouncement) ifFalse: [ ^ self ].
+	(addedMethod methodClass isNotNil and: [ addedMethod methodClass isObsolete not ]) ifFalse: [ ^ self ].
 
-	editedText := textPresenter isDirty ifTrue: [ textPresenter text ].
-	selectedMethod := self selectedMethod.
-	(filterPresenter unfilteredItems includes: item) ifFalse: [
-			self methods: (filterPresenter unfilteredItems asOrderedCollection
-					 add: item asFullRingDefinition;
-					 yourself) ].
+	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
+	previouslySelectedMethod := self selectedMethod.
+
+	ringDefinition := addedMethod asFullRingDefinition.
+	(filterPresenter unfilteredItems includes: ringDefinition) ifFalse: [
+			| updatedList |
+			updatedList := filterPresenter unfilteredItems asOrderedCollection.
+			updatedList add: ringDefinition.
+			self methods: updatedList ].
 
 	self defer: [
 			methodList unselectAll.
-			self selectIndex: ((self methods indexOf: selectedMethod) max: 1) ].
+			self selectIndex: ((filterPresenter unfilteredItems indexOf: previouslySelectedMethod) max: 1) ].
 
-	editedText ifNotNil: [
-			textPresenter text: editedText.
+	previousEditedText ifNotNil: [
+			textPresenter text: previousEditedText.
 			textPresenter markDirty ]
 ]
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodModified: anAnnouncement [
-	| item oldItem matchingItem index editedText list matchingIndex |
-	self isDisplayed ifFalse: [ ^ self ].
-	refreshingBlock ifNil: [ ^ self ].
-	item := anAnnouncement newMethod.
-	oldItem := anAnnouncement oldMethod.
-	matchingItem := self methods
-		                detect: [ :m | m methodClass = oldItem methodClass and: [ m selector = oldItem selector ] ]
-		                ifNone: [ nil ].
-	matchingItem ifNil: [
-			(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifTrue: [
-					self methods: (self methods
-							 add: item asFullRingDefinition;
-							 yourself) ].
+
+	| newCompiledMethod oldCompiledMethod existingItem existingItemIndex updatedList previousSelectionIndex previousEditedText |
+	self canHandleAnnouncement ifFalse: [ ^ self ].
+
+	newCompiledMethod := anAnnouncement newMethod.
+	oldCompiledMethod := anAnnouncement oldMethod.
+
+	existingItem := self unfilteredItemMatching: oldCompiledMethod.
+	existingItem ifNil: [
+			(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifTrue: [
+					updatedList := filterPresenter unfilteredItems asOrderedCollection.
+					updatedList add: newCompiledMethod asFullRingDefinition.
+					self methods: updatedList ].
 			^ self ].
-	editedText := textPresenter isDirty ifTrue: [ editedText := textPresenter text ].
-	index := methodList selectedIndex.
-	list := filterPresenter unfilteredItems asOrderedCollection.
-	matchingIndex := list indexOf: matchingItem ifAbsent: [ 0 ].
-	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
-			matchingIndex > 0 ifTrue: [ list removeIndex: matchingIndex ].
-			self methods: list.
+
+	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
+	previousSelectionIndex := methodList selectedIndex.
+	updatedList := filterPresenter unfilteredItems asOrderedCollection.
+	existingItemIndex := updatedList indexOf: existingItem ifAbsent: [ 0 ].
+
+	(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifFalse: [
+			existingItemIndex > 0 ifTrue: [ updatedList removeIndex: existingItemIndex ].
+			self methods: updatedList.
 			self defer: [
 					methodList unselectAll.
-					self selectIndex: (index min: self methods size) ].
+					self selectIndex: (previousSelectionIndex min: self methods size) ].
 			^ self ].
-	matchingIndex > 0
-		ifTrue: [ list at: matchingIndex put: item asFullRingDefinition ]
-		ifFalse: [ list add: item asFullRingDefinition ].
-	self methods: list.
+
+	existingItemIndex > 0
+		ifTrue: [ updatedList at: existingItemIndex put: newCompiledMethod asFullRingDefinition ]
+		ifFalse: [ updatedList add: newCompiledMethod asFullRingDefinition ].
+	self methods: updatedList.
 	self defer: [
 			methodList unselectAll.
-			self selectIndex: index ].
-	editedText ifNotNil: [
-			textPresenter text: editedText.
+			self selectIndex: previousSelectionIndex ].
+
+	previousEditedText ifNotNil: [
+			textPresenter text: previousEditedText.
 			textPresenter markConflict ]
 ]
 
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodRemoved: anAnnouncement [
 
-	| item selection matchingItem selectedMethod |
-	self isDisplayed ifFalse: [ ^ self ].
-	refreshingBlock ifNil: [ ^ self ].
-	self okToChange ifFalse: [ ^ self ]. "Item is a compiled methed, where the list is populated with RGMethod"
-	item := anAnnouncement method.
-	(item methodClass isNotNil and: [ item methodClass isObsolete not ]) ifFalse: [ ^ self ].
-	selection := methodList selectedIndex.
-	matchingItem := self methods
-		                detect: [ :m | m methodClass = item methodClass and: [ m selector = item selector ] ]
-		                ifNone: [ ^ self ].
-	selectedMethod := self selectedMethod.
-	self methods: (self methods asOrderedCollection
-			 remove: matchingItem ifAbsent: [ ];
-			 yourself).
+	| removedCompiledMethod removedItem previouslySelectedMethod previousSelectionIndex updatedList |
+	self canHandleAnnouncement ifFalse: [ ^ self ].
+	self okToChange ifFalse: [ ^ self ].
+
+	removedCompiledMethod := anAnnouncement method.
+	(removedCompiledMethod methodClass isNotNil and: [ removedCompiledMethod methodClass isObsolete not ]) ifFalse: [ ^ self ].
+
+	removedItem := self unfilteredItemMatching: removedCompiledMethod.
+	removedItem ifNil: [ ^ self ].
+
+	previouslySelectedMethod := self selectedMethod.
+	previousSelectionIndex := methodList selectedIndex.
+
+	updatedList := filterPresenter unfilteredItems asOrderedCollection.
+	updatedList remove: removedItem ifAbsent: [ ].
+	self methods: updatedList.
+
 	self defer: [
 			methodList unselectAll.
-			selectedMethod = matchingItem
-				ifTrue: [ self selectIndex: (selection min: self methods size) ]
-				ifFalse: [ self selectIndex: (self methods indexOf: selectedMethod) ] ]
+			previouslySelectedMethod = removedItem
+				ifTrue: [ self selectIndex: (previousSelectionIndex min: self methods size) ]
+				ifFalse: [ self selectIndex: (self methods indexOf: previouslySelectedMethod) ] ]
 ]
 
 { #category : 'text selection' }
@@ -698,6 +713,7 @@ StMethodBrowser >> methods: aCollection [
 	currentFilter := filterPresenter filterText.
 	filterPresenter unfilteredItems: aCollection asOrderedCollection.
 	methodList methods: aCollection.
+
 	self toolbarPresenter updatePresenter.
 	currentFilter isEmpty ifFalse: [ filterPresenter applyFilter: currentFilter ]
 ]
@@ -983,6 +999,14 @@ StMethodBrowser >> topologicSort [
 { #category : 'api' }
 StMethodBrowser >> topologicSort: aBoolean [
 	^ methodList topologicSort: aBoolean
+]
+
+{ #category : 'api - private' }
+StMethodBrowser >> unfilteredItemMatching: aCompiledMethod [
+
+	^ filterPresenter unfilteredItems
+		  detect: [ :ringDef | ringDef methodClass = aCompiledMethod methodClass and: [ ringDef selector = aCompiledMethod selector ] ]
+		  ifNone: [ nil ]
 ]
 
 { #category : 'api' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -488,7 +488,9 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 					 add: item asFullRingDefinition;
 					 yourself) ].
 
-	self defer: [ self selectIndex: ((self methods indexOf: selectedMethod) max: 1) ].
+	self defer: [
+			methodList unselectAll.
+			self selectIndex: ((self methods indexOf: selectedMethod) max: 1) ].
 
 	editedText ifNotNil: [
 			textPresenter text: editedText.
@@ -522,12 +524,16 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 	list remove: matchingItem ifAbsent: [ ].
 	(self shouldRefreshItem: item fromAnnouncement: anAnnouncement) ifFalse: [
 			self methods: list.
-			self defer: [ self selectIndex: (index min: self methods size) ].
+			self defer: [
+					methodList unselectAll.
+					self selectIndex: (index min: self methods size) ].
 			^ self ].
 
 	list add: item asFullRingDefinition.
 	self methods: list.
-	self defer: [ self selectIndex: index ].
+	self defer: [
+			methodList unselectAll.
+			self selectIndex: index ].
 
 	editedText ifNotNil: [
 			textPresenter text: editedText.
@@ -552,7 +558,7 @@ StMethodBrowser >> handleMethodRemoved: anAnnouncement [
 			 remove: matchingItem ifAbsent: [ ];
 			 yourself).
 	self defer: [
-			methodList listPresenter selection unselectAll.
+			methodList unselectAll.
 			selectedMethod = matchingItem
 				ifTrue: [ self selectIndex: (selection min: self methods size) ]
 				ifFalse: [ self selectIndex: (self methods indexOf: selectedMethod) ] ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -479,7 +479,7 @@ StMethodBrowser >> handleClassRenamed: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
-	| addedMethod ringDefinition previouslySelectedMethod previousEditedText |
+	| addedMethod previouslySelectedMethod previousEditedText |
 	self canHandleAnnouncement ifFalse: [ ^ self ].
 
 	addedMethod := anAnnouncement method.
@@ -489,11 +489,11 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
 	previouslySelectedMethod := self selectedMethod.
 
-	ringDefinition := addedMethod asFullRingDefinition.
-	(filterPresenter unfilteredItems includes: ringDefinition) ifFalse: [
+
+	(filterPresenter unfilteredItems includes: addedMethod) ifFalse: [
 			| updatedList |
 			updatedList := filterPresenter unfilteredItems asOrderedCollection.
-			updatedList add: ringDefinition.
+			updatedList add: addedMethod asFullRingDefinition.
 			self methods: updatedList ].
 
 	self defer: [
@@ -1005,7 +1005,7 @@ StMethodBrowser >> topologicSort: aBoolean [
 StMethodBrowser >> unfilteredItemMatching: aCompiledMethod [
 
 	^ filterPresenter unfilteredItems
-		  detect: [ :ringDef | ringDef methodClass = aCompiledMethod methodClass and: [ ringDef selector = aCompiledMethod selector ] ]
+		  detect: [ :method | method methodClass = aCompiledMethod methodClass and: [ method selector = aCompiledMethod selector ] ]
 		  ifNone: [ nil ]
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -513,18 +513,17 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 
 	newCompiledMethod := anAnnouncement newMethod.
 	oldCompiledMethod := anAnnouncement oldMethod.
-
+	updatedList := filterPresenter unfilteredItems asOrderedCollection.
 	existingItem := self unfilteredItemMatching: oldCompiledMethod.
 	existingItem ifNil: [
 			(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifTrue: [
-					updatedList := filterPresenter unfilteredItems asOrderedCollection.
 					updatedList add: newCompiledMethod asFullRingDefinition.
 					self methods: updatedList ].
 			^ self ].
 
 	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
 	previousSelectionIndex := methodList selectedIndex.
-	updatedList := filterPresenter unfilteredItems asOrderedCollection.
+
 	existingItemIndex := updatedList indexOf: existingItem ifAbsent: [ 0 ].
 
 	(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifFalse: [

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -498,7 +498,7 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
 	self defer: [
 			methodList unselectAll.
-			self selectIndex: ((filterPresenter unfilteredItems indexOf: previouslySelectedMethod) max: 1) ].
+			self selectIndex: (filterPresenter unfilteredItems indexOf: previouslySelectedMethod ifAbsent: [ 1 ]) ].
 
 	previousEditedText ifNotNil: [
 			textPresenter text: previousEditedText.

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -164,6 +164,28 @@ StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodModifiedPreservesOrder [
+
+	| window browser method initialOrder indexBefore |
+	[
+		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
+		method := self class >> #methodForTest.
+
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+		initialOrder := browser methods copy.
+		indexBefore := initialOrder indexOf: method.
+		self assert: indexBefore > 0.
+
+		self class compile: 'methodForTest ^ Object new printOn: Transcript "modified"' classified: 'tests-protocol'.
+		browser handleMethodModified:
+			(MethodModified methodChangedFrom: method to: self class >> #methodForTest oldProtocol: method protocol).
+		self assert: (browser methods indexOf: (self class >> #methodForTest) asFullRingDefinition) equals: indexBefore ] ensure: [
+			self class removeSelector: #methodForTest.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodModifiedRemovesSenderWhenNoLongerMatching [
 
 	| window browser method |

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -530,6 +530,12 @@ StMethodListPresenter >> topologicSort: anObject [
 	topologySort := anObject
 ]
 
+{ #category : 'api - selection' }
+StMethodListPresenter >> unselectAll [
+
+	listPresenter selection unselectAll
+]
+
 { #category : 'private - scopes' }
 StMethodListPresenter >> updateVisitedScopesFrom: aCompiledMethod [
 	"Private - Update the list of the visited scopes"

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -58,23 +58,23 @@ StMethodListPresenter >> browserEnvironment [
 
 { #category : 'testing' }
 StMethodListPresenter >> buildHierarchyForMessages: messages [
+
 	| result classes |
-	self topologicSort ifFalse: [ 
-		result := IdentityDictionary new.
-		messages do: [:m | result at: m put: {} ].
-		^ result ].
-	
-	result := Dictionary new.	
+	self topologicSort ifFalse: [
+			result := OrderedIdentityDictionary new.
+			messages do: [ :m | result at: m put: {  } ].
+			^ result ].
+
+	result := OrderedDictionary new.
 	classes := (messages collect: [ :each | each methodClass ]) asSet.
-	messages do: [:message || level class |
-		class := message methodClass.
-		level := OrderedCollection new.
-		class allSuperclassesDo: [:superClass |
-			(classes includes: superClass)
-				ifTrue: [ level addFirst: superClass ]].
-		level addLast: class.
-		level addLast: message selector.
-		result at: message put: level ].
+	messages do: [ :message |
+			| level class |
+			class := message methodClass.
+			level := OrderedCollection new.
+			class allSuperclassesDo: [ :superClass | (classes includes: superClass) ifTrue: [ level addFirst: superClass ] ].
+			level addLast: class.
+			level addLast: message selector.
+			result at: message put: level ].
 	^ result
 ]
 


### PR DESCRIPTION
- Since my changes on `unfilteredItems`, the items order in the browser was kind of random each time there was a code change
- I changed the dictionaries used in the hierarchy to have ordered ones, as well as updating the selection, keeping the order as it was before !
- Test to check if the order is preserved after a code change (`MethodModified`)
- Fixes #1428
- Refactored handling events code 