### PR TITLE
Fix https://github.com/pharo-project/pharo/issues/19730

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -61,7 +61,7 @@ StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol from: aCa
 { #category : 'opening explicit' }
 StMethodBrowser class >> browse: aCollection asImplementorsOfAll: aCollectionOfSymbols from: aCallerClass [
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser | browser methods: aCollection asImplementorsOfAll: aCollectionOfSymbols ]
 		from: aCallerClass

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -42,57 +42,56 @@ StMethodBrowser class >> beDefaultBrowser [
 StMethodBrowser class >> browse: aCollection [
 	"Basic version. Opens a browser on the given collection of methods without setting a title or refreshing block."
 
-	^ (self new
-		   methods: aCollection;
-		   callerClass: aCollection anyOne methodClass instanceSide) open
+	self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection ]
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asImplementorsOf: aSymbol [
+StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol [
 
-
-	^ self browse: compiledMethods asImplementorsOf: aSymbol from: nil
+	self browse: aCollection asImplementorsOfAll: { aSymbol } from: nil
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asImplementorsOf: aSymbol from: aCallerClass [
+StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol from: aCallerClass [
 	"Specialized version for better UX feedback"
 
-	^ self browse: compiledMethods asImplementorsOfAll: { aSymbol } from: aCallerClass
+	self browse: aCollection asImplementorsOfAll: { aSymbol } from: aCallerClass
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asImplementorsOfAll: aCollectionOfSymbols from: aCallerClass [
+StMethodBrowser class >> browse: aCollection asImplementorsOfAll: aCollectionOfSymbols from: aCallerClass [
 
-	^ self new
-		  methods: compiledMethods asImplementorsOfAll: aCollectionOfSymbols;
-		  callerClass: aCallerClass;
-		  open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser | browser methods: aCollection asImplementorsOfAll: aCollectionOfSymbols ]
+		from: aCallerClass
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asReferencesToClass: aClass [
+StMethodBrowser class >> browse: aCollection asReferencesToClass: aCallerClass [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	^ (self new
-		   methods: compiledMethods asReferenceTo: aClass binding;
-		   callerClass: aClass) open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser | browser methods: aCollection asReferenceTo: aCallerClass binding ]
+		from: aCallerClass
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asReferencesToLiteral: aLiteral [
+StMethodBrowser class >> browse: aCollection asReferencesToLiteral: aLiteral [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	^ (self new methods: compiledMethods asReferenceTo: aLiteral) open
+	self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection asReferenceTo: aLiteral ]
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asReferencesToVariable: aVariable inClass: aClass [
+StMethodBrowser class >> browse: aCollection asReferencesToVariable: aVariable inClass: aClass [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	^ (self new
-		   methods: compiledMethods asReferencesToVariable: aVariable inClass: aClass binding;
-		   callerClass: aClass) open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser | browser methods: aCollection asReferencesToVariable: aVariable inClass: aClass binding ]
+		from: aClass
 ]
 
 { #category : 'opening explicit' }
@@ -103,34 +102,64 @@ StMethodBrowser class >> browse: compiledMethods asSendersOf: aSymbol [
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asSendersOf: aSymbol from: aCallerClass [
+StMethodBrowser class >> browse: aCollection asSendersOf: aSymbol from: aClass [
 	"Specialized version for better UX feedback for senders and explicit list of methods"
 
-	^ self new
-		  methods: compiledMethods asSendersOfAll: { aSymbol };
-		  callerClass: aCallerClass;
-		  open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser | browser methods: aCollection asSendersOfAll: { aSymbol } ]
+		from: aClass
 ]
 
 { #category : 'opening explicit' }
-StMethodBrowser class >> browse: compiledMethods asSendersOfAll: aCollectionOfSymbols from: aCallerClass [
+StMethodBrowser class >> browse: aCollection asSendersOfAll: aCollectionOfSymbols from: aClass [
 	"Specialized version for better UX feedback for senders of all given selectors."
 
-	^ self new
-		  methods: compiledMethods asSendersOfAll: aCollectionOfSymbols;
-		  callerClass: aCallerClass;
-		  open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser | browser methods: aCollection asSendersOfAll: aCollectionOfSymbols ]
+		from: aClass
 ]
 
 { #category : 'opening - old' }
-StMethodBrowser class >> browse: aCollection title: aString from: aCallerMethod [
+StMethodBrowser class >> browse: aCollection title: aString from: aClass [
 	"Basic version with limited UX feedback. Use only if you cannot use the other methods."
 
-	^ self new
-		  methods: aCollection;
-		  callerClass: aCallerMethod;
-		  title: aString;
-		  open
+	self
+		browse: aCollection
+		withInitializationBlock: [ :browser |
+				browser
+					methods: aCollection;
+					title: aString ]
+		from: aClass
+]
+
+{ #category : 'opening explicit' }
+StMethodBrowser class >> browse: compiledMethods withInitializationBlock: aBlock [
+
+	self browse: compiledMethods withInitializationBlock: aBlock from: nil
+]
+
+{ #category : 'opening explicit' }
+StMethodBrowser class >> browse: compiledMethods withInitializationBlock: aBlock from: aCallerClass [
+	
+	| browser |
+	"Inform when the collection is empty.
+	We leave this code here because this method is called from many different places.
+	
+	However, putting this here has several drawbacks:
+	  - browse: should return a window/presenter?
+	  - is this a common browsing API or an API to open a StMethodBrowser? If it is the second, this is breaking expectations.
+	  - this is missing context because we are in class side. We have no application to attach the browser to.
+	"
+	compiledMethods ifEmpty: [
+			StPharoApplication current inform: 'No result found'.
+			^ nil ].
+
+	browser := self new.
+	aBlock value: browser.
+	browser callerClass: aCallerClass.
+	browser open
 ]
 
 { #category : 'opening' }
@@ -188,11 +217,15 @@ StMethodBrowser class >> browseReferencesToVariables: variables [
 	| methods |
 	methods := SystemNavigation default allMethods select: [ :m | variables anySatisfy: [ :var | var isAccessedIn: m ] ].
 
-	^ self new
-		  methods: methods asArray;
-		  callerClass:((variables first respondsTo: #owningClass) ifTrue: [ variables first owningClass ] ifFalse: [ variables first definingClass ]);
-		  title: 'References to ' , (', ' join: (variables collect: [ :v | v name ]));
-		  open
+	self
+		browse: methods
+		withInitializationBlock: [ :browser |
+				browser
+					methods: methods asArray;
+					title: 'References to ' , (', ' join: (variables collect: [ :v | v name ])) ]
+		from: ((variables first respondsTo: #owningClass)
+				 ifTrue: [ variables first owningClass ]
+				 ifFalse: [ variables first definingClass ])
 ]
 
 { #category : 'opening' }
@@ -227,11 +260,13 @@ StMethodBrowser class >> browseUsersOfSharedPool: aPoolClass [
 	methods := classes flatCollect: [ :cls |
 		           cls methods select: [ :m | poolVarNames anySatisfy: [ :varName | m ast references: varName ] ] ].
 
-	self new
-		methods: methods asArray;
-		callerClass: aPoolClass;
-		title: 'Users of pool ' , aPoolClass name;
-		open
+	self
+		browse: methods
+		withInitializationBlock: [ :browser |
+				browser
+					methods: methods asArray;
+					title: 'Users of pool ' , aPoolClass name ]
+		from: aPoolClass
 ]
 
 { #category : 'opening' }
@@ -241,11 +276,13 @@ StMethodBrowser class >> browseUsersOfTrait: aTrait [
 	classes := aTrait traitUsers.
 	methods := classes flatCollect: [ :cls | cls methods select: [ :m | m origin = aTrait ] ].
 
-	self new
-		methods: methods asArray;
-		callerClass: aTrait;
-		title: 'Users of trait ' , aTrait name;
-		open
+	self
+		browse: methods
+		withInitializationBlock: [ :browser |
+				browser
+					methods: methods asArray;
+					title: 'Users of trait ' , aTrait name ]
+		from: aTrait
 ]
 
 { #category : 'opening' }
@@ -254,13 +291,15 @@ StMethodBrowser class >> browseWritersOfVariables: variables [
 	| methods |
 	methods := SystemNavigation default allMethods select: [ :m | variables anySatisfy: [ :var | var isWrittenIn: m ] ].
 
-	^ self new
-		  methods: methods asArray;
-		  callerClass: ((variables first respondsTo: #owningClass)
-				   ifTrue: [ variables first owningClass ]
-				   ifFalse: [ variables first definingClass ]);
-		  title: 'Writers to ' , (', ' join: (variables collect: [ :v | v name ]));
-		  open
+	self
+		browse: methods
+		withInitializationBlock: [ :browser |
+				browser
+					methods: methods asArray;
+					title: 'Writers to ' , (', ' join: (variables collect: [ :v | v name ])) ]
+		from: ((variables first respondsTo: #owningClass)
+				 ifTrue: [ variables first owningClass ]
+				 ifFalse: [ variables first definingClass ])
 ]
 
 { #category : 'private' }
@@ -807,6 +846,10 @@ StMethodBrowser >> methods: aCollection [
 	currentFilter := filterPresenter filterText.
 	filterPresenter unfilteredItems: allMethods.
 	methodList methods: allMethods.
+	
+	"Select the first index when the list is set for the first time"
+	self selectIndex: 1.
+	
 	self toolbarPresenter updatePresenter.
 	currentFilter isEmpty ifFalse: [ filterPresenter applyFilter: currentFilter ]
 ]
@@ -863,9 +906,9 @@ StMethodBrowser >> navigateTo: aType value: anObject [
 
 	self navigateInPlace ifFalse: [
 			aType == #implementorsAll ifTrue: [
-				self methods: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject ].
+				self class methods: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject ].
 			aType == #sendersAll ifTrue: [
-				self methods: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject ].
+				self class methods: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject ].
 			aType == #references ifTrue: [ ^ self class browseReferencesToClass: anObject ].
 			^ self ].
 
@@ -888,14 +931,6 @@ StMethodBrowser >> newMethodToolbar [
 StMethodBrowser >> numberOfElements [ 
 	
 	^ methodList ifNil: [ 0 ] ifNotNil: [ methodList numberOfElements ]
-]
-
-{ #category : 'showing' }
-StMethodBrowser >> open [
-
-	allMethods ifEmpty: [ ^ self application inform: 'No result found' ].
-	self selectIndex: 1.
-	^ super open
 ]
 
 { #category : 'private' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -217,7 +217,7 @@ StMethodBrowser class >> browseReferencesToVariables: variables [
 	| methods |
 	methods := SystemNavigation default allMethods select: [ :m | variables anySatisfy: [ :var | var isAccessedIn: m ] ].
 
-	self
+	^ self
 		browse: methods
 		withInitializationBlock: [ :browser |
 				browser

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -105,7 +105,7 @@ StMethodBrowser class >> browse: compiledMethods asSendersOf: aSymbol [
 StMethodBrowser class >> browse: aCollection asSendersOf: aSymbol from: aClass [
 	"Specialized version for better UX feedback for senders and explicit list of methods"
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser | browser methods: aCollection asSendersOfAll: { aSymbol } ]
 		from: aClass

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -42,7 +42,7 @@ StMethodBrowser class >> beDefaultBrowser [
 StMethodBrowser class >> browse: aCollection [
 	"Basic version. Opens a browser on the given collection of methods without setting a title or refreshing block."
 
-	self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection ]
+	^ self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection ]
 ]
 
 { #category : 'opening explicit' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -276,7 +276,7 @@ StMethodBrowser class >> browseUsersOfTrait: aTrait [
 	classes := aTrait traitUsers.
 	methods := classes flatCollect: [ :cls | cls methods select: [ :m | m origin = aTrait ] ].
 
-	self
+	^ self
 		browse: methods
 		withInitializationBlock: [ :browser |
 				browser

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -137,7 +137,7 @@ StMethodBrowser class >> browse: aCollection title: aString from: aClass [
 { #category : 'opening explicit' }
 StMethodBrowser class >> browse: compiledMethods withInitializationBlock: aBlock [
 
-	self browse: compiledMethods withInitializationBlock: aBlock from: nil
+	^ self browse: compiledMethods withInitializationBlock: aBlock from: nil
 ]
 
 { #category : 'opening explicit' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -71,7 +71,7 @@ StMethodBrowser class >> browse: aCollection asImplementorsOfAll: aCollectionOfS
 StMethodBrowser class >> browse: aCollection asReferencesToClass: aCallerClass [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser | browser methods: aCollection asReferenceTo: aCallerClass binding ]
 		from: aCallerClass

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -125,7 +125,7 @@ StMethodBrowser class >> browse: aCollection asSendersOfAll: aCollectionOfSymbol
 StMethodBrowser class >> browse: aCollection title: aString from: aClass [
 	"Basic version with limited UX feedback. Use only if you cannot use the other methods."
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser |
 				browser

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -48,7 +48,7 @@ StMethodBrowser class >> browse: aCollection [
 { #category : 'opening explicit' }
 StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol [
 
-	self browse: aCollection asImplementorsOfAll: { aSymbol } from: nil
+	^ self browse: aCollection asImplementorsOfAll: { aSymbol } from: nil
 ]
 
 { #category : 'opening explicit' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -55,7 +55,7 @@ StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol [
 StMethodBrowser class >> browse: aCollection asImplementorsOf: aSymbol from: aCallerClass [
 	"Specialized version for better UX feedback"
 
-	self browse: aCollection asImplementorsOfAll: { aSymbol } from: aCallerClass
+	^ self browse: aCollection asImplementorsOfAll: { aSymbol } from: aCallerClass
 ]
 
 { #category : 'opening explicit' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -115,7 +115,7 @@ StMethodBrowser class >> browse: aCollection asSendersOf: aSymbol from: aClass [
 StMethodBrowser class >> browse: aCollection asSendersOfAll: aCollectionOfSymbols from: aClass [
 	"Specialized version for better UX feedback for senders of all given selectors."
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser | browser methods: aCollection asSendersOfAll: aCollectionOfSymbols ]
 		from: aClass

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -159,7 +159,7 @@ StMethodBrowser class >> browse: compiledMethods withInitializationBlock: aBlock
 	browser := self new.
 	aBlock value: browser.
 	browser callerClass: aCallerClass.
-	browser open
+	^ browser open
 ]
 
 { #category : 'opening' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -291,7 +291,7 @@ StMethodBrowser class >> browseWritersOfVariables: variables [
 	| methods |
 	methods := SystemNavigation default allMethods select: [ :m | variables anySatisfy: [ :var | var isWrittenIn: m ] ].
 
-	self
+	^ self
 		browse: methods
 		withInitializationBlock: [ :browser |
 				browser

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -260,7 +260,7 @@ StMethodBrowser class >> browseUsersOfSharedPool: aPoolClass [
 	methods := classes flatCollect: [ :cls |
 		           cls methods select: [ :m | poolVarNames anySatisfy: [ :varName | m ast references: varName ] ] ].
 
-	self
+	^ self
 		browse: methods
 		withInitializationBlock: [ :browser |
 				browser

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -81,7 +81,7 @@ StMethodBrowser class >> browse: aCollection asReferencesToClass: aCallerClass [
 StMethodBrowser class >> browse: aCollection asReferencesToLiteral: aLiteral [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection asReferenceTo: aLiteral ]
+	^ self browse: aCollection withInitializationBlock: [ :browser | browser methods: aCollection asReferenceTo: aLiteral ]
 ]
 
 { #category : 'opening explicit' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -88,7 +88,7 @@ StMethodBrowser class >> browse: aCollection asReferencesToLiteral: aLiteral [
 StMethodBrowser class >> browse: aCollection asReferencesToVariable: aVariable inClass: aClass [
 	"Specialized version for better UX feedback for class references and explicit list of methods"
 
-	self
+	^ self
 		browse: aCollection
 		withInitializationBlock: [ :browser | browser methods: aCollection asReferencesToVariable: aVariable inClass: aClass binding ]
 		from: aClass

--- a/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserToolbarPresenter.class.st
@@ -21,7 +21,7 @@ StMethodBrowserToolbarPresenter >> connectPresenters [
 
 	messageList whenSelectedDo: [ :item |
 			item ifNotNil: [
-					messageList updateVisitedScopesFrom: item.
+					messageList updateVisitedScopesForMethod: item.
 					scopeList disableSelectionDuring: [ scopeList items: messageList allScopes ].
 					savedScope ifNotNil: [
 							| match |

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -157,24 +157,7 @@ StMethodListPresenter >> defaultOutputPort [
 StMethodListPresenter >> defaultScopes [
 	"Private - Answer scopes from both the caller class and the currently selected method"
 
-	| scopeSet |
-	scopeSet := Set new.
-
-	self callerClass ifNotNil: [ :caller |
-			scopeSet
-				add: (self packageOrganizer packageOf: caller);
-				add: caller;
-				add: (RBClassHierarchyEnvironment class: caller) ].
-
-
-	self selectedMethod ifNotNil: [ :method |
-			scopeSet
-				add: (self packageOf: method);
-				add: (self classOf: method);
-				add: (self classHierarchyOf: method) ].
-
-	scopeSet addAll: ScopesManager availableScopes.
-	^ scopeSet
+	^ self newVisitedScopesForMethod: self selectedMethod
 ]
 
 { #category : 'private - actions' }
@@ -426,6 +409,31 @@ StMethodListPresenter >> navigationBlock: aBlock [
 	navigationBlock := aBlock
 ]
 
+{ #category : 'private - scopes' }
+StMethodListPresenter >> newVisitedScopesForMethod: aCompiledMethod [
+	"Create a set of scopes from both the caller class and the selected method"
+
+	| newScopeSet |
+
+	newScopeSet := Set new.
+
+	self callerClass ifNotNil: [ :caller |
+			newScopeSet
+				add: (self packageOrganizer packageOf: caller);
+				add: caller;
+				add: (RBClassHierarchyEnvironment class: caller) ].
+
+	aCompiledMethod ifNil: [ ^ newScopeSet ].
+	newScopeSet
+		add: (self packageOf: aCompiledMethod);
+		add: (self classOf: aCompiledMethod);
+		add: (self classHierarchyOf: aCompiledMethod).
+
+	newScopeSet addAll: ScopesManager availableScopes.
+
+	^ newScopeSet
+]
+
 { #category : 'accessing' }
 StMethodListPresenter >> numberOfElements [
 
@@ -593,32 +601,17 @@ StMethodListPresenter >> unselectAll [
 ]
 
 { #category : 'private - scopes' }
-StMethodListPresenter >> updateVisitedScopesFrom: aCompiledMethod [
-	"Private - Update the list of visited scopes from both the caller class and the selected method"
+StMethodListPresenter >> updateVisitedScopesForMethod: aCompiledMethod [
 
-	visitedScopes := Set new.
-
-	self callerClass ifNotNil: [ :caller |
-			visitedScopes
-				add: (self packageOrganizer packageOf: caller);
-				add: caller;
-				add: (RBClassHierarchyEnvironment class: caller) ].
-
-	aCompiledMethod ifNil: [ ^ self ].
-	visitedScopes
-		add: (self packageOf: aCompiledMethod);
-		add: (self classOf: aCompiledMethod);
-		add: (self classHierarchyOf: aCompiledMethod)
+	visitedScopes := self newVisitedScopesForMethod: aCompiledMethod
 ]
 
 { #category : 'private - scopes' }
 StMethodListPresenter >> visitedScopes [
-	"Answer a <Collection> of <Package> which has been selected in the receiver"
+	"Answer a <Collection> of <Scopes> which has been selected in the receiver"
 	
 	^ visitedScopes
 		ifNil: [ visitedScopes := self defaultScopes ]
-
-
 ]
 
 { #category : 'api - events' }


### PR DESCRIPTION
- do not set a caller class if no methods are set
- cleanup methods with side effects and duplicated code
- cleanup redefined open method, move popup to browse methods, refactor to minimize duplications