### PR TITLE
Remove dependencies to morphic setting browser

### DIFF
--- a/src/NewTools-SettingsBrowser/StSettingNodeBuilder.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingNodeBuilder.class.st
@@ -1,0 +1,172 @@
+"
+Used to build nodes from the settings framework
+"
+Class {
+	#name : 'StSettingNodeBuilder',
+	#superclass : 'Object',
+	#instVars : [
+		'node',
+		'builder',
+		'callback'
+	],
+	#category : 'NewTools-SettingsBrowser',
+	#package : 'NewTools-SettingsBrowser'
+}
+
+{ #category : 'private - tree building' }
+StSettingNodeBuilder >> asParentWhile: aBlock [
+	builder parent: self while: aBlock
+]
+
+{ #category : 'accessing' }
+StSettingNodeBuilder >> builder: aTreeBuilder [
+	builder := aTreeBuilder
+]
+
+{ #category : 'initialization' }
+StSettingNodeBuilder >> buttonLabel: aString [ 
+	"Set the current's node declaration button label to aString"
+
+	node item actionLabel: aString
+]
+
+{ #category : 'accessing' }
+StSettingNodeBuilder >> callback: aFullBlockClosure [ 
+
+	callback := aFullBlockClosure 
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> default: anObject [
+	node item  default: anObject
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> description: aText [
+	node item description: aText
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> dialog: aSymbol [
+	node item dialog: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> domainValues: aCollection [
+	node item domainValues: aCollection
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> getSelector: aSymbol [
+	node item getSelector: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> ghostHelp: aString [
+	node item ghostHelp: aString
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> icon: aForm [
+	node item icon: aForm
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> iconName: aSymbol [
+	self icon: (self iconNamed: aSymbol)
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> label: aString [
+	node item label: aString
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> name [
+	^ node item name
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> name: aString [
+	node item name: aString
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> noOrdering [
+	node item noOrdering
+]
+
+{ #category : 'accessing' }
+StSettingNodeBuilder >> node [
+	^ node
+]
+
+{ #category : 'accessing' }
+StSettingNodeBuilder >> node: aSettingTreeNode [
+	node := aSettingTreeNode
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> order: aNumber [
+	node item order: aNumber
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> parent: aSymbol [
+	node parentName: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> parentName [
+	^ node parentName
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> parentName: aSymbol [
+	node parentName: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> precondition: aValuable [
+	node item precondition: aValuable
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> range: anInterval [
+	node item range: anInterval
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> script: aSymbol [
+	node item script: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> selector: aSymbol [
+	node item selector: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> setSelector: aSymbol [
+	node item setSelector: aSymbol
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> target: anObject [
+	node item target: anObject
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> targetSelector: aSelector [
+	node item targetSelector: aSelector
+]
+
+{ #category : 'declaration accessing' }
+StSettingNodeBuilder >> type: anObject [
+	node item type: anObject
+]
+
+{ #category : 'tree building' }
+StSettingNodeBuilder >> with: aBlock [
+	self asParentWhile: aBlock
+]

--- a/src/NewTools-SettingsBrowser/StSettingTreeBuilder.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingTreeBuilder.class.st
@@ -1,13 +1,94 @@
+"
+A builder for the settings tree
+"
 Class {
 	#name : 'StSettingTreeBuilder',
-	#superclass : 'SettingTreeBuilder',
+	#superclass : 'Object',
+	#instVars : [
+		'nodeList',
+		'currentParent',
+		'currentPragma'
+	],
 	#category : 'NewTools-SettingsBrowser-Model',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Model'
 }
 
+{ #category : 'instance creation' }
+StSettingTreeBuilder class >> acceptableKeywords: aCollectionOfRegExps [
+	^ self new acceptableKeywords: aCollectionOfRegExps
+]
+
+{ #category : 'accessing' }
+StSettingTreeBuilder >> buildPragma: aPragma [
+	currentPragma := aPragma.
+	self perform: aPragma selector withArguments: aPragma arguments.
+	^ nodeList
+]
+
+{ #category : 'accessing - structure variables' }
+StSettingTreeBuilder >> button: aSymbol [
+
+	^ self nodeClass: ActionSettingDeclaration name: aSymbol
+]
+
+{ #category : 'tree building' }
+StSettingTreeBuilder >> group: aSymbol [
+	^ self nodeClass: PragmaSetting name: aSymbol
+]
+
 { #category : 'accessing' }
 StSettingTreeBuilder >> nodeClass [
 
 	^ StSettingNode
+]
+
+{ #category : 'private - tree building' }
+StSettingTreeBuilder >> nodeClass: aClass name: aSymbol [
+	| node |
+	node := self nodeClass with: aClass new.
+	node item name: aSymbol.
+	node pragma: currentPragma.
+	node parentName: (currentParent ifNotNil: [currentParent name]).
+	self nodeList add: node.
+	^ (StSettingNodeBuilder new) node: node; builder: self; yourself
+]
+
+{ #category : 'accessing' }
+StSettingTreeBuilder >> nodeList [
+	^ nodeList ifNil: [nodeList := OrderedCollection new]
+]
+
+{ #category : 'private - tree building' }
+StSettingTreeBuilder >> parent: aNode while: aBlock [
+	| oldParent |
+	oldParent := currentParent.
+	currentParent := aNode.
+	aBlock value.
+	currentParent := oldParent
+]
+
+{ #category : 'tree building' }
+StSettingTreeBuilder >> pickOne: aSymbol [
+	^ self nodeClass: PickOneSettingDeclaration name: aSymbol
+]
+
+{ #category : 'tree building' }
+StSettingTreeBuilder >> range: aSymbol [
+	^ self nodeClass: RangeSettingDeclaration name: aSymbol
+]
+
+{ #category : 'tree building' }
+StSettingTreeBuilder >> setting: aSymbol [
+	^ self nodeClass: SettingDeclaration name: aSymbol
+]
+
+{ #category : 'pragmas' }
+StSettingTreeBuilder >> systemsettings [
+	"Process a <systemsettings> pragma"
+
+	<settingPragmaProcessor>
+	currentPragma methodClass instanceSide
+		perform: currentPragma methodSelector
+		with: self
 ]

--- a/src/NewTools-SettingsBrowser/StSettingsTree.class.st
+++ b/src/NewTools-SettingsBrowser/StSettingsTree.class.st
@@ -1,6 +1,11 @@
 Class {
 	#name : 'StSettingsTree',
-	#superclass : 'SettingTree',
+	#superclass : 'Model',
+	#instVars : [
+		'collector',
+		'nodeList',
+		'persistence'
+	],
 	#category : 'NewTools-SettingsBrowser-Model',
 	#package : 'NewTools-SettingsBrowser',
 	#tag : 'Model'
@@ -13,10 +18,94 @@ StSettingsTree class >> settingsKeywords [
 ]
 
 { #category : 'accessing' }
+StSettingsTree >> acceptableKeywords: keywords [
+	self collector
+		selectors: keywords;
+		filter: [:prg | prg methodClass isMeta].
+	nodeList := nil.
+	self collector reset
+]
+
+{ #category : 'checking' }
+StSettingsTree >> checkForUnknownParent [
+	self unclassified
+		ifNotEmpty: [ :nodesWithUnknownParent |
+			| builder g |
+			builder := StSettingTreeBuilder new.
+			g := (builder group: #nodesWithUnknownParent) node.
+			self nodeList addFirst: g.
+			g model: self.
+			g item label: '*** Unclassified ***'.
+			g item icon: (self iconNamed: #smallDebug).
+			g item order: 0.0.
+			nodesWithUnknownParent
+				do: [ :node | node parentName: #nodesWithUnknownParent ] ]
+]
+
+{ #category : 'checking' }
+StSettingsTree >> checkForUnknownTarget [
+	"check only root because other nodes with unknown target inherits it from its parent"
+	self settingTreeRoots do: [:node | node item target ifNil: [node item target: (node pragma ifNotNil: [:prg | prg methodClass instanceSide])]].
+	self settingTreeRoots do: [:node | node checkForUnknownTarget]
+]
+
+{ #category : 'querying' }
+StSettingsTree >> childrenOf: aNode [
+	| children idx order |
+	"Get aNode children. Assign children order if one child has an order which is not nil"
+	children := self nodeList select: [ :p | p parentName = aNode settingDeclaration name ].
+	children
+		detect: [ :n | n order isNotNil ]
+		ifFound: [ :firstWithOrder |
+			idx := children indexOf: firstWithOrder.
+			order := firstWithOrder order.
+			idx > 1
+				ifTrue: [
+					idx - 1 to: 1 do: [ :pos |
+						(children at: pos) order: order - 1.
+						order := order - 1 ] ].
+			order := firstWithOrder order.
+			idx + 1 to: children size do: [ :pos |
+				(children at: pos) order ifNil: [ (children at: pos) order: order + 1 ] ifNotNil: [ order := (children at: pos) order ].
+				order := order + 1 ] ].
+	^ children
+]
+
+{ #category : 'accessing' }
+StSettingsTree >> collector [
+	^ collector ifNil: [collector := PragmaCollector new]
+]
+
+{ #category : 'querying' }
+StSettingsTree >> deeplyDetect: aBlock [
+	self settingTreeRoots
+		do: [:sub | (sub deeplyDetect: aBlock)
+				ifNotNil: [:found | ^ found]].
+	^ nil
+]
+
+{ #category : 'querying' }
+StSettingsTree >> deeplySelect: aBlock [
+	^ self deeplySelect: aBlock in: OrderedCollection new
+]
+
+{ #category : 'querying' }
+StSettingsTree >> deeplySelect: aBlock in: aCollection [
+	self settingTreeRoots
+		do: [:aRoot | aRoot deeplySelect: aBlock in: aCollection].
+	^ aCollection
+]
+
+{ #category : 'accessing' }
 StSettingsTree >> defaultCategories [
 	"Answer a <Collection> of <StSettingNode> representing the default main setting categories in the system"
 
 	^ self treeRoots.
+]
+
+{ #category : 'private - tree building' }
+StSettingsTree >> emptyNodeNamed: aSymbol [
+	(self nodeNamed: aSymbol)
 ]
 
 { #category : 'testing' }
@@ -24,6 +113,16 @@ StSettingsTree >> hasSettingsFile [
 	"Answer <true> if a system settings file exists"
 
 	^ self persistence hasSettingsFile 
+]
+
+{ #category : 'accessing' }
+StSettingsTree >> itemSortBlock [
+	^ [:a :b |
+		((a order isNotNil and: [b order isNotNil]) and: [a order ~= b order])
+			ifTrue: [a order < b order]
+			ifFalse: [((a order isNil and: [b order isNil]) or: [a order = b order])
+				ifTrue: [a label < b label]
+				ifFalse: [a order ifNil: [false] ifNotNil: [true]]]]
 ]
 
 { #category : 'instance creation' }
@@ -62,6 +161,26 @@ StSettingsTree >> nodeList: aCollection [
 	nodeList := aCollection
 ]
 
+{ #category : 'private - tree building' }
+StSettingsTree >> nodeNamed: aSymbol [
+	^ self nodeNamed: aSymbol ifAbsent: []
+]
+
+{ #category : 'private - tree building' }
+StSettingsTree >> nodeNamed: aSymbol ifAbsent: aBlock [
+	^ self nodeList detect: [:d | d settingDeclaration name = aSymbol] ifNone: aBlock
+]
+
+{ #category : 'accessing' }
+StSettingsTree >> persistence [
+	^ persistence ifNil: [ persistence := SystemSettingsPersistence settingTree: self ]
+]
+
+{ #category : 'querying' }
+StSettingsTree >> pragmasDo: aBlock [
+	^  self collector do: aBlock
+]
+
 { #category : 'private - queries' }
 StSettingsTree >> processSearch: aString [
 	"Recursively collect the nodes matching aString in the receiver"
@@ -69,6 +188,19 @@ StSettingsTree >> processSearch: aString [
 	^ self treeRoots 
 		flatCollect: [ : settingNode | settingNode matches: aString ]
 		as: Set
+]
+
+{ #category : 'querying' }
+StSettingsTree >> retainedNodesFromList: aListOfNodes [
+	| retained |
+	retained := OrderedCollection new.
+	aListOfNodes do: [:n | [n item precondition value ifTrue: [retained add: n]] on: Error do: [retained add: n]].
+	^ retained
+]
+
+{ #category : 'querying' }
+StSettingsTree >> settingTreeRoots [
+	^ self retainedNodesFromList: ((self nodeList select: [:n | n parentName isNil]) asArray sort: self sortBlock) asOrderedCollection
 ]
 
 { #category : 'accessing' }
@@ -95,9 +227,35 @@ StSettingsTree >> sortBlock [
 	^ [:a :b | self itemSortBlock value: a declaration value: b declaration ]
 ]
 
+{ #category : 'persistence' }
+StSettingsTree >> storeSettingNodes [
+	self persistence storeSettingNodes
+]
+
 { #category : 'instance creation' }
 StSettingsTree >> treeRoots [
 	"Answer a <Collection> of <StSettingNodePresenter> representing the main setting categories in the system"
 
 	^ self newTreeHolder settingTreeRoots
+]
+
+{ #category : 'querying' }
+StSettingsTree >> unclassified [
+	^ self nodeList select: [:node | node parentName isNotNil and: [node parentNode isNil]]
+]
+
+{ #category : 'accessing' }
+StSettingsTree >> updateList [
+	nodeList := nil
+]
+
+{ #category : 'persistence' }
+StSettingsTree >> updateSettingNodes [
+	self persistence updateSettingNodes
+]
+
+{ #category : 'updating' }
+StSettingsTree >> whenChangedSend: aSelector to: aTarget [
+	self collector whenChangedSend: aSelector to: aTarget.
+	self collector whenResetSend: aSelector to: aTarget
 ]

--- a/src/NewTools-Spotter-Extensions/StSettingsTree.extension.st
+++ b/src/NewTools-Spotter-Extensions/StSettingsTree.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'StSettingsTree' }
+
+{ #category : '*NewTools-Spotter-Extensions' }
+StSettingsTree >> spotterForSettingsFor: aStep [
+	<stSpotterOrder: 0>
+	aStep listProcessor
+		title: 'Settings';
+		allCandidates: [ self nodeList ];
+		itemName: [ :each | each spotterLabel ];
+		filter: StFilterSubstring
+]


### PR DESCRIPTION
The new browser depends on the old browser.

Remove the dependencies by duplicating the old classes into the new browser.