### PR TITLE
[Method Browser] Fix changing selection on dirty discard changes

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -397,11 +397,33 @@ StMethodBrowser >> codeEditor [
 	^ textPresenter
 ]
 
+{ #category : 'tools support' }
+StMethodBrowser >> confirmDiscardChanges [
+
+	textPresenter isDirty ifFalse: [ ^ true ].
+
+	^ self application confirm: 'Changes have not been saved. Is it OK to discard changes?'
+]
+
 { #category : 'initialization' }
 StMethodBrowser >> connectPresenters [
 
+	| isReverting |
+	isReverting := false.
+
 	methodList
-		whenSelectionChangedDo: [ :selection | self selectItem: selection selectedItem ];
+		whenSelectionChangedDo: [ :selection |
+				isReverting ifFalse: [
+							self confirmDiscardChanges
+								ifTrue: [ self selectItem: selection selectedItem ]
+								ifFalse: [
+										| oldIndex |
+										oldIndex := self methods indexOf: self codeEditor codePresenter selectedMethod.
+										isReverting := true.
+										self defer: [
+													[
+														methodList unselectAll.
+														self selectIndex: oldIndex ] ensure: [ isReverting := false ] ] ] ] ];
 		whenModelChangedDo: [ self updateTitle ].
 	methodList navigationBlock: [ :type :val | self navigateTo: type value: val ].
 	textPresenter
@@ -793,14 +815,14 @@ StMethodBrowser >> navigateTo: aType value: anObject [
 				self methods: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject ].
 			aType == #sendersAll ifTrue: [
 				self methods: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject ].
-			aType == #references ifTrue: [ ^ self class browseReferencesOf: anObject ].
+			aType == #references ifTrue: [ ^ self class browseReferencesToClass: anObject ].
 			^ self ].
-	
+
 	aType == #implementorsAll ifTrue: [
 		self methods: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject ].
 	aType == #sendersAll ifTrue: [
 		self methods: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject ].
-	aType == #references ifTrue: [ self methods: (self class referencesOf: anObject) asReferenceTo: anObject ]
+	aType == #references ifTrue: [ self methods: (self class referencesToClass: anObject) asReferenceTo: anObject ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -195,9 +195,10 @@ StMethodListPresenter >> doBrowseUsers [
 
 	| class |
 	class := self selectedMethod methodClass.
+
 	navigationBlock
 		ifNotNil: [ navigationBlock value: #references value: class ]
-		ifNil: [ self systemNavigation browseAllUsersOfClassOrTrait: class ]
+		ifNil: [ StMethodBrowser browseReferencesToClass: class ]
 ]
 
 { #category : 'private - actions' }


### PR DESCRIPTION
- Fixes #1088
- If a method was dirty, the browser switched selection and discarded changes silently
- Also refactored code and fixed the `References` command for a class