### PR TITLE
Small fixes to smallint and dependency analyser presenters

### DIFF
--- a/src/NewTools-CodeCritiques/Package.extension.st
+++ b/src/NewTools-CodeCritiques/Package.extension.st
@@ -4,5 +4,5 @@ Extension { #name : 'Package' }
 Package >> criticNameOn: aStream [
 	"This behavior may be folded later by changing the name of this method or using another one."
 
-	aStream << self packageName
+	aStream << self name
 ]

--- a/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
+++ b/src/NewTools-CodeCritiques/StCritiqueBrowserPresenter.class.st
@@ -526,18 +526,17 @@ StCritiqueBrowserPresenter >> setActionLogButton [
 StCritiqueBrowserPresenter >> setActionResetButton [
 
 	^ [
-	| logging |
-		logging := self application newConfirm
-			           title: 'Question';
-			           label:
-				           'Do you want to delete the current configuration
+		  | logging |
+		  logging := self application newConfirm
+			             title: 'Question';
+			             message: 'Do you want to delete the current configuration
  and create a new configuration ?';
-			           acceptLabel: 'Sure!';
-			           cancelLabel: 'No';
-			           openModal.
-		logging ifTrue: [
-		  self delete.
-		  StCritiquePackageSelectorPresenter open ] ]
+			             acceptLabel: 'Sure!';
+			             cancelLabel: 'No';
+			             openModal.
+		  logging ifTrue: [
+				  self delete.
+				  StCritiquePackageSelectorPresenter open ] ]
 ]
 
 { #category : 'initialization' }

--- a/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
+++ b/src/NewTools-DependencyAnalyser-UI/StDependencyTreePresenter.class.st
@@ -25,21 +25,6 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'layout' }
-StDependencyTreePresenter class >> defaultLayout [
-	<spec: #default>
-	^ SpBoxLayout newVertical
-		add: (SpBoxLayout newHorizontal
-					add: #textPackageField expand: true;
-					add: #buttonDefault expand: false;
-					yourself)
-			expand: false;
-		add: #packageLabel expand: false;
-		add: #tree;
-		add: #actionBar expand: false;
-		yourself
-]
-
 { #category : 'examples' }
 StDependencyTreePresenter class >> onPackagesMatch: match [
 
@@ -188,6 +173,21 @@ StDependencyTreePresenter >> defaultDirectory [
 	^ 'saving'
 ]
 
+{ #category : 'layout' }
+StDependencyTreePresenter >> defaultLayout [
+
+	^ SpBoxLayout newVertical
+		add: #packageLabel expand: false;
+		add: #tree;
+		add: (SpBoxLayout newHorizontal
+					add: #textPackageField expand: true;
+					add: #buttonDefault expand: false;
+					yourself)
+			expand: false;
+		add: #actionBar expand: false;
+		yourself
+]
+
 { #category : 'saving' }
 StDependencyTreePresenter >> defaultName [
 	^ self defaultDirectory, '/relationGraph.FL'
@@ -212,8 +212,8 @@ StDependencyTreePresenter >> filter: aString [
 StDependencyTreePresenter >> initializeButtons [
 
 	buttonRefresh
-		icon: (self iconNamed: #refresh);
-		label: ''.
+		label: 'Refresh';
+		icon: (self iconNamed: #refresh).
 	buttonBrowseCycles := self newButton
 		help: 'Find all the cycles where the package is in the system';
 		icon: (self iconNamed: #objects).
@@ -230,6 +230,7 @@ StDependencyTreePresenter >> initializeButtons [
 		help: 'Open the graph in world';
 		label: 'Open the graph'.
 	buttonReverseAnalysis := self newButton
+		label: 'Reverse';
 		help: 'Reverse the analysis : set the dependent packages as root packages';
 		icon: (self iconNamed: #refresh).
 	buttonSave := self newButton
@@ -253,8 +254,7 @@ StDependencyTreePresenter >> initializePresenters [
 	super initializePresenters.
 	packageLabel := self newLabel label: 'Analysis of packages'.
 	textPackageField := self newTextInput
-		                    placeholder: 'Enter a package name';
-		                    entryCompletion: self packagesEntryCompletion.
+		                    placeholder: 'Filter...'.
 	self initializeButtons.
 
 	tree actionsWith: [ :group |
@@ -307,17 +307,6 @@ StDependencyTreePresenter >> nodesFor: anItemList [
 			treeModelParent: self;
 			browser: self browser;
 			yourself ]
-]
-
-{ #category : 'accessing' }
-StDependencyTreePresenter >> packagesEntryCompletion [
-
-	| applicants |
-	applicants := self packageOrganizer packages collect: [ :package | package name asString ].
-
-	^ EntryCompletion new
-		  dataSourceBlock: [ :currText | applicants ];
-		  filterBlock: [ :currApplicant :currText | currText size > 3 and: [ currApplicant asUppercase includesSubstring: currText asString asUppercase ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- Fix small lint rules issues (DNU)
- Improve dependency analyser

Before:

- two buttons with the same icon
- the filter (on top) had a completion that made no sense: completed all packages

<img width="464" height="301" alt="imagen" src="https://github.com/user-attachments/assets/ff7228a8-ccd5-4f1e-82f3-34f17cdd5788" />

After:

- label on icons
- filter moved below to follow other UIs in the system
- filter is just a filter, no completion

<img width="460" height="457" alt="imagen" src="https://github.com/user-attachments/assets/aa24f125-ab9f-493a-bfa8-33bf02337bdd" />

