### PR TITLE
Fix scope preservation during announcements in MethodBrowser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -373,6 +373,12 @@ StMethodBrowser >> addHighlightedSegments [
 					 yourself) ]
 ]
 
+{ #category : 'accessing' }
+StMethodBrowser >> allMethods [
+
+	^ allMethods
+]
+
 { #category : 'private - scopes' }
 StMethodBrowser >> allScopes [ 
 	

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -18,7 +18,8 @@ Class {
 		'refreshingBlock',
 		'textPresenter',
 		'highlight',
-		'filterPresenter'
+		'filterPresenter',
+		'allMethods'
 	],
 	#classVars : [
 		'NavigateInPlace',
@@ -378,6 +379,23 @@ StMethodBrowser >> allScopes [
 	^ methodList allScopes
 ]
 
+{ #category : 'private - scopes' }
+StMethodBrowser >> applyCurrentScopeAndFilter [
+
+	| scopedMethods currentFilter currentScope |
+	currentScope := toolbarPresenter currentScope.
+
+	scopedMethods := currentScope ifNil: [ allMethods ] ifNotNil: [ :scope |
+			                 | scoped |
+			                 scoped := (scope selectMessagesFrom: allMethods) asOrderedCollection.
+			                 allMethods select: [ :m | scoped includes: m ] ].
+	currentFilter := filterPresenter filterText.
+	filterPresenter unfilteredItems: scopedMethods.
+	currentFilter isEmpty
+		ifTrue: [ methodList methods: scopedMethods ]
+		ifFalse: [ filterPresenter applyFilter: currentFilter ]
+]
+
 { #category : 'api - private' }
 StMethodBrowser >> canHandleAnnouncement [
 
@@ -429,12 +447,14 @@ StMethodBrowser >> connectPresenters [
 	textPresenter
 		whenSubmitDo: [ :text | self accept: text notifying: nil ];
 		whenResetDo: [ self selectItem: methodList selectedMethod ].
-
 	filterPresenter filterInputPresenter whenTextChangedDo: [ :text |
-			| allMethods filtered |
-			allMethods := filterPresenter unfilteredItems.
-			text ifEmpty: [ methodList methods: allMethods ] ifNotEmpty: [
-					filtered := allMethods select: [ :m | (filterPresenter display value: m) asLowercase includesSubstring: text asLowercase ].
+			| currentScope scopedMethods filtered |
+			currentScope := toolbarPresenter currentScope.
+			scopedMethods := currentScope
+				                 ifNil: [ allMethods ]
+				                 ifNotNil: [ :scope | (scope selectMessagesFrom: allMethods) asOrderedCollection ].
+			text ifEmpty: [ methodList methods: scopedMethods ] ifNotEmpty: [
+					filtered := scopedMethods select: [ :m | (filterPresenter display value: m) asLowercase includesSubstring: text asLowercase ].
 					methodList methods: filtered ] ]
 ]
 
@@ -503,7 +523,6 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 
 	| addedMethod previouslySelectedMethod previousEditedText |
 	self canHandleAnnouncement ifFalse: [ ^ self ].
-
 	addedMethod := anAnnouncement method.
 	(self shouldRefreshItem: addedMethod fromAnnouncement: anAnnouncement) ifFalse: [ ^ self ].
 	(addedMethod methodClass isNotNil and: [ addedMethod methodClass isObsolete not ]) ifFalse: [ ^ self ].
@@ -511,16 +530,13 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
 	previouslySelectedMethod := self selectedMethod.
 
+	(self itemMatching: addedMethod) ifNil: [ allMethods add: addedMethod ].
 
-	(filterPresenter unfilteredItems includes: addedMethod) ifFalse: [
-			| updatedList |
-			updatedList := filterPresenter unfilteredItems asOrderedCollection.
-			updatedList add: addedMethod asFullRingDefinition.
-			self methods: updatedList ].
+	self applyCurrentScopeAndFilter.
 
 	self defer: [
 			methodList unselectAll.
-			self selectIndex: (filterPresenter unfilteredItems indexOf: previouslySelectedMethod ifAbsent: [ 1 ]) ].
+			self selectIndex: (self methods indexOf: previouslySelectedMethod ifAbsent: [ 1 ]) ].
 
 	previousEditedText ifNotNil: [
 			textPresenter text: previousEditedText.
@@ -530,36 +546,35 @@ StMethodBrowser >> handleMethodAdded: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodModified: anAnnouncement [
 
-	| newCompiledMethod oldCompiledMethod existingItem existingItemIndex updatedList previousSelectionIndex previousEditedText |
+	| newCompiledMethod oldCompiledMethod existingItem existingItemIndex previousSelectionIndex previousEditedText |
 	self canHandleAnnouncement ifFalse: [ ^ self ].
 
 	newCompiledMethod := anAnnouncement newMethod.
 	oldCompiledMethod := anAnnouncement oldMethod.
-	updatedList := filterPresenter unfilteredItems asOrderedCollection.
-	existingItem := self unfilteredItemMatching: oldCompiledMethod.
+	existingItem := self itemMatching: oldCompiledMethod.
 	existingItem ifNil: [
 			(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifTrue: [
-					updatedList add: newCompiledMethod asFullRingDefinition.
-					self methods: updatedList ].
+					allMethods add: newCompiledMethod.
+					self applyCurrentScopeAndFilter ].
 			^ self ].
 
 	previousEditedText := textPresenter isDirty ifTrue: [ textPresenter text ].
 	previousSelectionIndex := methodList selectedIndex.
 
-	existingItemIndex := updatedList indexOf: existingItem ifAbsent: [ 0 ].
+	existingItemIndex := allMethods indexOf: existingItem ifAbsent: [ 0 ].
 
 	(self shouldRefreshItem: newCompiledMethod fromAnnouncement: anAnnouncement) ifFalse: [
-			existingItemIndex > 0 ifTrue: [ updatedList removeIndex: existingItemIndex ].
-			self methods: updatedList.
+			existingItemIndex > 0 ifTrue: [ allMethods removeIndex: existingItemIndex ].
+			self applyCurrentScopeAndFilter.
 			self defer: [
 					methodList unselectAll.
 					self selectIndex: (previousSelectionIndex min: self methods size) ].
 			^ self ].
 
 	existingItemIndex > 0
-		ifTrue: [ updatedList at: existingItemIndex put: newCompiledMethod asFullRingDefinition ]
-		ifFalse: [ updatedList add: newCompiledMethod asFullRingDefinition ].
-	self methods: updatedList.
+		ifTrue: [ allMethods at: existingItemIndex put: newCompiledMethod ]
+		ifFalse: [ allMethods add: newCompiledMethod ].
+	self applyCurrentScopeAndFilter.
 	self defer: [
 			methodList unselectAll.
 			self selectIndex: previousSelectionIndex ].
@@ -572,22 +587,21 @@ StMethodBrowser >> handleMethodModified: anAnnouncement [
 { #category : 'announcements' }
 StMethodBrowser >> handleMethodRemoved: anAnnouncement [
 
-	| removedCompiledMethod removedItem previouslySelectedMethod previousSelectionIndex updatedList |
+	| removedCompiledMethod removedItem previouslySelectedMethod previousSelectionIndex |
 	self canHandleAnnouncement ifFalse: [ ^ self ].
 	self okToChange ifFalse: [ ^ self ].
 
 	removedCompiledMethod := anAnnouncement method.
 	(removedCompiledMethod methodClass isNotNil and: [ removedCompiledMethod methodClass isObsolete not ]) ifFalse: [ ^ self ].
 
-	removedItem := self unfilteredItemMatching: removedCompiledMethod.
+	removedItem := self itemMatching: removedCompiledMethod.
 	removedItem ifNil: [ ^ self ].
 
 	previouslySelectedMethod := self selectedMethod.
 	previousSelectionIndex := methodList selectedIndex.
 
-	updatedList := filterPresenter unfilteredItems asOrderedCollection.
-	updatedList remove: removedItem ifAbsent: [ ].
-	self methods: updatedList.
+	allMethods remove: removedItem ifAbsent: [ ].
+	self applyCurrentScopeAndFilter.
 
 	self defer: [
 			methodList unselectAll.
@@ -646,6 +660,7 @@ StMethodBrowser >> initializePresenters [
 	methodCodePresenter := self instantiate: StMethodCodePresenter.
 	methodCodePresenter methodBrowser: self.
 
+	allMethods := OrderedCollection new.
 	textPresenter := self newCodeEditor.
 	textPresenter codePresenter: methodCodePresenter.
 	methodCodePresenter whenTextChangedDo: [ :aString | textPresenter markDirty ].
@@ -696,6 +711,14 @@ StMethodBrowser >> intervalOf: aSelector inCommentText: aText [
 	^ self searchedString: aSelector asString in: aText
 ]
 
+{ #category : 'api - private' }
+StMethodBrowser >> itemMatching: aCompiledMethod [
+
+	^ allMethods
+		  detect: [ :method | method methodClass = aCompiledMethod methodClass and: [ method selector = aCompiledMethod selector ] ]
+		  ifNone: [ nil ]
+]
+
 { #category : 'announcements' }
 StMethodBrowser >> methodAdded: anAnnouncement [
 	"this method forces the announcement to be handled in the UI process"
@@ -731,10 +754,10 @@ StMethodBrowser >> methods [
 StMethodBrowser >> methods: aCollection [
 
 	| currentFilter |
+	allMethods := aCollection asOrderedCollection.
 	currentFilter := filterPresenter filterText.
-	filterPresenter unfilteredItems: aCollection asOrderedCollection.
-	methodList methods: aCollection.
-
+	filterPresenter unfilteredItems: allMethods.
+	methodList methods: allMethods.
 	self toolbarPresenter updatePresenter.
 	currentFilter isEmpty ifFalse: [ filterPresenter applyFilter: currentFilter ]
 ]
@@ -1022,14 +1045,6 @@ StMethodBrowser >> topologicSort: aBoolean [
 	^ methodList topologicSort: aBoolean
 ]
 
-{ #category : 'api - private' }
-StMethodBrowser >> unfilteredItemMatching: aCompiledMethod [
-
-	^ filterPresenter unfilteredItems
-		  detect: [ :method | method methodClass = aCompiledMethod methodClass and: [ method selector = aCompiledMethod selector ] ]
-		  ifNone: [ nil ]
-]
-
 { #category : 'api' }
 StMethodBrowser >> updateTitle [
 	self withWindowDo: [ :window | window title: self windowTitle ]
@@ -1069,8 +1084,8 @@ StMethodBrowser >> windowTitle [
 
 	| msg total |
 	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
-	(title isNotNil and: [ self methods isEmpty ])  ifTrue: [ ^ title , ' [No Results]' ].
-	total := filterPresenter unfilteredItems size.
+	(title isNotNil and: [ self methods isEmpty ]) ifTrue: [ ^ title , ' [No Results]' ].
+	total := allMethods size.
 	msg := methodList ifNil: [ '' ] ifNotNil: [
 			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])
 				       ifTrue: [ ' [' , total printString , ']' ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -255,13 +255,13 @@ StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
 	[
 		window := StMethodBrowser browseImplementorsOf: #printOn:.
 		browser := window presenter.
-
-		method := browser methods second.
+  
+		method := browser methods second. 
 		browser selectIndex: 2.
-
+ 
 		browser handleMethodRemoved: (MethodRemoved new method: method compiledMethod).
-		World doOneCycle.
-		self assert: (browser methods indexOf: browser selectedMethod) equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
+		3 timesRepeat: [ self currentWorld doOneCycle ]. 
+		self assert: (browser methods indexOf: browser selectedMethod) equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ] 
 ]
 
 { #category : 'tests - smoke' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -138,7 +138,7 @@ StMethodBrowserTest >> testHandleMethodAddedAddsMatchingSender [
 		browser handleMethodAdded: (MethodAdded method: newMethod).
 
 		self assert: browser methods size equals: initialSize + 1.
-		self assert: (browser methods includes: newMethod asFullRingDefinition) ] ensure: [
+		self assert: (browser methods includes: newMethod) ] ensure: [
 			self class removeSelector: #tmpSenderMethodForTest.
 			window ifNotNil: [ window delete ] ]
 ]
@@ -180,7 +180,32 @@ StMethodBrowserTest >> testHandleMethodModifiedPreservesOrder [
 		self class compile: 'methodForTest ^ Object new printOn: Transcript "modified"' classified: 'tests-protocol'.
 		browser handleMethodModified:
 			(MethodModified methodChangedFrom: method to: self class >> #methodForTest oldProtocol: method protocol).
-		self assert: (browser methods indexOf: (self class >> #methodForTest) asFullRingDefinition) equals: indexBefore ] ensure: [
+		self assert: (browser methods indexOf: self class >> #methodForTest) equals: indexBefore ] ensure: [
+			self class removeSelector: #methodForTest.
+			window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserTest >> testHandleMethodModifiedPreservesScopeSelection [
+	"After a method is modified, the selected scope should remain the same"
+
+	| window browser method |
+	[
+		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
+		method := self class >> #methodForTest.
+
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+		browser selectIndex: 1.
+
+		browser toolbarPresenter scopeList selectIndex: 3.
+
+		self class compile: 'methodForTest ^ Object new printOn: Transcript "modified"' classified: 'tests-protocol'.
+		browser handleMethodModified:
+			(MethodModified methodChangedFrom: method to: self class >> #methodForTest oldProtocol: method protocol).
+
+
+		self assert: browser toolbarPresenter scopeList selectedIndex equals: 3 ] ensure: [
 			self class removeSelector: #methodForTest.
 			window ifNotNil: [ window delete ] ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'StMethodToolbarPresenter',
 	#instVars : [
 		'flipAction',
-		'scopeList'
+		'scopeList',
+		'savedScope'
 	],
 	#category : 'NewTools-MethodBrowsers-Senders',
 	#package : 'NewTools-MethodBrowsers',
@@ -14,14 +15,24 @@ Class {
 StMethodBrowserToolbarPresenter >> connectPresenters [
 
 	scopeList whenSelectedItemChangedDo: [ :scopeEnvironment |
-		scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
+			savedScope := scopeEnvironment.
+			scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
 
 	messageList whenSelectedDo: [ :item |
 			item ifNotNil: [
 					messageList updateVisitedScopesFrom: item.
-					scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ] ] ].
-	scopeList items: messageList allScopes.
-	
+					scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ].
+					savedScope ifNotNil: [
+							| match |
+							match := scopeList items detect: [ :s | s label = savedScope label ] ifNone: [ nil ].
+							match ifNotNil: [ scopeList disableSelectionDuring: [ scopeList selectItem: match ] ] ] ] ].
+	scopeList items: messageList allScopes
+]
+
+{ #category : 'private' }
+StMethodBrowserToolbarPresenter >> currentScope [
+
+	^ savedScope
 ]
 
 { #category : 'layout' }
@@ -74,6 +85,12 @@ StMethodBrowserToolbarPresenter >> owner: aPresenter [
 
 	super owner: aPresenter.
 	messageList := aPresenter methodList
+]
+
+{ #category : 'accessing' }
+StMethodBrowserToolbarPresenter >> scopeList [
+
+	^ scopeList
 ]
 
 { #category : 'events' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -16,7 +16,8 @@ StMethodBrowserToolbarPresenter >> connectPresenters [
 
 	scopeList whenSelectedItemChangedDo: [ :scopeEnvironment |
 			savedScope := scopeEnvironment.
-			scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ] ].
+			scopeEnvironment ifNotNil: [ messageList switchScopeTo: scopeEnvironment ].
+			messageList listPresenter listSize > 0 ifTrue: [ self defer: [ messageList selectIndex: 1 ] ] ].
 
 	messageList whenSelectedDo: [ :item |
 			item ifNotNil: [

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -362,7 +362,7 @@ StMethodListPresenter >> methods: aCollection [
 	listPresenter items: cachedHierarchy keys asOrderedCollection.
 	allMessages := listPresenter items.
 
-	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]
+
 ]
 
 { #category : 'accessing' }
@@ -515,10 +515,10 @@ StMethodListPresenter >> sortingBlock: aBlock [
 StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [
 	"Private - Callback to scope selection from the user"
 
-	| scoped |
-	scoped := aRBBrowserEnvironment selectMessagesFrom: allMessages.
-
-	self methods: (allMessages select: [ :m | scoped includes: m ])
+	| scoped source |
+	source := (owner allMethods ifNil: [ allMessages ]) ifEmpty: [ allMessages ].
+	scoped := aRBBrowserEnvironment selectMessagesFrom: source.
+	self methods: (source select: [ :m | scoped includes: m ])
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -512,11 +512,13 @@ StMethodListPresenter >> sortingBlock: aBlock [
 ]
 
 { #category : 'private - scopes' }
-StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [ 
+StMethodListPresenter >> switchScopeTo: aRBBrowserEnvironment [
 	"Private - Callback to scope selection from the user"
 
-	listPresenter items: (aRBBrowserEnvironment selectMessagesFrom: allMessages) asArray
+	| scoped |
+	scoped := aRBBrowserEnvironment selectMessagesFrom: allMessages.
 
+	self methods: (allMessages select: [ :m | scoped includes: m ])
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Previously, handleMethodAdded/Modified/Removed worked directly on 
filterPresenter unfilteredItems, which caused an issue:
- The selected scope was reset to "Current image" after any method 
  modification, because updating the list triggered scope reconstruction 
  from a temporary/wrong selected item

As modifying the scopes manually after this issue was a dirty solution, I changed a bit the architecture and the handling of methods in the Method Browser to have a cleaner approach.

## Changes

Introduce `allMethods` as the single source of truth (StMethodBrowser)
- `allMethods` holds the complete unscoped, unfiltered list of methods
- All handle methods now operate exclusively on `allMethods`
- `applyCurrentScopeAndFilter` reconstructs the displayed list from 
  `allMethods` on each announcement, respecting the active scope and 
  text filter without touching either
- `unfilteredItems` is now only a derived view used for display purposes
- Drop `asFullRingDefinition` conversions: `allMethods` holds 
  `CompiledMethod` directly, matching the initial methods on browser opening

Preserve scope selection across refreshes (StMethodBrowserToolbarPresenter)
- Introduce `savedScope` ivar, updated only on explicit user interaction 
  via `whenSelectedItemChangedDo:`
- `currentScope` returns `savedScope` instead of `scopeList selectedItem`, 
  which becomes nil during list reconstruction
- After `updateVisitedScopesFrom:` rebuilds the scope list, restore the 
  saved scope by label match

Preserve display order when a scope is active (StMethodListPresenter)
- `switchScopeTo:` now filters `allMessages` by scope membership instead 
  of using the order returned by `selectMessagesFrom:`, preserving the 
  user-facing order

Also new test for scope selection preservation !
Fixes https://github.com/pharo-project/pharo/issues/19676