### PR TITLE
Method Browser tabs UX fix

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -65,7 +65,7 @@ StMethodBrowserGroup >> connectPresenters [
 	notebook whenSelectedPageChangedDo: [ :page | page ifNotNil: [ self withWindowDo: [ :window | window title: page title ] ] ].
 	notebook whenPageRemovedDo: [ :page |
 			page activePresenter ifNotNil: [ :browser | browser unregisterFromAnnouncements ].
-			notebook pages isEmpty ifTrue: [ self withWindowDo: [ :w | w delete ] ] ]
+			notebook pages ifEmpty: [ self withWindowDo: [ :w | w delete ] ] ]
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -63,7 +63,9 @@ StMethodBrowserGroup >> addTab: aMethodBrowser [
 StMethodBrowserGroup >> connectPresenters [
 
 	notebook whenSelectedPageChangedDo: [ :page | page ifNotNil: [ self withWindowDo: [ :window | window title: page title ] ] ].
-	notebook whenPageRemovedDo: [ :page | page activePresenter ifNotNil: [ :browser | browser unregisterFromAnnouncements ] ]
+	notebook whenPageRemovedDo: [ :page |
+			page activePresenter ifNotNil: [ :browser | browser unregisterFromAnnouncements ].
+			notebook pages isEmpty ifTrue: [ self withWindowDo: [ :w | w delete ] ] ]
 ]
 
 { #category : 'layout' }
@@ -78,8 +80,13 @@ StMethodBrowserGroup >> defaultLayout [
 StMethodBrowserGroup >> handleTabsFor: anAnnouncement [
 
 	notebook pages size > 1 ifFalse: [ ^ self ].
+
 	anAnnouncement denyClose.
-	notebook removePage: notebook selectedPage
+	notebook removePage: notebook selectedPage.
+
+	self defer: [
+			self withWindowDo: [ :w | w activate ].
+			notebook selectedPage activePresenter ifNotNil: [ :browser | browser methodList listPresenter takeKeyboardFocus ] ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
- Doing multiple CMD + W on tabs lost the focus every time, now we can close multiple times in a row
- Closing the last tab is closing the whole browser group now
- When closing a tab, the new selected tab has the focus on the list now