### PR TITLE
Method Browser tabs bug fixes

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -48,20 +48,22 @@ StMethodBrowserGroup class >> reset [
 StMethodBrowserGroup >> addTab: aMethodBrowser [
 
 	| page |
-
 	page := SpNotebookPage title: aMethodBrowser windowTitle provider: [ aMethodBrowser ].
+	page beCloseable.
 
 	aMethodBrowser onTitleChangedDo: [ :newTitle |
 			page title: newTitle.
 			notebook pageTitleChanged: page ].
 	notebook addPage: page.
-	notebook selectPage: page
+	notebook selectPage: page.
+	self defer: [ aMethodBrowser methodList listPresenter takeKeyboardFocus ]
 ]
 
 { #category : 'initialization' }
 StMethodBrowserGroup >> connectPresenters [
 
-	notebook whenSelectedPageChangedDo: [ :page | page ifNotNil: [ self withWindowDo: [ :window | window title: page title ] ] ]
+	notebook whenSelectedPageChangedDo: [ :page | page ifNotNil: [ self withWindowDo: [ :window | window title: page title ] ] ].
+	notebook whenPageRemovedDo: [ :page | page activePresenter ifNotNil: [ :browser | browser unregisterFromAnnouncements ] ]
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -74,6 +74,14 @@ StMethodBrowserGroup >> defaultLayout [
 		  yourself
 ]
 
+{ #category : 'closing' }
+StMethodBrowserGroup >> handleTabsFor: anAnnouncement [
+
+	notebook pages size > 1 ifFalse: [ ^ self ].
+	anAnnouncement denyClose.
+	notebook removePage: notebook selectedPage
+]
+
 { #category : 'initialization' }
 StMethodBrowserGroup >> initializePresenters [
 
@@ -84,10 +92,12 @@ StMethodBrowserGroup >> initializePresenters [
 StMethodBrowserGroup >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
+
 	aWindowPresenter
 		title: 'Message Browser';
 		initialExtent: 900 @ 600.
 	aWindowPresenter whenWillCloseDo: [ :ann |
+			self handleTabsFor: ann.
 			(notebook pages anySatisfy: [ :page | page activePresenter ifNil: [ false ] ifNotNil: [ :browser | browser isDirty ] ])
 				ifTrue: [
 						(self application confirm: 'Some tabs have unsaved changes.

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
@@ -22,12 +22,29 @@ StMethodBrowserGroupTest >> testAddTabCreatesNewPage [
 { #category : 'tests' }
 StMethodBrowserGroupTest >> testAddTwoTabsReusesSameGroup [
 
-	| browser1 browser2 group |
+	| group |
 	[
-		browser1 := StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
-		browser2 := StMethodBrowser browseImplementorsOf: #browseSendersOf:.
+		StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		StMethodBrowser browseImplementorsOf: #browseSendersOf:.
 		group := StMethodBrowserGroup current.
 		self assert: group notebook pages size equals: 2 ] ensure: [
+			StMethodBrowserGroup reset.
+			group ifNotNil: [
+					group window delete.
+					group window delete ] ]
+]
+
+{ #category : 'tests' }
+StMethodBrowserGroupTest >> testRemovePageWhenMultipleDoesNotCloseTheGroup [
+
+	| group |
+	[
+		StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		StMethodBrowser browseSendersOf: #printOn:.
+		group := StMethodBrowserGroup current.
+		self assert: group notebook pages size equals: 2.
+		group window delete.
+		self assert: group notebook pages size equals: 1 ] ensure: [
 			StMethodBrowserGroup reset.
 			group ifNotNil: [ group window delete ] ]
 ]


### PR DESCRIPTION
Some bugs that this PR fix:

- List of the browser didn't have the focus since tab introduction
- Tabs were not closable
- When closing the browser using shortcuts, only the selected tab is removed if tabs > 1 (Added a test to ensure this behaviour)