### PR TITLE
[Method Browser] Senders of a recursive method should not appear

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -311,8 +311,12 @@ StMethodBrowser class >> registerToolsOn: registry [
 StMethodBrowser class >> sendersOf: aSymbol [
 	"Do not use aSymbol senders because it is a disguised global"
 
-	^ SystemNavigation default allSendersOf: aSymbol
-	
+	| senders nonRecursive |
+	senders := SystemNavigation default allSendersOf: aSymbol.
+
+	nonRecursive := senders reject: [ :method | method selector = aSymbol ].
+
+	^ nonRecursive
 ]
 
 { #category : 'icons' }


### PR DESCRIPTION
- Having a recursive method only called by itself should show 'No Results'
- Fixes https://github.com/pharo-project/pharo/issues/19688