### PR TITLE
[Method Browser] No browser opening when no results

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -839,6 +839,13 @@ StMethodBrowser >> numberOfElements [
 	^ methodList ifNil: [ 0 ] ifNotNil: [ methodList numberOfElements ]
 ]
 
+{ #category : 'showing' }
+StMethodBrowser >> open [
+
+	filterPresenter unfilteredItems isEmpty ifTrue: [ ^ self application inform: 'No result found' ].
+	^ super open
+]
+
 { #category : 'private' }
 StMethodBrowser >> packageNameForItem: anItem [
 	^ anItem package ifNil: [ '' ] ifNotNil: [ :package | package name ]
@@ -1069,7 +1076,7 @@ StMethodBrowser >> windowTitle [
 
 	| msg total |
 	(filterPresenter isNil or: [ methodList isNil ]) ifTrue: [ ^ title ifNil: [ 'Message Browser' ] ].
-	(title isNotNil and: [ self methods isEmpty ])  ifTrue: [ ^ title , ' [No Results]' ].
+
 	total := filterPresenter unfilteredItems size.
 	msg := methodList ifNil: [ '' ] ifNotNil: [
 			       (filterPresenter filterText isEmpty or: [ methodList numberOfElements = total ])

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -919,7 +919,7 @@ StMethodBrowser >> numberOfElements [
 { #category : 'showing' }
 StMethodBrowser >> open [
 
-	filterPresenter unfilteredItems isEmpty ifTrue: [ ^ self application inform: 'No result found' ].
+	allMethods ifEmpty: [ ^ self application inform: 'No result found' ].
 	^ super open
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -281,9 +281,8 @@ StMethodBrowserTest >> testMethodsAreSortedByHierarchy [
 StMethodBrowserTest >> testOpenWithoutMessageShouldNotDNU [
 
 	| br |
-	[ br := StMethodBrowser new.
-	self shouldnt: [ br open ] raise: MessageNotUnderstood.
-		] ensure: [ br window close ]
+	br := StMethodBrowser new.
+	self shouldnt: [ br open ] raise: MessageNotUnderstood
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
- Instead of opening a new empty browser when no results are found for a query, the user gets informed that no there are no results. This avoid an extra window to pop up
- Fixes https://github.com/pharo-project/pharo/issues/19663