### PR TITLE
Tabs for the new Method Browser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowser.class.st
@@ -20,10 +20,10 @@ Class {
 		'highlight',
 		'filterPresenter',
 		'allMethods',
-		'callerClass'
+		'callerClass',
+		'titleChangedCallbacks'
 	],
 	#classVars : [
-		'NavigateInPlace',
 		'UsingLayout'
 	],
 	#category : 'NewTools-MethodBrowsers-Senders',
@@ -160,7 +160,7 @@ StMethodBrowser class >> browse: compiledMethods withInitializationBlock: aBlock
 			^ nil ].
 
 
-	^ browser open
+	^ StMethodBrowserGroup addOrCreateTab: browser
 ]
 
 { #category : 'opening' }
@@ -317,30 +317,6 @@ StMethodBrowser class >> methods: methods [
 	^ self new 
 		  methods: methods;
 		  yourself
-]
-
-{ #category : 'private' }
-StMethodBrowser class >> navigateInPlace [
-
-	^ NavigateInPlace ifNil: [ NavigateInPlace := false ]  
-]
-
-{ #category : 'private' }
-StMethodBrowser class >> navigateInPlace: aBoolean [
-
-	NavigateInPlace := aBoolean 
-]
-
-{ #category : 'private' }
-StMethodBrowser class >> navigateInPlaceSettingsOn: aBuilder [
-
-	<systemsettings>
-	(aBuilder setting: #navigateInPlace)
-		label: 'Navigate in place in Method Browser';
-		description:
-			'When browsing senders/implementors/references from a Method Browser, reuse the current window instead of opening a new one';
-		target: self;
-		parent: #tools
 ]
 
 { #category : 'private' }
@@ -530,7 +506,7 @@ StMethodBrowser >> connectPresenters [
 														methodList unselectAll.
 														self selectIndex: oldIndex ] ensure: [ isReverting := false ] ] ] ] ];
 		whenModelChangedDo: [ self updateTitle ].
-	methodList navigationBlock: [ :type :val | self navigateTo: type value: val ].
+
 	textPresenter
 		whenSubmitDo: [ :text | self accept: text notifying: textPresenter interactionModel ];
 		whenResetDo: [ self selectItem: methodList selectedMethod ].
@@ -797,6 +773,12 @@ StMethodBrowser >> intervalOf: aSelector inCommentText: aText [
 	^ self searchedString: aSelector asString in: aText
 ]
 
+{ #category : 'testing' }
+StMethodBrowser >> isDirty [
+
+	^ textPresenter isDirty
+]
+
 { #category : 'api - private' }
 StMethodBrowser >> itemMatching: aCompiledMethod [
 
@@ -906,30 +888,6 @@ StMethodBrowser >> methods: compiledMethods asSendersOfAll: aCollectionOfSymbols
 		title: 'Senders of ' , (', ' join: aCollectionOfSymbols)
 ]
 
-{ #category : 'private' }
-StMethodBrowser >> navigateInPlace [
-
-	^ self class navigateInPlace
-]
-
-{ #category : 'private' }
-StMethodBrowser >> navigateTo: aType value: anObject [
-
-	self navigateInPlace ifFalse: [
-			aType == #implementorsAll ifTrue: [
-				self class browse: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject from: nil ].
-			aType == #sendersAll ifTrue: [
-				self class browse: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject from: nil ].
-			aType == #references ifTrue: [ ^ self class browseReferencesToClass: anObject ].
-			^ self ].
-
-	aType == #implementorsAll ifTrue: [
-		self methods: (anObject flatCollect: [ :sel | self class implementorsOf: sel ]) asImplementorsOfAll: anObject ].
-	aType == #sendersAll ifTrue: [
-		self methods: (anObject flatCollect: [ :sel | self class sendersOf: sel ]) asSendersOfAll: anObject ].
-	aType == #references ifTrue: [ self methods: (self class referencesToClass: anObject) asReferenceTo: anObject ]
-]
-
 { #category : 'initialization' }
 StMethodBrowser >> newMethodToolbar [
 
@@ -942,6 +900,13 @@ StMethodBrowser >> newMethodToolbar [
 StMethodBrowser >> numberOfElements [ 
 	
 	^ methodList ifNil: [ 0 ] ifNotNil: [ methodList numberOfElements ]
+]
+
+{ #category : 'enumerating' }
+StMethodBrowser >> onTitleChangedDo: aBlock [
+
+	titleChangedCallbacks ifNil: [ titleChangedCallbacks := OrderedCollection new ].
+	titleChangedCallbacks add: aBlock
 ]
 
 { #category : 'private' }
@@ -1111,9 +1076,20 @@ StMethodBrowser >> topologicSort: aBoolean [
 	^ methodList topologicSort: aBoolean
 ]
 
+{ #category : 'system annoucements' }
+StMethodBrowser >> unregisterFromAnnouncements [
+
+	TestCase historyAnnouncer unsubscribe: methodList.
+	self class codeChangeAnnouncer unsubscribe: self
+]
+
 { #category : 'api' }
 StMethodBrowser >> updateTitle [
-	self withWindowDo: [ :window | window title: self windowTitle ]
+    | newTitle |
+    newTitle := self windowTitle.
+    self withWindowDo: [ :window | window title: newTitle ].
+    titleChangedCallbacks ifNotNil: [
+        titleChangedCallbacks do: [ :callback | callback value: newTitle ] ]
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -19,9 +19,11 @@ Class {
 StMethodBrowserGroup class >> addOrCreateTab: aMethodBrowser [
 	"Main entry point. Find or create the group window, add a tab for aMethodBrowser."
 
-	(Current isNil or: [ Current isDisplayed not ]) ifTrue: [
-			Current := self new.
-			Current open ].
+	(Current isNil or: [ Current isDisplayed not ])
+		ifTrue: [
+				Current := self new.
+				Current open ]
+		ifFalse: [ Current window activate ].
 
 	aMethodBrowser application: Current application.
 	aMethodBrowser owner: Current.

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -1,0 +1,100 @@
+"
+I am a presenter representing a group for method browsers, allowing them to open as tabs.
+"
+Class {
+	#name : 'StMethodBrowserGroup',
+	#superclass : 'StPresenter',
+	#instVars : [
+		'notebook'
+	],
+	#classVars : [
+		'Current'
+	],
+	#category : 'NewTools-MethodBrowsers-Senders',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Senders'
+}
+
+{ #category : 'adding' }
+StMethodBrowserGroup class >> addOrCreateTab: aMethodBrowser [
+	"Main entry point. Find or create the group window, add a tab for aMethodBrowser."
+
+	(Current isNil or: [ Current isDisplayed not ]) ifTrue: [
+			Current := self new.
+			Current open ].
+
+	aMethodBrowser application: Current application.
+	aMethodBrowser owner: Current.
+	Current addTab: aMethodBrowser.
+	^ aMethodBrowser
+]
+
+{ #category : 'accessing' }
+StMethodBrowserGroup class >> current [
+
+	^ Current
+]
+
+{ #category : 'initialization' }
+StMethodBrowserGroup class >> reset [
+
+	<script>
+	Current := nil
+]
+
+{ #category : 'adding' }
+StMethodBrowserGroup >> addTab: aMethodBrowser [
+
+	| page |
+
+	page := SpNotebookPage title: aMethodBrowser windowTitle provider: [ aMethodBrowser ].
+
+	aMethodBrowser onTitleChangedDo: [ :newTitle |
+			page title: newTitle.
+			notebook pageTitleChanged: page ].
+	notebook addPage: page.
+	notebook selectPage: page
+]
+
+{ #category : 'initialization' }
+StMethodBrowserGroup >> connectPresenters [
+
+	notebook whenSelectedPageChangedDo: [ :page | page ifNotNil: [ self withWindowDo: [ :window | window title: page title ] ] ]
+]
+
+{ #category : 'layout' }
+StMethodBrowserGroup >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: notebook;
+		  yourself
+]
+
+{ #category : 'initialization' }
+StMethodBrowserGroup >> initializePresenters [
+
+	notebook := self newNotebook
+]
+
+{ #category : 'initialization' }
+StMethodBrowserGroup >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter
+		title: 'Message Browser';
+		initialExtent: 900 @ 600.
+	aWindowPresenter whenWillCloseDo: [ :ann |
+			(notebook pages anySatisfy: [ :page | page activePresenter ifNil: [ false ] ifNotNil: [ :browser | browser isDirty ] ])
+				ifTrue: [
+						(self application confirm: 'Some tabs have unsaved changes.
+Is it OK to discard changes?') ifFalse: [ ann denyClose ] ] ].
+	aWindowPresenter whenClosedDo: [
+			notebook pages do: [ :page | page activePresenter ifNotNil: [ :browser | browser unregisterFromAnnouncements ] ].
+			self class reset ]
+]
+
+{ #category : 'accessing' }
+StMethodBrowserGroup >> notebook [
+
+	^ notebook
+]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : 'StMethodBrowserGroupTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-MethodBrowsers-Tests',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+StMethodBrowserGroupTest >> testAddTabCreatesNewPage [
+
+	| browser group |
+	[
+		browser := StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		group := StMethodBrowserGroup current.
+		self assert: group notebook pages size equals: 1.
+		self assert: group notebook selectedPage title equals: browser windowTitle ] ensure: [
+			StMethodBrowserGroup reset.
+			group ifNotNil: [ group window delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserGroupTest >> testAddTwoTabsReusesSameGroup [
+
+	| browser1 browser2 group |
+	[
+		browser1 := StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		browser2 := StMethodBrowser browseImplementorsOf: #browseSendersOf:.
+		group := StMethodBrowserGroup current.
+		self assert: group notebook pages size equals: 2 ] ensure: [
+			StMethodBrowserGroup reset.
+			group ifNotNil: [ group window delete ] ]
+]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserTest.class.st
@@ -15,49 +15,49 @@ StMethodBrowserTest >> dataMethodForTest [
 { #category : 'tests' }
 StMethodBrowserTest >> testBrowseClassNameAsClass [
 
-	| window |
+	| browser |
 	[
-		window := StMethodBrowser browseReferencesToClass: StMethodBrowserDummyClass.
+		browser := StMethodBrowser browseReferencesToClass: StMethodBrowserDummyClass.
 
-		self assert: window presenter methods size equals: 6] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: 6] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testBrowseClassNameAsLiteral [
 
-	| window |
+	| browser |
 	[
-		window := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
+		browser := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
 
-		self assert: window presenter methods size equals: 4 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: 4 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testBrowseReferencesToVariableInClass [
 
-	| window | 
+	| browser | 
 	[
-		window := StMethodBrowser browseReferencesToVariable: (StMethodBrowser slotNamed: #title )inClass: StMethodBrowser.
+		browser := StMethodBrowser browseReferencesToVariable: (StMethodBrowser slotNamed: #title )inClass: StMethodBrowser.
 
-		self assert: window presenter methods size equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: 2 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testCallerClassIsSetFromConstructor [
 
-	| window browser |
+	| browser |
 	[
-		window := StMethodBrowser browseImplementorsOf: #printOn: from: self class.
-		browser := window presenter.
+		browser := StMethodBrowser browseImplementorsOf: #printOn: from: self class.
+
 
 		self assert: browser callerClass isNotNil.
-		self assert: browser callerClass identicalTo: self class ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser callerClass identicalTo: self class ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testDeprecatedMethodDisplayedStruckOut [
 
-	| window browser deprecatedMethod label column |
+	| browser deprecatedMethod label column |
 	[
 		self class
 			compile: 'tmpDeprecatedMethod
@@ -66,8 +66,7 @@ StMethodBrowserTest >> testDeprecatedMethodDisplayedStruckOut [
 			classified: 'tests-protocol'.
 		deprecatedMethod := self class >> #tmpDeprecatedMethod.
 
-		window := StMethodBrowser browseImplementorsOf: #tmpDeprecatedMethod.
-		browser := window presenter.
+		browser := StMethodBrowser browseImplementorsOf: #tmpDeprecatedMethod.
 		column := browser methodList listPresenter contentView columns detect: [ :col | col title = 'Selector' ].
 		label := SpLabelPresenter new.
 		column bindAction value: label value: deprecatedMethod.
@@ -75,62 +74,63 @@ StMethodBrowserTest >> testDeprecatedMethodDisplayedStruckOut [
 
 		self assert: (label displayStrikethrough cull: deprecatedMethod) ] ensure: [
 			self class removeSelector: #tmpDeprecatedMethod.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testExplicitBrowseClassNameAsClass [
 
-	| window |
+	| browser |
 	[
-		window := StMethodBrowser
+		browser := StMethodBrowser
 			          browse: {
 					          (StMethodBrowserTest >> #testBrowseClassNameAsClass).
 					          (StMethodBrowserTest >> #testExplicitBrowseClassNameAsClass) }
 			          asReferencesToClass: StMethodBrowserDummyClass.
 
-		self assert: window presenter methods size equals: 2 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: 2 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testExplicitBrowseClassNameAsLiteral [
 
-	| window |
+	| browser |
 	[
-	window := StMethodBrowser 
-		browse: { StMethodBrowserTest>>#dataMethodForTest . StMethodBrowserTest>>#testExplicitBrowseClassNameAsLiteral } 
-		asReferencesToLiteral: 'StMethodBrowser'.
+		browser := StMethodBrowser
+			           browse: {
+					           (StMethodBrowserTest >> #dataMethodForTest).
+					           (StMethodBrowserTest >> #testExplicitBrowseClassNameAsLiteral) }
+			           asReferencesToLiteral: 'StMethodBrowser'.
 
-	self assert: window presenter methods size equals: 2  ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: 2 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testExplicitBrowseImplementors [
 
-	| window |
+	| browser |
 	[
-		window := StMethodBrowser
-			          browse: { (StMethodBrowser >> #methods:asImplementorsOfAll:) }
-			          asImplementorsOf: #methods:asImplementorsOfAll:.
-		self assert: window presenter methods size equals: 1 ] ensure: [ window ifNotNil: [ window delete ] ]
+		browser := StMethodBrowser
+			           browse: { (StMethodBrowser >> #methods:asImplementorsOfAll:) }
+			           asImplementorsOf: #methods:asImplementorsOfAll:.
+		self assert: browser methods size equals: 1 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testExplicitBrowseSenders [
 
-	| window |
+	| browser |
 	[
-		window := StMethodBrowser browse: { (StMethodBrowserTest >> #testMethodBrowserSenders) } asSendersOf: #browseImplementorsOf:.
-		self assert: window presenter methods size equals: 1 ] ensure: [ window ifNotNil: [ window delete ] ]
+		browser := StMethodBrowser browse: { (StMethodBrowserTest >> #testMethodBrowserSenders) } asSendersOf: #browseImplementorsOf:.
+		self assert: browser methods size equals: 1 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodAddedAddsMatchingSender [
 
-	| window browser initialSize newMethod |
+	| browser initialSize newMethod |
 	[
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		initialSize := browser methods size.
 
 		self class compile: 'tmpSenderMethodForTest ^ self printOn: String new' classified: 'tests-protocol'.
@@ -141,16 +141,15 @@ StMethodBrowserTest >> testHandleMethodAddedAddsMatchingSender [
 		self assert: browser methods size equals: initialSize + 1.
 		self assert: (browser methods includes: newMethod) ] ensure: [
 			self class removeSelector: #tmpSenderMethodForTest.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems [
 
-	| window browser total newMethod |
+	| browser total newMethod |
 	[
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		total := browser filterPresenter unfilteredItems size.
 		self assert: total > 0.
 		browser filterPresenter filterInputPresenter text: 'zzznomatch'.
@@ -161,19 +160,18 @@ StMethodBrowserTest >> testHandleMethodAddedWithActiveFilterKeepsUnfilteredItems
 
 		self assert: browser filterPresenter unfilteredItems size > total ] ensure: [
 			self class removeSelector: #tmpSenderMethodForTest.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodModifiedPreservesOrder [
 
-	| window browser method initialOrder indexBefore |
+	| browser method initialOrder indexBefore |
 	[
 		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
 		method := self class >> #methodForTest.
 
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		initialOrder := browser methods copy.
 		indexBefore := initialOrder indexOf: method.
 		self assert: indexBefore > 0.
@@ -183,20 +181,19 @@ StMethodBrowserTest >> testHandleMethodModifiedPreservesOrder [
 			(MethodModified methodChangedFrom: method to: self class >> #methodForTest oldProtocol: method protocol).
 		self assert: (browser methods indexOf: self class >> #methodForTest) equals: indexBefore ] ensure: [
 			self class removeSelector: #methodForTest.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodModifiedPreservesScopeSelection [
 	"After a method is modified, the selected scope should remain the same"
 
-	| window browser method |
+	| browser method |
 	[
 		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
 		method := self class >> #methodForTest.
 
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		browser selectIndex: 1.
 
 		browser toolbarPresenter scopeList selectIndex: 3.
@@ -208,19 +205,18 @@ StMethodBrowserTest >> testHandleMethodModifiedPreservesScopeSelection [
 
 		self assert: browser toolbarPresenter scopeList selectedIndex equals: 3 ] ensure: [
 			self class removeSelector: #methodForTest.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodModifiedRemovesSenderWhenNoLongerMatching [
 
-	| window browser method |
+	| browser method |
 	[
 		self class compile: 'methodForTest ^ Object new printOn: Transcript' classified: 'tests-protocol'.
 		method := self class >> #methodForTest.
 
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		self assert: (browser methods includes: method).
 		self class compile: 'methodForTest ^ Object new'.
 		browser handleMethodModified:
@@ -228,17 +224,15 @@ StMethodBrowserTest >> testHandleMethodModifiedRemovesSenderWhenNoLongerMatching
 
 		self deny: (browser methods includes: method) ] ensure: [
 			self class removeSelector: #methodForTest.
-			window ifNotNil: [ window delete ] ]
+			browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodRemovedRemovesMatchingMethod [
 
-	| window browser method announcement initialSize |
+	| browser method announcement initialSize |
 	[
-		window := StMethodBrowser browseImplementorsOf: #printOn:.
-		browser := window presenter.
-
+		browser := StMethodBrowser browseImplementorsOf: #printOn:.
 		method := browser methods anyOne.
 		initialSize := browser methods size.
 
@@ -246,16 +240,16 @@ StMethodBrowserTest >> testHandleMethodRemovedRemovesMatchingMethod [
 
 		browser handleMethodRemoved: announcement.
 
-		self assert: browser methods size equals: initialSize - 1 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods size equals: initialSize - 1 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
 
-	| window browser method |
+	| browser method |
 	[
-		window := StMethodBrowser browseImplementorsOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseImplementorsOf: #printOn:.
+
 
 		method := browser methods third.
 		browser methodList unselectAll.
@@ -263,94 +257,76 @@ StMethodBrowserTest >> testHandleMethodRemovedUpdatesSelection [
 
 		browser handleMethodRemoved: (MethodRemoved new method: method compiledMethod).
 		self currentWorld doOneCycle.
-		self assert: (browser methods indexOf: browser selectedMethod) equals: 3 ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: (browser methods indexOf: browser selectedMethod) equals: 3 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testHighlightSelectsFirstOccurrence [
 
-	| window browser interval |
+	| browser interval |
 	[
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
 		interval := browser codeEditor codePresenter selectionInterval.
 
 		self assert: interval isNotEmpty.
 		self assert: ((browser codeEditor text copyFrom: interval first to: interval last) includesSubstring: 'printOn:') ] ensure: [
-		window ifNotNil: [ window delete ] ]
+		browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testMethodBrowserImplementors [
 
-	| window |
-	[ window := StMethodBrowser browseImplementorsOf: #printOn:. 
-	window presenter methods size > 0 ] 
-		ensure: [ window ifNotNil: [ window delete ] ]
+	| browser |
+	[
+		browser := StMethodBrowser browseImplementorsOf: #printOn:.
+		browser methods size > 0 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testMethodBrowserSenders [
 
-	| window |
+	| browser |
 	[
-	window := StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
-	window presenter methods size > 0 ] ensure: [ window ifNotNil: [ window delete ] ]
+		browser := StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		browser methods size > 0 ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testMethodsAreSortedByHierarchy [
 
-	| window browser methodObject methodCollection methodArray |
+	| browser methodObject methodCollection methodArray |
 	methodObject := Object >> #printString.
 	methodCollection := Collection >> #size.
 	methodArray := Array >> #asArray.
 
 	[
-		window := StMethodBrowser browse: {
-				          methodArray.
-				          methodObject.
-				          methodCollection }.
-		browser := window presenter.
-
+		browser := StMethodBrowser browse: {
+				           methodArray.
+				           methodObject.
+				           methodCollection }.
 		self assert: browser methods first compiledMethod equals: methodObject.
 		self assert: browser methods second compiledMethod equals: methodCollection.
-		self assert: browser methods third compiledMethod equals: methodArray ] ensure: [ window ifNotNil: [ window delete ] ]
+		self assert: browser methods third compiledMethod equals: methodArray ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests - smoke' }
 StMethodBrowserTest >> testOpenWithoutMessageShouldNotDNU [
 
-	| br |
-	br := StMethodBrowser new.
-	self shouldnt: [ br open ] raise: MessageNotUnderstood
+	| browser |
+	[
+		browser := StMethodBrowser new.
+		self shouldnt: [ browser open ] raise: MessageNotUnderstood ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
 StMethodBrowserTest >> testRefreshingBlockWithLiteralString [
 
-	| window browser methodToAdd |
+	| browser methodToAdd |
 	[
-		window := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
-		browser := window presenter.
+		browser := StMethodBrowser browseReferencesToLiteral: 'StMethodBrowser'.
+
 		methodToAdd := (self class >> #dataMethodForTest) copy.
-		self assert: (browser refreshingBlock value: methodToAdd) ] ensure: [ window ifNotNil: [ window delete ] ]
-]
-
-{ #category : 'tests' }
-StMethodBrowserTest >> testReuseWindowCheckboxInitialState [
-
-	| presenter initialSetting |
-	initialSetting := StMethodBrowser navigateInPlace.
-	[
-		StMethodBrowser navigateInPlace: true.
-		presenter := StMethodBrowser new.
-		self assert: presenter toolbarPresenter reuseWindowButton state.
-		StMethodBrowser navigateInPlace: false.
-		presenter := StMethodBrowser new.
-		self deny: presenter toolbarPresenter reuseWindowButton state ] ensure: [
-			StMethodBrowser navigateInPlace: initialSetting.
-			presenter ifNotNil: [ presenter delete ] ]
+		self assert: (browser refreshingBlock value: methodToAdd) ] ensure: [ browser ifNotNil: [ browser delete ] ]
 ]
 
 { #category : 'tests' }
@@ -415,10 +391,10 @@ StMethodBrowserTest >> testSendersOfExcludesTraitUsers [
 { #category : 'tests' }
 StMethodBrowserTest >> testWindowTitleWithFilterRatio [
 
-	| window browser total filtered |
+	| browser total filtered |
 	[
-		window := StMethodBrowser browseSendersOf: #printOn:.
-		browser := window presenter.
+		browser := StMethodBrowser browseSendersOf: #printOn:.
+
 
 		total := browser methods size.
 
@@ -427,5 +403,5 @@ StMethodBrowserTest >> testWindowTitleWithFilterRatio [
 
 		self assert: filtered < total.
 		self assert: (browser windowTitle includesSubstring: filtered asString , '/' , total asString) ] ensure: [
-		window ifNotNil: [ window delete ] ]
+		browser ifNotNil: [ browser delete ] ]
 ]

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -23,8 +23,7 @@ Class {
 		'listPresenter',
 		'scopes',
 		'allMessages',
-		'visitedScopes',
-		'navigationBlock'
+		'visitedScopes'
 	],
 	#category : 'NewTools-MethodBrowsers-Base',
 	#package : 'NewTools-MethodBrowsers',
@@ -195,9 +194,7 @@ StMethodListPresenter >> doBrowseImplementors [
 	| selectors |
 	selectors := self selectedMethods collect: [ :method | method selector ].
 
-	navigationBlock
-		ifNotNil: [ navigationBlock value: #implementorsAll value: selectors ]
-		ifNil: [ StMethodBrowser browseImplementorsOfAll: selectors from: self class ]
+	StMethodBrowser browseImplementorsOfAll: selectors from: self class
 ]
 
 { #category : 'private - actions' }
@@ -212,9 +209,7 @@ StMethodListPresenter >> doBrowseSenders [
 	| selectors |
 	selectors := self selectedMethods collect: [ :method | method selector ].
 
-	navigationBlock
-		ifNotNil: [ navigationBlock value: #sendersAll value: selectors ]
-		ifNil: [ StMethodBrowser browseSendersOfAll: selectors from: self class]
+	StMethodBrowser browseSendersOfAll: selectors from: self class
 ]
 
 { #category : 'private - actions' }
@@ -223,9 +218,7 @@ StMethodListPresenter >> doBrowseUsers [
 	| class |
 	class := self selectedMethod methodClass.
 
-	navigationBlock
-		ifNotNil: [ navigationBlock value: #references value: class ]
-		ifNil: [ StMethodBrowser browseReferencesToClass: class ]
+	StMethodBrowser browseReferencesToClass: class
 ]
 
 { #category : 'private - actions' }
@@ -401,12 +394,6 @@ StMethodListPresenter >> methods: aCollection [
 	allMessages := listPresenter items.
 
 
-]
-
-{ #category : 'accessing' }
-StMethodListPresenter >> navigationBlock: aBlock [
-
-	navigationBlock := aBlock
 ]
 
 { #category : 'private - scopes' }

--- a/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodToolbarPresenter.class.st
@@ -17,7 +17,6 @@ Class {
 		'toolbarPresenter',
 		'messageList',
 		'runTestsButton',
-		'reuseWindowButton',
 		'historyButton',
 		'copyButton'
 	],
@@ -120,14 +119,6 @@ StMethodToolbarPresenter >> emptyDropList [
 ]
 
 { #category : 'initialization' }
-StMethodToolbarPresenter >> iconForReuseState: aBoolean [
-
-	^ aBoolean
-		  ifTrue: [ self iconNamed: #checkboxSelected ]
-		  ifFalse: [ self iconNamed: #checkboxUnselected ]
-]
-
-{ #category : 'initialization' }
 StMethodToolbarPresenter >> initializePresenters [
 
 	(browseButton := self newToolbarButton)
@@ -139,7 +130,7 @@ StMethodToolbarPresenter >> initializePresenters [
 		label: 'References';
 		icon: (self iconNamed: #smallFind);
 		help: 'Browse references of current selected class';
-		action: [ self doBrowseUsers ]. 
+		action: [ self doBrowseUsers ].
 	(sendersButton := self newToolbarButton)
 		label: 'Senders';
 		icon: (self iconNamed: #smallFind);
@@ -171,17 +162,7 @@ StMethodToolbarPresenter >> initializePresenters [
 		icon: (self iconNamed: #smallCopy);
 		help: 'Copy selected methods into Clipboard as class>>selector';
 		action: [ self doCopy ].
-	reuseWindowButton := self newToolbarToggleButton
-		                     label: 'Reuse window';
-		                     help: 'If checked, new searches will replace current results.';
-		                     state: StMethodBrowser navigateInPlace;
-		                     icon: (self iconForReuseState: StMethodBrowser navigateInPlace);
-		                     whenActivatedDo: [
-				                     StMethodBrowser navigateInPlace: true.
-				                     reuseWindowButton icon: (self iconForReuseState: true) ];
-		                     whenDeactivatedDo: [
-				                     StMethodBrowser navigateInPlace: false.
-				                     reuseWindowButton icon: (self iconForReuseState: false) ].
+
 	toolbarPresenter := self newToolbar
 		                    displayMode: self application toolbarDisplayMode;
 		                    add: browseButton;
@@ -191,7 +172,6 @@ StMethodToolbarPresenter >> initializePresenters [
 		                    add: versionButton;
 		                    add: historyButton;
 		                    add: copyButton;
-		                    add: reuseWindowButton;
 		                    add: runTestsButton;
 		                    yourself.
 
@@ -224,12 +204,6 @@ StMethodToolbarPresenter >> replaceVersionWithLabel: aString action: aBlock [
 	versionButton 
 		label: aString;
 		action: aBlock
-]
-
-{ #category : 'accessing' }
-StMethodToolbarPresenter >> reuseWindowButton [
-
-	^ reuseWindowButton
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- Method browser results now open as tabs in a single window, following the same pattern as Iceberg's repository browser.
- The group window title updates to reflect the currently selected tab
- Tab titles update dynamically when filter/count changes
- Unsaved changes across all tabs are checked before closing the group window
- Removed `Navigate in Place` feature since it was temporary until the tabs
- If the window is hidden while a user triggers a query, the window activates and pop on top of the other windows
- Added two tests for tab creation and addition !