### PR TITLE
Compiling a method should set a timestamp and not an empty string.

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -380,7 +380,7 @@ StMethodBrowser >> accept: text notifying: notifyer [
 		message methodClass 
 			compile: text
 			classified: message protocol 
-			withStamp: '' 
+			withStamp: DateAndTime now 
 			notifying: notifyer 
 			logSource: true	 
 		  ]


### PR DESCRIPTION
Otherwise the change record parser will skip the entry and not list prior code versions.

This was causing that when coding in the method browser, the history of the method was lost.
The root cause is actually that the change record parser inside `FilesSourceManager` does not properly manage method without stamp, and stops looking for previous methdos even though they have a prior pointer.

Eventually, the DateAndTime should be set by default, but that introduces a System-Time dependency into the kernel that we would like to avoid.