### PR TITLE
Hierarchy building fix

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -257,6 +257,26 @@ StMethodBrowserTest >> testMethodBrowserSenders [
 	window presenter methods size > 0 ] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
+{ #category : 'tests' }
+StMethodBrowserTest >> testMethodsAreSortedByHierarchy [
+
+	| window browser methodObject methodCollection methodArray |
+	methodObject := Object >> #printString.
+	methodCollection := Collection >> #size.
+	methodArray := Array >> #asArray.
+
+	[
+		window := StMethodBrowser browse: {
+				          methodArray.
+				          methodObject.
+				          methodCollection }.
+		browser := window presenter.
+
+		self assert: browser methods first compiledMethod equals: methodObject.
+		self assert: browser methods second compiledMethod equals: methodCollection.
+		self assert: browser methods third compiledMethod equals: methodArray ] ensure: [ window ifNotNil: [ window delete ] ]
+]
+
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testOpenWithoutMessageShouldNotDNU [
 

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -359,7 +359,7 @@ StMethodListPresenter >> methods: aCollection [
 
 	self cacheHierarchyForClasses: aCollection.
 	listPresenter items:
-		(cachedHierarchy keys asSortedCollection: [ :a :b | self should: a havePriorityOver: b ]) asOrderedCollection.
+		(cachedHierarchy keys asSortedCollection: [ :method :otherMethod | self should: method havePriorityOver: otherMethod ]) asOrderedCollection.
 	allMessages := listPresenter items.
 
 	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -257,22 +257,6 @@ StMethodListPresenter >> handleTestResultChanged: anAnnouncement [
 	self defer: [ listPresenter updateItemsKeepingSelection: listPresenter items ]
 ]
 
-{ #category : 'sorting' }
-StMethodListPresenter >> hierarchySortBlock [
-
-	^ [ :a :b |
-		  | hierarchyA hierarchyB minSize answer |
-		  hierarchyA := cachedHierarchy at: a ifAbsent: [ #(  ) ].
-		  hierarchyB := cachedHierarchy at: b ifAbsent: [ #(  ) ].
-
-		  minSize := (hierarchyA size min: hierarchyB size) - 1.
-		  answer := nil.
-		  1 to: minSize do: [ :i |
-			  answer ifNil: [
-				  (hierarchyA at: i) == (hierarchyB at: i) ifFalse: [ answer := (hierarchyA at: i) name < (hierarchyB at: i) name ] ] ].
-		  answer ifNil: [ hierarchyA size <= hierarchyB size ] ]
-]
-
 { #category : 'initialization' }
 StMethodListPresenter >> initialize [
 
@@ -374,10 +358,11 @@ StMethodListPresenter >> methods [
 StMethodListPresenter >> methods: aCollection [
 
 	self cacheHierarchyForClasses: aCollection.
-	listPresenter items: (cachedHierarchy keys asSortedCollection: self hierarchySortBlock ) asOrderedCollection.
+	listPresenter items:
+		(cachedHierarchy keys asSortedCollection: [ :a :b | self should: a havePriorityOver: b ]) asOrderedCollection.
 	allMessages := listPresenter items.
 
-	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ] 
+	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]
 ]
 
 { #category : 'accessing' }
@@ -499,6 +484,22 @@ StMethodListPresenter >> selectorOf: anItem [
 
 { #category : 'accessing - model' }
 StMethodListPresenter >> setModelBeforeInitialization: aMethod [
+]
+
+{ #category : 'sorting' }
+StMethodListPresenter >> should: aMethodDefinition havePriorityOver: anotherMethodDefinition [
+
+	| hierarchyA hierarchyB minSize answer |
+	hierarchyA := cachedHierarchy at: aMethodDefinition ifAbsent: [ #(  ) ].
+	hierarchyB := cachedHierarchy at: anotherMethodDefinition ifAbsent: [ #(  ) ].
+
+	minSize := (hierarchyA size min: hierarchyB size) - 1.
+
+	1 to: minSize do: [ :i |
+		answer ifNil: [
+			(hierarchyA at: i) == (hierarchyB at: i) ifFalse: [ answer := (hierarchyA at: i) name < (hierarchyB at: i) name ] ] ].
+
+	^ answer ifNil: [ hierarchyA size <= hierarchyB size ]
 ]
 
 { #category : 'api' }

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -56,7 +56,7 @@ StMethodListPresenter >> browserEnvironment [
 	^ RBBrowserEnvironment default label: 'current image'
 ]
 
-{ #category : 'testing' }
+{ #category : 'sorting' }
 StMethodListPresenter >> buildHierarchyForMessages: messages [
 
 	| result classes |
@@ -257,6 +257,22 @@ StMethodListPresenter >> handleTestResultChanged: anAnnouncement [
 	self defer: [ listPresenter updateItemsKeepingSelection: listPresenter items ]
 ]
 
+{ #category : 'sorting' }
+StMethodListPresenter >> hierarchySortBlock [
+
+	^ [ :a :b |
+		  | hierarchyA hierarchyB minSize answer |
+		  hierarchyA := cachedHierarchy at: a ifAbsent: [ #(  ) ].
+		  hierarchyB := cachedHierarchy at: b ifAbsent: [ #(  ) ].
+
+		  minSize := (hierarchyA size min: hierarchyB size) - 1.
+		  answer := nil.
+		  1 to: minSize do: [ :i |
+			  answer ifNil: [
+				  (hierarchyA at: i) == (hierarchyB at: i) ifFalse: [ answer := (hierarchyA at: i) name < (hierarchyB at: i) name ] ] ].
+		  answer ifNil: [ hierarchyA size <= hierarchyB size ] ]
+]
+
 { #category : 'initialization' }
 StMethodListPresenter >> initialize [
 
@@ -274,7 +290,6 @@ StMethodListPresenter >> initializePresenters [
 	listPresenter
 		addColumn: (SpColumnViewColumn new
 				 title: 'Location';
-				 sortFunction: [ :item | self locationOf: item ] ascending;
 				 bind: [ :p :item | p label: (self locationOf: item) ];
 				 yourself);
 		addColumn: (StTestIconColumnView new
@@ -359,10 +374,10 @@ StMethodListPresenter >> methods [
 StMethodListPresenter >> methods: aCollection [
 
 	self cacheHierarchyForClasses: aCollection.
-	listPresenter items: cachedHierarchy keys asOrderedCollection.
+	listPresenter items: (cachedHierarchy keys asSortedCollection: self hierarchySortBlock ) asOrderedCollection.
 	allMessages := listPresenter items.
 
-	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ]
+	listPresenter listSize > 0 ifTrue: [ self defer: [ self selectIndex: 1 ] ] 
 ]
 
 { #category : 'accessing' }
@@ -484,25 +499,6 @@ StMethodListPresenter >> selectorOf: anItem [
 
 { #category : 'accessing - model' }
 StMethodListPresenter >> setModelBeforeInitialization: aMethod [
-]
-
-{ #category : 'sorting' }
-StMethodListPresenter >> sortClassesInCachedHierarchy: aMethodDefinition b: otherMethodDefinition [
-	"This method checks wether the cached inheritance hierarchy of a method should be before than the one of another method.
-	It compares alphabetically the hierarchy using #compare:
-	If both are alphabetically equals, it uses the size the hierarchy.
-	We do not know why this is done like this."
-	| aMethodHierarchy otherMethodHierarchy minSize|
-	aMethodHierarchy := cachedHierarchy at: aMethodDefinition.
-	otherMethodHierarchy := cachedHierarchy at: otherMethodDefinition.
-	
-	minSize := aMethodHierarchy size min: otherMethodHierarchy size.
-	
-	1 to: minSize do: [ :i | |compare|
-		compare := (aMethodHierarchy at: i) printString compare: (otherMethodHierarchy at: i) printString.
-		compare ~~ 2
-			ifTrue: [  ^ compare == 1 ]].
-	^  aMethodHierarchy size < otherMethodHierarchy size
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
- The hiearchy was not built right because `methods:` cancelled the sort at initialization
- Applied a sort block to sort items by hierarchy indentation
- Deleted unused methods and `sortFunction:` for the classes, since we want the hierarchy built from the start. We can still sort by method or package
- Test to validate hierarchical sorting
- Fixes https://github.com/pharo-project/pharo/issues/19681