### PR TITLE
Fix syntax for subclassing AbstractTutorial in HowToMakeYourOwnTutorial

### DIFF
--- a/src/ProfStef-Core/HowToMakeYourOwnTutorial.class.st
+++ b/src/ProfStef-Core/HowToMakeYourOwnTutorial.class.st
@@ -92,11 +92,8 @@ lesson:
 
 First, create a subclass of AbstractTutorial. For example:"
 
-AbstractTutorial subclass: #HowToDebug
-	instanceVariableNames: ''''
-	classVariableNames: ''''
-	poolDictionaries: ''''
-	category: ''YourTutorial''.
+AbstractTutorial << #HowToDebug
+	package: ''YourTutorial'';  install.
 
 ProfStef next.'
 ]


### PR DESCRIPTION
resolves #1504 