### PR TITLE
Hide Refactoring commands in browser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodCodePresenter.class.st
@@ -39,6 +39,7 @@ StMethodCodePresenter >> refactoringCommandsGroup [
 		         beDisplayedAsSubMenu;
 		         iconName: #smallAuthoringTools;
 		         yourself.
-	StRefactoringCommandRegistry commands do: [ :cmdClass | group register: (cmdClass forSpecContext: self methodBrowser) ].
+	StRefactoringCommandRegistry commands do: [ :cmdClass |
+		group register: (cmdClass forSpecContext: self methodBrowser) beHiddenWhenCantBeRun ].
 	^ group
 ]

--- a/src/NewTools-Refactoring-Commands-Tests/ReMoveMethodToClassSideTest.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/ReMoveMethodToClassSideTest.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : 'ReMoveMethodToClassSideTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Refactoring-Commands-Tests',
+	#package : 'NewTools-Refactoring-Commands-Tests'
+}
+
+{ #category : 'tests' }
+ReMoveMethodToClassSideTest >> testMoveInstanceVariableToClassSideCommandSuccess [
+
+	| driver command context |
+	command := StMoveMethodToClassSideCommand new.
+	context := StCommandContextMock new selectedMethod: RBTransformationRuleTestData >> #isEmpty.
+
+	command context: context.
+	driver := command prepareDriver.
+	driver
+		forTesting: true;
+		runRefactoring.
+
+	self assert: driver changes changes size equals: 6
+]

--- a/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -10,7 +10,8 @@ Class {
 		'selectedNode',
 		'variable',
 		'behavior',
-		'method'
+		'method',
+		'methods'
 	],
 	#category : 'NewTools-Refactoring-Commands-Tests',
 	#package : 'NewTools-Refactoring-Commands-Tests'
@@ -80,6 +81,12 @@ StCommandContextMock >> method [
 StCommandContextMock >> method: anObject [
 
 	method := anObject
+]
+
+{ #category : 'accessing' }
+StCommandContextMock >> methods: someMethods [
+
+	methods := someMethods
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
+++ b/src/NewTools-Refactoring-Commands-Tests/StCommandContextMock.class.st
@@ -10,8 +10,7 @@ Class {
 		'selectedNode',
 		'variable',
 		'behavior',
-		'method',
-		'methods'
+		'method'
 	],
 	#category : 'NewTools-Refactoring-Commands-Tests',
 	#package : 'NewTools-Refactoring-Commands-Tests'
@@ -81,12 +80,6 @@ StCommandContextMock >> method [
 StCommandContextMock >> method: anObject [
 
 	method := anObject
-]
-
-{ #category : 'accessing' }
-StCommandContextMock >> methods: someMethods [
-
-	methods := someMethods
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-Refactoring-Commands/StMoveMethodToClassSideCommand.class.st
+++ b/src/NewTools-Refactoring-Commands/StMoveMethodToClassSideCommand.class.st
@@ -1,0 +1,47 @@
+"
+I am a command to move method to the class side of defining class
+"
+Class {
+	#name : 'StMoveMethodToClassSideCommand',
+	#superclass : 'StRefactoringCommand',
+	#category : 'NewTools-Refactoring-Commands',
+	#package : 'NewTools-Refactoring-Commands'
+}
+
+{ #category : 'default' }
+StMoveMethodToClassSideCommand class >> defaultDescription [
+
+	^ 'Move method to the class side.'
+]
+
+{ #category : 'accessing' }
+StMoveMethodToClassSideCommand class >> defaultIconName [
+	^ #smallRedo
+]
+
+{ #category : 'default' }
+StMoveMethodToClassSideCommand class >> defaultName [
+
+	^ '(R) Move to class side'
+]
+
+{ #category : 'accessing' }
+StMoveMethodToClassSideCommand class >> priority [
+
+	^ 9
+]
+
+{ #category : 'testing' }
+StMoveMethodToClassSideCommand >> canBeExecuted [
+
+	| node |
+	node := self codePresenter selectedNode.
+
+	^ node isMethod | node isMessage and: [ node methodNode methodClass isInstanceSide ]
+]
+
+{ #category : 'executing' }
+StMoveMethodToClassSideCommand >> prepareDriver [
+
+	^ ReMoveMethodsToClassSideDriver scopes: context allScopes methods: { self codePresenter selectedMethod }
+]


### PR DESCRIPTION
- When can't be run, a command is hidden instead of being disabled. This makes the list cleaner
- Also introduced `Move method to class side` for Spec + test for the command !