### PR TITLE
`Dismiss from results` new command

### DIFF
--- a/src/NewTools-MethodBrowsers/StDismissMethodsCommand.class.st
+++ b/src/NewTools-MethodBrowsers/StDismissMethodsCommand.class.st
@@ -1,0 +1,35 @@
+"
+Dismiss selected method from a message browser list
+"
+Class {
+	#name : 'StDismissMethodsCommand',
+	#superclass : 'StCommand',
+	#category : 'NewTools-MethodBrowsers-Commands',
+	#package : 'NewTools-MethodBrowsers',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+StDismissMethodsCommand class >> defaultDescription [
+
+	^ 'Dismiss selected method from current results'
+]
+
+{ #category : 'default' }
+StDismissMethodsCommand class >> defaultName [
+
+	^ 'Dismiss from results'
+]
+
+{ #category : 'testing' }
+StDismissMethodsCommand >> canBeExecuted [
+
+	^ context selectedMethods isNotEmpty
+]
+
+{ #category : 'executing' }
+StDismissMethodsCommand >> execute [
+
+	context methods removeAll: context selectedMethods.
+	context update
+]

--- a/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodListPresenter.class.st
@@ -364,6 +364,7 @@ StMethodListPresenter >> methodListActions [
 				   register: (StMethodBrowseFullCommand forSpecContext: self);
 				   register: (StInspectMethodCommand forSpecContext: self);
 				   register: (StRunMethodTestCommand forSpecContext: self);
+				   register: (StDismissMethodsCommand forSpecContext: self);
 				   yourself);
 		  register: ((CmCommandGroup forSpecNamed: 'Navigation')
 				   beDisplayedAsGroup;


### PR DESCRIPTION
- Fixes #1498
- Depending on the user flow and the task, this command can be useful to clean the method browser, it allows to "hide" the selected methods from the results