### PR TITLE
Fix search of StBrowserSearchPresenter

### DIFF
--- a/src/NewTools-Core-Tests/StBrowserSearchPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StBrowserSearchPresenterTest.class.st
@@ -1,0 +1,28 @@
+"
+A StBrowserSearchPresenterTest is a test class for testing the behavior of StBrowserSearchPresenter
+"
+Class {
+	#name : 'StBrowserSearchPresenterTest',
+	#superclass : 'TestCase',
+	#category : 'NewTools-Core-Tests-Calypso',
+	#package : 'NewTools-Core-Tests',
+	#tag : 'Calypso'
+}
+
+{ #category : 'tests' }
+StBrowserSearchPresenterTest >> testSearchOfCompileMethods [
+	"Regression test. In the past, when we searched for methods, it was not using the display block to search. So it was filtering also based on the class containing the method.
+	Now it applies the display block before filtering."
+
+	| presenter methodsToSelect |
+	presenter := StBrowserSearchPresenter new
+		             items: StBrowserSearchPresenter localMethods;
+		             display: [ :aMethod | aMethod selector ].
+
+	methodsToSelect := StBrowserSearchPresenter localMethods select: [ :method | method selector includesSubstring: 'search' caseSensitive: false ].
+
+	presenter searchValue: 'Search'.
+	presenter updateList.
+
+	self assertCollection: presenter itemsList items hasSameElements: methodsToSelect
+]

--- a/src/NewTools-Core-Tests/StBrowserSearchPresenterTest.class.st
+++ b/src/NewTools-Core-Tests/StBrowserSearchPresenterTest.class.st
@@ -14,14 +14,18 @@ StBrowserSearchPresenterTest >> testSearchOfCompileMethods [
 	"Regression test. In the past, when we searched for methods, it was not using the display block to search. So it was filtering also based on the class containing the method.
 	Now it applies the display block before filtering."
 
-	| presenter methodsToSelect |
+	| presenter methodsToSelect pattern |
+	pattern := 'Search'.
+	self
+		assert: (StBrowserSearchPresenter name includesSubstring: pattern)
+		description: 'This test ensure we search only the selector of a compiled method and not the class name. So the class name needs to contain the pattern.'.
 	presenter := StBrowserSearchPresenter new
 		             items: StBrowserSearchPresenter localMethods;
 		             display: [ :aMethod | aMethod selector ].
 
-	methodsToSelect := StBrowserSearchPresenter localMethods select: [ :method | method selector includesSubstring: 'search' caseSensitive: false ].
+	methodsToSelect := StBrowserSearchPresenter localMethods select: [ :method | method selector includesSubstring: pattern caseSensitive: false ].
 
-	presenter searchValue: 'Search'.
+	presenter searchValue: pattern.
 	presenter updateList.
 
 	self assertCollection: presenter itemsList items hasSameElements: methodsToSelect

--- a/src/NewTools-Core/StBrowserSearchPresenter.class.st
+++ b/src/NewTools-Core/StBrowserSearchPresenter.class.st
@@ -76,6 +76,18 @@ StBrowserSearchPresenter >> defaultLayout [
 		  yourself
 ]
 
+{ #category : 'api' }
+StBrowserSearchPresenter >> display: aBlock [
+
+	itemsList display: aBlock
+]
+
+{ #category : 'api' }
+StBrowserSearchPresenter >> displayOf: anItem [
+
+	^ itemsList display value: anItem
+]
+
 { #category : 'initialization' }
 StBrowserSearchPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 
@@ -151,9 +163,7 @@ StBrowserSearchPresenter >> search: text [
 	"Main search callback method. Answer a <Collection> of results"
 
 	^ OrderedCollection streamContents: [ :stream |
-		  items do: [ :class |
-			  (self selectBlock value: class name value: text)  
-					ifTrue: [ stream nextPut: class ] ] ]
+		  items do: [ :item | (self selectBlock value: (self displayOf: item) value: text) ifTrue: [ stream nextPut: item ] ] ]
 ]
 
 { #category : 'instance creation' }
@@ -191,7 +201,7 @@ StBrowserSearchPresenter >> searchValue: aString [
 { #category : 'api' }
 StBrowserSearchPresenter >> searchWithItem: anItem [
 
-	self searchValue: (itemsList display value: anItem)
+	self searchValue: (self displayOf: anItem)
 ]
 
 { #category : 'updating' }


### PR DESCRIPTION
The search was always using #name but it is possible to define another dislpay block. Now it reuses the display block to do the search. 

Before if we did a find on a method list, the search was also matching the class name. Now it does it only on the selector