### PR TITLE
Fix: browsing senders from traits showed users too

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -338,11 +338,14 @@ StMethodBrowser class >> registerToolsOn: registry [
 
 { #category : 'private' }
 StMethodBrowser class >> sendersOf: aSymbol [
-	"Do not use aSymbol senders because it is a disguised global"
+	"Do not use aSymbol senders because it is a disguised global.
+	When browsing senders of a trait method we only want to have the method trait itself.
+Therefore, we need both checks here because if we just put isFromTrait, we wouldn't have any methods coming from a Trait.
+And the second check allows to know whether the method is coming from a trait OR used from a trait."
 
 	| allSenders |
 	allSenders := SystemNavigation default allSendersOf: aSymbol.
-	
+
 	^ allSenders reject: [ :sender | sender isFromTrait and: [ sender origin ~= sender methodClass ] ]
 ]
 

--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -340,8 +340,10 @@ StMethodBrowser class >> registerToolsOn: registry [
 StMethodBrowser class >> sendersOf: aSymbol [
 	"Do not use aSymbol senders because it is a disguised global"
 
-	^ SystemNavigation default allSendersOf: aSymbol
+	| allSenders |
+	allSenders := SystemNavigation default allSendersOf: aSymbol.
 	
+	^ allSenders reject: [ :sender | sender isFromTrait and: [ sender origin ~= sender methodClass ] ]
 ]
 
 { #category : 'icons' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserData.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserData.class.st
@@ -1,6 +1,8 @@
 Class {
 	#name : 'StMethodBrowserData',
 	#superclass : 'Object',
+	#traits : 'TData',
+	#classTraits : 'TData classTrait',
 	#category : 'NewTools-MethodBrowsers-Tests',
 	#package : 'NewTools-MethodBrowsers',
 	#tag : 'Tests'

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -19,7 +19,7 @@ StMethodBrowserTest >> testBrowseClassNameAsClass [
 	[
 		window := StMethodBrowser browseReferencesToClass: StMethodBrowserData.
 
-		self assert: window presenter methods size equals: 2] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: window presenter methods size equals: 3] ensure: [ window ifNotNil: [ window delete ] ]
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -43,16 +43,6 @@ StMethodBrowserTest >> testBrowseReferencesToVariableInClass [
 ]
 
 { #category : 'tests' }
-StMethodBrowserTest >> testBrowseTraitMethodOnlyShowConcernedTrait [
-
-	| window | 
-	[
-		window := StMethodBrowser browseReferencesToVariable: (StMethodBrowser slotNamed: #title )inClass: StMethodBrowser.
-
-		self assert: window presenter methods size equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
-]
-
-{ #category : 'tests' }
 StMethodBrowserTest >> testCallerClassIsSetFromConstructor [
 
 	| window browser |

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -43,6 +43,16 @@ StMethodBrowserTest >> testBrowseReferencesToVariableInClass [
 ]
 
 { #category : 'tests' }
+StMethodBrowserTest >> testBrowseTraitMethodOnlyShowConcernedTrait [
+
+	| window | 
+	[
+		window := StMethodBrowser browseReferencesToVariable: (StMethodBrowser slotNamed: #title )inClass: StMethodBrowser.
+
+		self assert: window presenter methods size equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserTest >> testCallerClassIsSetFromConstructor [
 
 	| window browser |
@@ -351,6 +361,16 @@ StMethodBrowserTest >> testReuseWindowCheckboxInitialState [
 		self deny: presenter toolbarPresenter reuseWindowButton state ] ensure: [
 			StMethodBrowser navigateInPlace: initialSetting.
 			presenter ifNotNil: [ presenter delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserTest >> testSendersOfExcludesTraitUsers [
+
+	| senders |
+	senders := StMethodBrowser sendersOf: #sendMe.
+
+	self assert: (senders anySatisfy: [ :m | m methodClass = TData ]).
+	self deny: (senders anySatisfy: [ :m | m methodClass = StMethodBrowserData ])
 ]
 
 { #category : 'tests' }

--- a/src/NewTools-MethodBrowsers/TData.trait.st
+++ b/src/NewTools-MethodBrowsers/TData.trait.st
@@ -1,0 +1,18 @@
+Trait {
+	#name : 'TData',
+	#category : 'NewTools-MethodBrowsers-Tests',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Tests'
+}
+
+{ #category : 'accessing' }
+TData >> sendMe [
+
+	^ 2
+]
+
+{ #category : 'accessing' }
+TData >> sender [
+
+	self sendMe
+]


### PR DESCRIPTION
- When browsing senders of a method coming from a trait, the methods coming from users of the trait were shown too
- Now it is not !
- New test for method exclusion (trait)