### PR TITLE
[Method Browser] Fix `locationOf:` unknown red square

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -361,14 +361,16 @@ StMethodListPresenter >> listPresenter [
 { #category : 'accessing' }
 StMethodListPresenter >> locationOf: anItem [
 
-	^ String streamContents: [ :aStream | 
-		3 to: (cachedHierarchy at: anItem) size do: [ :i | aStream << '    ' ].
-		aStream << (self methodClassNameForItem: anItem) << ' ('.
-		anItem isFromTrait
-			ifTrue: [ aStream
-					<< anItem compiledMethod origin name;
-					space ].
-		aStream << (self protocolNameForItem: anItem) << ')' ]
+	^ String streamContents: [ :aStream |
+			  | level |
+			  level := cachedHierarchy at: anItem ifAbsent: [ #(  ) ].
+			  3 to: level size do: [ :i | aStream << '    ' ].
+			  aStream << (self methodClassNameForItem: anItem) << ' ('.
+			  anItem isFromTrait ifTrue: [
+					  aStream
+						  << anItem compiledMethod origin name;
+						  space ].
+			  aStream << (self protocolNameForItem: anItem) << ')' ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
- Since we can't identify when the red square of death happens, I added a fix to prevent a key not found error
- Fixes https://github.com/pharo-project/pharo/issues/19722
- Fixes https://github.com/pharo-project/pharo/issues/19706