### PR TITLE
Fix the closure for tabs method browser

### DIFF
--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -82,7 +82,7 @@ StMethodBrowserGroup >> handleTabsFor: anAnnouncement [
 	notebook pages size > 1 ifFalse: [ ^ self ].
 
 
-	SystemWindow currentCloseSource = #closeButton ifTrue: [
+	(self withWindowDo: [ :w | w window wasClosedFromShortcut ]) ifFalse: [
 			(notebook pages anySatisfy: [ :page | page activePresenter ifNil: [ false ] ifNotNil: [ :b | b isDirty ] ]) ifTrue: [
 					(self application confirm: 'Some tabs have unsaved changes.
 Is it OK to discard changes?') ifFalse: [ anAnnouncement denyClose ] ].

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroup.class.st
@@ -81,9 +81,14 @@ StMethodBrowserGroup >> handleTabsFor: anAnnouncement [
 
 	notebook pages size > 1 ifFalse: [ ^ self ].
 
+
+	SystemWindow currentCloseSource = #closeButton ifTrue: [
+			(notebook pages anySatisfy: [ :page | page activePresenter ifNil: [ false ] ifNotNil: [ :b | b isDirty ] ]) ifTrue: [
+					(self application confirm: 'Some tabs have unsaved changes.
+Is it OK to discard changes?') ifFalse: [ anAnnouncement denyClose ] ].
+			^ self ].
 	anAnnouncement denyClose.
 	notebook removePage: notebook selectedPage.
-
 	self defer: [
 			self withWindowDo: [ :w | w activate ].
 			notebook selectedPage activePresenter ifNotNil: [ :browser | browser methodList listPresenter takeKeyboardFocus ] ]

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
@@ -35,6 +35,22 @@ StMethodBrowserGroupTest >> testAddTwoTabsReusesSameGroup [
 ]
 
 { #category : 'tests' }
+StMethodBrowserGroupTest >> testCloseBoxHitClosesEntireWindow [
+
+	| group |
+	[
+		StMethodBrowser browseImplementorsOf: #browseImplementorsOf:.
+		StMethodBrowser browseImplementorsOf: #browseSendersOf:.
+		group := StMethodBrowserGroup current.
+		self assert: group notebook pages size equals: 2.
+		group window window closeBoxHit.
+
+		self assert: group isDisplayed not ] ensure: [
+			SystemWindow setCurrentCloseSource: nil.
+			StMethodBrowserGroup reset ]
+]
+
+{ #category : 'tests' }
 StMethodBrowserGroupTest >> testRemovePageWhenMultipleDoesNotCloseTheGroup [
 
 	| group |

--- a/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
+++ b/src/NewTools-MethodBrowsers/StMethodBrowserGroupTest.class.st
@@ -45,9 +45,7 @@ StMethodBrowserGroupTest >> testCloseBoxHitClosesEntireWindow [
 		self assert: group notebook pages size equals: 2.
 		group window window closeBoxHit.
 
-		self assert: group isDisplayed not ] ensure: [
-			SystemWindow setCurrentCloseSource: nil.
-			StMethodBrowserGroup reset ]
+		self assert: group isDisplayed not ] ensure: [ StMethodBrowserGroup reset ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
This fix allows the window group to close with a mouse button, and to only close a tab with a shortcut closure.