### PR TITLE
Use test as debug callback and set to recompile new method

### DIFF
--- a/src/NewTools-Debugger-Tests/StDebuggerClientModelTest.class.st
+++ b/src/NewTools-Debugger-Tests/StDebuggerClientModelTest.class.st
@@ -195,10 +195,11 @@ StDebuggerClientModelTest >> setResult [
 StDebuggerClientModelTest >> setSessionAndDebuggerModelForMethod: aMethod inContext: aContext [
 
 	| dummyActionModel |
-	session ifNotNil: [ session clear ].
+	"session ifNotNil: [ session clear ]."
 	dummyActionModel := (StTestDebuggerProvider new debuggerWithContext:
 		                     aContext) debuggerClientModel.
 	session := dummyActionModel session.
+	session debugCallBack: self.
 	dummyActionModel clear.
 	session stepIntoUntil: [ :currentContext |
 		currentContext method == aMethod ].
@@ -1233,4 +1234,11 @@ StDebuggerClientModelTest >> testUpdateTopContextAfterSessionOperation [
 	mockDebugActionModel
 		clear;
 		clearDebugSession
+]
+
+{ #category : 'callbacks' }
+StDebuggerClientModelTest >> wantsToBroweAndRecompileMethodNotFoundInStack: aCollection [ 
+	
+	"The tests assume this is true"
+	^ true
 ]


### PR DESCRIPTION
With the introduction of the recompile callback, when a callback is not set the default value does a different thing than the UI (which was tested).

Fixes https://github.com/pharo-project/pharo/issues/19819#issuecomment-4808373903