### PR TITLE
Fix: secondary highlight selection in method browser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -383,7 +383,7 @@ StMethodBrowser >> accept: text notifying: notifyer [
 { #category : 'private' }
 StMethodBrowser >> addHighlightedSegments [
 
-	| message highlightInterval highlights  |
+	| message highlightInterval highlights |
 	message := self selectedMethod.
 	message ifNil: [ ^ self ].
 
@@ -396,9 +396,7 @@ StMethodBrowser >> addHighlightedSegments [
 				                     ifFalse: [ self intervalOf: each inCommentText: textPresenter text ]
 				                     ifTrue: [ self intervalOf: each inCode: textPresenter text of: message ].
 
-			textPresenter addTextSegmentDecoration: (SpTextPresenterDecorator forHighlight
-					 interval: (highlightInterval first to: highlightInterval last + 1);
-					 yourself) ]
+			textPresenter codePresenter selectionInterval: highlightInterval ]
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -266,6 +266,23 @@ StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
 		self assert: (browser methods indexOf: browser selectedMethod) equals: 3 ] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
+{ #category : 'tests' }
+StMethodBrowserTest >> testHighlightSelectsFirstOccurrence [
+
+	| window browser method interval |
+	[
+		window := StMethodBrowser browseSendersOf: #printOn:.
+		browser := window presenter.
+
+		method := browser selectedMethod.
+
+		interval := browser codeEditor codePresenter selectionInterval.
+
+		self assert: interval isNotEmpty.
+		self assert: ((browser codeEditor text copyFrom: interval first to: interval last) includesSubstring: 'printOn:') ] ensure: [
+		window ifNotNil: [ window delete ] ]
+]
+
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testMethodBrowserImplementors [
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -269,13 +269,10 @@ StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
 { #category : 'tests' }
 StMethodBrowserTest >> testHighlightSelectsFirstOccurrence [
 
-	| window browser method interval |
+	| window browser interval |
 	[
 		window := StMethodBrowser browseSendersOf: #printOn:.
 		browser := window presenter.
-
-		method := browser selectedMethod.
-
 		interval := browser codeEditor codePresenter selectionInterval.
 
 		self assert: interval isNotEmpty.


### PR DESCRIPTION
- `selectionInterval:` selects now the first occurence and does the job for remaining occurences (secondary highlight)
- Added a test to ensure selection is done well
- Fixes https://github.com/pharo-project/pharo/issues/19723