### PR TITLE
Simplify testInspectingObjectWithPrintOnWithHaltOpenInspector

### DIFF
--- a/src/NewTools-Debugger-Tests/StObjectWithPrintingRaisingHaltTest.class.st
+++ b/src/NewTools-Debugger-Tests/StObjectWithPrintingRaisingHaltTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'ObjectWithPrintingRaisingHaltTest',
+	#name : 'StObjectWithPrintingRaisingHaltTest',
 	#superclass : 'TestCase',
 	#category : 'NewTools-Debugger-Tests-Model',
 	#package : 'NewTools-Debugger-Tests',
@@ -7,32 +7,23 @@ Class {
 }
 
 { #category : 'tests' }
-ObjectWithPrintingRaisingHaltTest >> testInspectingObjectWithPrintOnWithHaltOpenInspector [
+StObjectWithPrintingRaisingHaltTest >> testInspectingObjectWithPrintOnWithHaltOpenInspector [
 	"Make sure that inspecting an object with a broken printOn: does not produce an endless loop.
 	"
 	
-	| openInspectors inspectedObject |
+	| inspectedObject window |
 	
-	5 timesRepeat: [ Smalltalk garbageCollect ].
-	StInspectorPresenter allInstances select: [ :e | e window isOpen ] 
-					thenDo: [ :each | each window close ].
-
 	inspectedObject := ObjectWithPrintingRaisingHalt new.
 	"We are using halt in printOn: because halt is an exception (not an error).
 	The problem was that protecting with onErrorDo: does not catch all exception in particular 
 	Halt. And catching Exception in general is not possible else we could break on any printOn: method 
 	in the system."
 	
-	inspectedObject inspect.
-
-	openInspectors := StInspectorPresenter allInstances select: [ :e | 
-		                  e window isOpen ].
-
-	self assert: openInspectors size equals: 1.
+	window := StInspectorPresenter inspect: inspectedObject.
 
 	self
-		assert: openInspectors first model inspectedObject
+		assert: window presenter model inspectedObject
 		equals: inspectedObject.
-
-	StInspectorPresenter allInstances do: [ :each | each delete ].
+		
+	window delete
 ]


### PR DESCRIPTION
Simplify test, this test is failing in the CI (see https://github.com/pharo-project/pharo/issues/19578#issuecomment-4809933236).

This happens because many things:
 - multiple GCs and all instances during test, a timeout may happen eventually => rewritten without that!
 - it depends on the number of open windows, so any test failing and leaving instances behind makes it fail => rewritten without that

Also the new version is more understandable.

🫶 