### PR TITLE
Bring History and Copy commands to method browser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -66,6 +66,7 @@ StMethodBrowserToolbarPresenter >> initializePresenters [
 
 	toolbarPresenter add: (self newToolbarButton
 			 label: 'Flip';
+			 icon: (self iconNamed: #glamorousRefresh);
 			 action: [ self doFlipLayout ])
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -66,7 +66,7 @@ StMethodBrowserToolbarPresenter >> initializePresenters [
 
 	toolbarPresenter add: (self newToolbarButton
 			 label: 'Flip';
-			 icon: (self iconNamed: #glamorousRefresh);
+			 icon: (self iconNamed: #refreshCircling);
 			 action: [ self doFlipLayout ])
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -163,6 +163,35 @@ StMethodListPresenter >> defaultScopes [
 ]
 
 { #category : 'private - actions' }
+StMethodListPresenter >> doBrowseHistory [
+
+	| browserClass packageName repositoriesWithPackage repository |
+	packageName := self selectedMethod package name.
+	repositoriesWithPackage := IceRepository registry select: [ :repo | repo includesPackageNamed: packageName ].
+
+	repositoriesWithPackage ifEmpty: [
+			self application inform: 'No repositories include package ' , packageName.
+			^ self ].
+
+	repository := repositoriesWithPackage size > 1
+		              ifTrue: [
+				              SpSelectDialog new
+					              application: self application;
+					              title: 'Choose a repository';
+					              message: 'Please select the repository for package ' , packageName;
+					              items: repositoriesWithPackage;
+					              display: [ :each | each name ];
+					              openModal ]
+		              ifFalse: [ repositoriesWithPackage anyOne ].
+
+	repository ifNil: [ ^ self ].
+
+	self flag: #pharoTodo.
+	browserClass := #IceTipVersionHistoryBrowser asClassInEnvironment: self class environment.
+	(browserClass onRepository: repository method: self selectedMethod) open
+]
+
+{ #category : 'private - actions' }
 StMethodListPresenter >> doBrowseImplementors [
 
 	| selectors |
@@ -205,6 +234,15 @@ StMethodListPresenter >> doBrowseUsers [
 StMethodListPresenter >> doBrowseVersions [
 	
 	self systemNavigation browseVersionsOf: self selectedMethod
+]
+
+{ #category : 'private - actions' }
+StMethodListPresenter >> doCopy [
+
+	| text |
+	text := (self selectedMethods collect: #displayString) joinUsing: String cr.
+	Clipboard clipboardText: text.
+	self application inform: 'Copied methods:' , String cr , text
 ]
 
 { #category : 'private - actions' }

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -17,7 +17,9 @@ Class {
 		'toolbarPresenter',
 		'messageList',
 		'runTestsButton',
-		'reuseWindowButton'
+		'reuseWindowButton',
+		'historyButton',
+		'copyButton'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -64,6 +66,12 @@ StMethodToolbarPresenter >> defaultLayout [
 ]
 
 { #category : 'private - actions' }
+StMethodToolbarPresenter >> doBrowseHistory [
+
+	messageList doBrowseHistory
+]
+
+{ #category : 'private - actions' }
 StMethodToolbarPresenter >> doBrowseImplementors [
 
 	messageList doBrowseImplementors
@@ -91,6 +99,12 @@ StMethodToolbarPresenter >> doBrowseUsers [
 StMethodToolbarPresenter >> doBrowseVersions [
 
 	messageList doBrowseVersions
+]
+
+{ #category : 'private - actions' }
+StMethodToolbarPresenter >> doCopy [
+
+	messageList doCopy
 ]
 
 { #category : 'private - actions' }
@@ -125,7 +139,7 @@ StMethodToolbarPresenter >> initializePresenters [
 		label: 'References';
 		icon: (self iconNamed: #smallFind);
 		help: 'Browse references of current selected class';
-		action: [ self doBrowseUsers ].
+		action: [ self doBrowseUsers ]. 
 	(sendersButton := self newToolbarButton)
 		label: 'Senders';
 		icon: (self iconNamed: #smallFind);
@@ -141,12 +155,22 @@ StMethodToolbarPresenter >> initializePresenters [
 		icon: (self iconNamed: #history);
 		help: 'Browse versions of current selected method';
 		action: [ self doBrowseVersions ].
+
 	(runTestsButton := self newToolbarButton)
 		label: 'Run Tests';
 		icon: (self iconNamed: #testGreen);
 		help: 'Run all test methods in the list';
 		action: [ self doRunTests ].
-
+	(historyButton := self newToolbarButton)
+		label: 'Commit history';
+		icon: (self iconNamed: #komitterSmalltalkhubRemote);
+		help: 'Browse commit history';
+		action: [ self doBrowseHistory ].
+	(copyButton := self newToolbarButton)
+		label: 'Copy to clipboard';
+		icon: (self iconNamed: #smallCopy);
+		help: 'Copy selected methods into Clipboard as class>>selector';
+		action: [ self doCopy ].
 	reuseWindowButton := self newToolbarToggleButton
 		                     label: 'Reuse window';
 		                     help: 'If checked, new searches will replace current results.';
@@ -165,6 +189,8 @@ StMethodToolbarPresenter >> initializePresenters [
 		                    add: sendersButton;
 		                    add: implementorsButton;
 		                    add: versionButton;
+		                    add: historyButton;
+		                    add: copyButton;
 		                    add: reuseWindowButton;
 		                    add: runTestsButton;
 		                    yourself.


### PR DESCRIPTION
- Added previous browser commands in the new method browser: `Commit history` and `Copy to clipboard`
- Also added the Flip icon to the toolbar
- Fixes https://github.com/pharo-project/pharo/issues/19691