### PR TITLE
Update rewriter tools

### DIFF
--- a/src/NewTools-RewriterTools-Tests/StRewriterRulesHelpPresenterTest.class.st
+++ b/src/NewTools-RewriterTools-Tests/StRewriterRulesHelpPresenterTest.class.st
@@ -33,7 +33,8 @@ StRewriterRulesHelpPresenterTest >> testGetMicrodownParsedText [
 
 	| aText |
 	aText := rulesHelper class getParsedText.
-	self assert: aText isNotEmpty
+	self assert: aText isNotEmpty.
+	self assert: aText isText
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterExpressionFinderPresenter.class.st
@@ -48,8 +48,8 @@ StRewriterExpressionFinderPresenter class >> menuCommandOn: aBuilder [
 		action: [ self new open ];
 		order: 31;
 		parent: #Tools;
-		iconName: self iconName;
-		help: self descriptionText
+		help: self descriptionText;
+		iconName: self iconName
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-RewriterTools/StRewriterHelpBrowserPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterHelpBrowserPresenter.class.st
@@ -15,23 +15,29 @@ Class {
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> basicPatterns [
 
-	^ '(\`) BASIC PATTERN NODES
-
+	^ '##### (\`) BASIC PATTERN NODES
+ 
 Code prefixed with a backtick character (\`) defines a pattern node. A pattern node can be a
 variable or a literal:
 
+```language=text
 `node asString
+```
 
 that will match message asString sent to any receiver.
 It can be a message:
 
+```language=text
 Smalltalk globals `message
+```
 
 that will match any unary message sent to `Smalltalk globals`.
 It can also be a method itself:
 
+```language=text
 `method
 	^ nil
+```
 
 that will match any method which returns nil.
 '
@@ -40,14 +46,16 @@ that will match any method which returns nil.
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> blockPatterns [
 
-	^ '(`{ }) BLOCK PATTERN NODES
-
+	^ '##### (`{ }) BLOCK PATTERN NODES
+ 
 These are the most exotic of all the nodes. They match any AST nodes like a list pattern
 and test it with a block. The syntax is similar to the smalltalk block, but curly braces
 are used instead of square brackets and as always the whole expression begins with a backtick.
 Consider the following example:
 
+```language=text
 `{ :node | node isVariable and: [ node isGlobal ] } become: nil
+```
 
 this pattern will match a message #become: with an attribute nil, where the receiver is a
 variable and it is a global variable.
@@ -56,7 +64,9 @@ There is also a special case called wrapped block pattern node which has the sam
 follows a normal pattern node. In this case first the node will be matched based on its
 pattern, and then passed to the block. For example:
 
+```language=text
 `#arr `{ :node | node isLiteralArray } asArray
+```
 
 is a simple way to detect expression like `#(1 2 3) asArray`.
 In this case first `#(1 2 3)` will be matched by the literal node and then tested by the block.
@@ -72,7 +82,7 @@ StRewriterHelpBrowserPresenter class >> defaultPreferredExtent [
 { #category : 'api' }
 StRewriterHelpBrowserPresenter class >> getParsedText [
 
-	^ String streamContents: [ :stream |
+	^ Microdown asRichText: (String streamContents: [ :stream |
 		stream << self patternCodeIntro << String cr
 			<< self basicPatterns << String cr
 			<< self literalPatterns << String cr
@@ -82,15 +92,15 @@ StRewriterHelpBrowserPresenter class >> getParsedText [
 			<< self namingImportant << String cr
 			<< self whatNext << String cr
 			<< self issues << String cr
-			<< self thanks]
+			<< self thanks])
 ]
 
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> issues [
 
-	^ 'ISSUES?
-
- If you found any issues you can submit them here:
+	^ '##### ISSUES?
+ 
+If you found any issues you can submit them here:
 
 [https://github.com/pharo-spec/NewTools/issues](https://github.com/pharo-spec/NewTools/issues)
 '
@@ -99,21 +109,27 @@ StRewriterHelpBrowserPresenter class >> issues [
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> listPatterns [
 
-	^ '(\`@) LIST PATTERN NODES
-
+	^ '##### (\`@) LIST PATTERN NODES
+ 
 To have complete flexibility there is the possibility to use an at sign `@` before the name
 of a pattern node which turns the node into a `list pattern node`. These nodes can match more
 than a single entity. For example:
 
+```language=text
 `@expr isPatternVariable
+```
 
 will match both messages
 
+```language=text
 1 isPatternVariable
+```
 
 and
 
+```language=text
 ast statement first isPatternVariable.
+```
 
 but in the second case `\`@expr` will represent `ast statement first`. These pattern nodes
 will also match block definitions.
@@ -121,7 +137,9 @@ will also match block definitions.
 With message and method list nodes one can match any number of keywords and parameters.
 An expression:
 
+```language=text
 Smalltalk globals `@message: `@args
+```
 
 will match any message (including) unary sent to `Smalltalk globals` and `\`@args` will be
 mapped to the list of arguments.
@@ -131,24 +149,28 @@ But, following the list pattern grammar makes it easier to read.
 
 Similarly you can match a list of temporary variables:
 
+```language=text
 `@method: `@args
 	| `temp `@temps |
+```
 
 This will match any method with one or more temporary variables and without any statement.
-The first temporary variable will be mapped to `\`temp` the rest ones — to `\`@temps`.
+The first temporary variable will be mapped to `\`temp` and the rest to `\`@temps`.
 
 Finally you can have a list of statements:
 
+```language=text
 [ `.@Statements.
-	`var := `@object ]
+  `var := `@object ]
+```
 
 this expression will match a block which has an assignment of an expression to a variable as a
-last statement. It can be preceded by any number of other statement (including 0).
+last statement. It can be preceded by any number of other statements (including 0).
 
 The list patterns does not make any sense for literal nodes i.e. `\`#@literal`.
 
-P.S. In the end it does not matter whether you will write `\`.@Statement` or `\`@.Statement`.
-But I like to put `@` closer to the variable name as the character is larger itself and the
+P.S. In the end it does not matter whether you write `\`.@Statement` or `\`@.Statement`.
+I like to put `@` closer to the variable name as the character is larger itself and the
 name looks nicer this way.
 '
 ]
@@ -156,25 +178,29 @@ name looks nicer this way.
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> literalPatterns [
 
-	^ '(\`\#) LITERAL PATTERN NODES
+	^ '##### (\`\#) LITERAL PATTERN NODES
+ 
+For variables, backtick can be followed by hash to enforce that matched receiver will be a literal:
 
-For variables backtick can be followed by hash to enforce that matched receiver will be a literal:
-
+```language=text
 `#literal asArray
+```
 '
 ]
 
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> namingImportant [
 
-	^ 'NAMING IS IMPORTANT
+	^ '##### NAMING IS IMPORTANT
+ 
+Pattern nodes can match anything in their place. Their naming is important as the code
+gets mapped to them by name. For example:
 
-The pattern nodes are so that you can match anything in their place. But their naming is also
-important as the code gets mapped to them by name. For example:
-
+```language=text
 `block value: `@expression value: `@expression
+```
 
-will match only those “value:value:” messages that have exactly the same expressions as both
+will match only `value:value:` messages that have exactly the same expressions as both
 arguments. It is like that because we used the same pattern variable name.
 
 You can find more information at [ https://thepharo.dev/2021/12/09/what-is-rbparsetreesearcher/ ](https://thepharo.dev/2021/12/09/what-is-rbparsetreesearcher/)
@@ -184,23 +210,27 @@ You can find more information at [ https://thepharo.dev/2021/12/09/what-is-rbpar
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> patternCodeIntro [
 
-	^ 'PATTERN CODE INTRODUCTION
-
+	^ '##### PATTERN CODE INTRODUCTION
+ 
 Pattern code is very similar to ordinary Smalltalk code, but allows to specify some “wildcards”.
 The purpose is fairly simple. Imagine that you have a piece of code:
 
+```language=text
 car isNil ifTrue: [ ^ self ].
+```
 
 You can of course compare it with the same piece of code for equality, but wouldn''t it be cool
 if you could compare something similar, but ignore the fact that the receiver is named `car`?
 With pattern rules you can do exactly that. Consider the following code and notice the
 backtick before car:
 
+```language=text
 `car isNil ifTrue: [ ^ self ].
+```
 
 Now this expression can match any other expression where `isNil ifTrue: [ ^ self ]` is sent
 to any variable (or literal). With such power you can find all the usages of `isNil ifTrue:`
-and replace them with `ifNil`.
+and replace them with `ifNil:`.
 
 The following sections will go over different kinds of wildcards (pattern nodes).
 '
@@ -209,13 +239,15 @@ The following sections will go over different kinds of wildcards (pattern nodes)
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> statementPatterns [
 
-	^ '(\`.) STATEMENT PATTERN NODES
-
+	^ '##### (\`.) STATEMENT PATTERN NODES
+ 
 Backtick can be followed by a period to match statements. For example:
 
+```language=text
 `var
 	ifTrue:  [ `.statement1 ]
 	ifFalse: [ `.statement2 ]
+```
 
 will match an `ifTrue:ifFalse:` message send to any variable, where both blocks have
 only one statement each.
@@ -235,8 +267,8 @@ Also thanks to him for writing this help description.
 { #category : 'accessing' }
 StRewriterHelpBrowserPresenter class >> whatNext [
 
-	^ 'WHAT IS NEXT?
-
+	^ '##### WHAT IS NEXT?
+ 
 At the moment you can create quality rules that use pattern expression to detect and even
 automatically fix violations.
 

--- a/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterRuleEditorPresenter.class.st
@@ -185,7 +185,7 @@ StRewriterRuleEditorPresenter >> windowIcon [
 ]
 
 { #category : 'accessing' }
-StRewriterRuleEditorPresenter >> windowTile [
+StRewriterRuleEditorPresenter >> windowTitle [
 
-	^ 'Rewrite Basic Editor'
+	^ 'Rewrite Rule Editor'
 ]

--- a/src/NewTools-RewriterTools/StRewriterScopeSelectorPresenter.class.st
+++ b/src/NewTools-RewriterTools/StRewriterScopeSelectorPresenter.class.st
@@ -131,15 +131,6 @@ StRewriterScopeSelectorPresenter >> initializeWithPackages: aPackagesCollection 
 	packagesListWithFilterPresenter items: aPackagesCollection
 ]
 
-{ #category : 'showing' }
-StRewriterScopeSelectorPresenter >> openDialog [
-
-	| window |
-	window := super openDialog.
-	window resize: self class windowExtent.
-	^ window
-]
-
 { #category : 'actions' }
 StRewriterScopeSelectorPresenter >> packagesChanged [
 


### PR DESCRIPTION
Some improvements to the RewriterTools package:

1. `StRewriterScopeSelectorPresenter` opened debugger when executing [`openDialog`](https://github.com/pharo-spec/NewTools/blob/003ab41d42689e139d8d3af8e7e726a5c240ec4c/src/NewTools-RewriterTools/StRewriterScopeSelectorPresenter.class.st#L139) because its class does not implement `windowExtent`. Simply removing the method makes it behave as intended.

2. `StRewriterRuleEditorPresenter` produced unnamed windows because its title method was incorrectly named `windowTile` instead of `windowTitle`. I also renamed the window to match the name that appears in the "Library" World menu.

3. The help presenter now uses rich Text, which seems to align with the original intention. I also added section headers, code blocks, and simplified the prose a bit where I thought it would help.